### PR TITLE
fix(experiments): parse tegrastats LFB sizes reported in kB

### DIFF
--- a/experiments/phase0/telemetry.py
+++ b/experiments/phase0/telemetry.py
@@ -149,7 +149,7 @@ class EventRecorder:
 
 _RAM_RE = re.compile(
     r"\bRAM\s+(?P<used>\d+)/(?P<total>\d+)MB\s+"
-    r"\(lfb\s+(?P<count>\d+)x(?P<size>\d+)MB\)"
+    r"\(lfb\s+(?P<count>\d+)x(?P<size>\d+)(?P<size_unit>MB|kB)\)"
 )
 _SWAP_RE = re.compile(
     r"\bSWAP\s+(?P<used>\d+)/(?P<total>\d+)MB\s+"
@@ -220,12 +220,15 @@ def parse_tegrastats_line(line: str) -> dict[str, Any]:
 
     ram = _RAM_RE.search(line)
     if ram:
+        lfb_size = int(ram.group("size"))
+        if ram.group("size_unit") == "kB":
+            lfb_size /= 1024
         row.update(
             {
                 "ram_used_mb": int(ram.group("used")),
                 "ram_total_mb": int(ram.group("total")),
                 "ram_lfb_count": int(ram.group("count")),
-                "ram_lfb_size_mb": int(ram.group("size")),
+                "ram_lfb_size_mb": lfb_size,
             }
         )
     else:

--- a/experiments/phase0/test_telemetry.py
+++ b/experiments/phase0/test_telemetry.py
@@ -85,6 +85,8 @@ class TegrastatsParserTests(unittest.TestCase):
         self.assertEqual(row["tegrastats_time"], "08-23-2026 13:57:46")
         self.assertEqual(row["ram_used_mb"], 3595)
         self.assertEqual(row["ram_total_mb"], 7607)
+        self.assertEqual(row["ram_lfb_count"], 1)
+        self.assertEqual(row["ram_lfb_size_mb"], 1)
         self.assertEqual(row["swap_used_mb"], 11)
         self.assertEqual(row["cpu0_usage_pct"], 100)
         self.assertEqual(row["cpu5_freq_mhz"], 729)
@@ -95,6 +97,23 @@ class TegrastatsParserTests(unittest.TestCase):
         self.assertEqual(row["vdd_in_avg_mw"], 5852)
         self.assertEqual(row["vdd_cpu_gpu_cv_mw"], 1307)
         self.assertEqual(row["vdd_soc_avg_mw"], 1468)
+
+    def test_normalizes_kilobyte_lfb_sizes_observed_under_memory_pressure(self) -> None:
+        observed_formats = [
+            ("1x512kB", 1, 0.5),
+            ("6x256kB", 6, 0.25),
+            ("205x128kB", 205, 0.125),
+            ("1311x64kB", 1311, 0.0625),
+        ]
+
+        for lfb, expected_count, expected_size_mb in observed_formats:
+            with self.subTest(lfb=lfb):
+                line = TEGRASTATS_SAMPLE.replace("1x1MB", lfb)
+                row = parse_tegrastats_line(line)
+
+                self.assertEqual(row["parse_error"], "")
+                self.assertEqual(row["ram_lfb_count"], expected_count)
+                self.assertEqual(row["ram_lfb_size_mb"], expected_size_mb)
 
     def test_reports_missing_sections(self) -> None:
         row = parse_tegrastats_line("unexpected output")


### PR DESCRIPTION
## Summary

- Accept Jetson `tegrastats` LFB sizes reported in either `MB` or `kB`.
- Normalize `kB` values into the existing `ram_lfb_size_mb` field.
- Add regression coverage for the observed 512, 256, 128, and 64 kB formats.

## Validation

- 25 unit tests passed on Windows and Jetson.
- Compile, Pyflakes, and `git diff --check` passed.
- Reparsed a preserved VLM run: 76 RAM parse errors reduced to 0.
- Completed a fresh VLM validation with 383 resource samples.
- The fresh run contained 10 real `kB` LFB samples and no parse errors.
- VLM used the Qwen route and Moondream unloaded successfully.

## Experiment impact

- Formal collection remains paused until this fix is merged.
- Pre-fix and dirty-runner validation directories are preserved but excluded.
- All formal sessions will restart on one clean post-fix runner commit.