### PR TITLE
feat(runtime): add phase 1 bounded task kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository began with my bachelor's thesis on speech interaction and visual perception for a wheeled robot. The thesis system runs fully local speech and vision pipelines on a Jetson Orin Nano, while an STM32F407 executes motion commands and enforces a communication watchdog. The same platform will now be used to study how long-running perception and inference can coexist with predictable control timing.
 
-> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；异步运行时属于下一阶段工作。
+> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 正从 host-only 运行时内核开始推进，尚未接入整机应用。
 
 ## Project status
 
@@ -15,7 +15,7 @@ This repository began with my bachelor's thesis on speech interaction and visual
 | Bachelor's thesis software and firmware | Complete and hardware validated |
 | Custom base-driver PCB | Published and tested on the physical robot |
 | Jetson–STM32 command link | Validated with ACK/error responses and a 1.2 s command watchdog |
-| Asynchronous inference runtime | Planned research work |
+| Asynchronous inference runtime | Phase 1 host-only kernel under development; not yet integrated |
 
 The validated Jetson–STM32 code is preserved at [`v0.1.0-thesis-baseline`](https://github.com/yuzhang-robotics/embodied-robot-heterogeneous-control/tree/v0.1.0-thesis-baseline). The current `main` branch also includes the reviewed hardware documentation and editable PCB export.
 
@@ -61,7 +61,10 @@ The STM32 currently applies open-loop PWM commands. Encoder measurements are ava
 
 The current Jetson application is synchronous: wake-word detection, recording, ASR, dialogue or VLM inference, speech output and target tracking run as blocking stages. This is straightforward to reproduce, but inference latency can delay unrelated work and there is no explicit deadline or data-age policy.
 
-The next stage will investigate:
+Phase 1 has started with an immutable task/result model, bounded task ownership,
+scoped state generations and host-only lifecycle tests. These components are
+not yet connected to the Jetson application or model services. The broader
+research stage will investigate:
 
 - independent acquisition, inference, planning and control workers;
 - timestamped bounded queues, cancellation and stale-result rejection;
@@ -82,6 +85,8 @@ These are research objectives, not claims about the current implementation. The 
 | [`hardware/pcb/`](hardware/pcb/) | Editable EasyEDA Pro export of the custom base-driver PCB |
 | [`docs/hardware/`](docs/hardware/) | Physical platform, wiring, pin assignments, power and safety notes |
 | [`docs/architecture/`](docs/architecture/) | Current timing model and the boundary of the planned asynchronous architecture |
+| [`experiments/phase0/`](experiments/phase0/) | Synchronous fixed-input measurement, validation and formal analysis tools |
+| [`experiments/phase1/`](experiments/phase1/) | Host tests and planned experiment tools for the asynchronous runtime study |
 
 ## Reproducing the baseline
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -96,6 +96,13 @@ The first experiments will address these questions:
 4. Which safety actions must remain on the STM32, and which supervisory states belong on the Jetson?
 5. How does encoder feedback change approach accuracy and stopping repeatability compared with the open-loop thesis baseline?
 
+The proposed task model, lifecycle invariants, queue policies, cancellation
+semantics, and Phase 1 safety Gates are specified in the
+[Phase 1 runtime contract](phase1-runtime-contract.md). That document is a
+design and correctness boundary. The initial host-only task model and bounded
+broker do not yet constitute a validated Jetson runtime or a performance
+result.
+
 ## Evaluation plan
 
 Future experiments should record at least:

--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -1,0 +1,471 @@
+# Phase 1 Runtime Contract
+
+This document defines the proposed correctness and safety contract for the
+first asynchronous runtime used by the Octopus robot research platform. It is
+a design specification, not a claim that the runtime has already been
+implemented or validated.
+
+> 中文简介：本文冻结 Phase 1 异步运行时的任务模型、生命周期、队列、取消、结果新鲜度、
+> 快速周期代理和安全边界。当前状态仍是设计草案；实现、Jetson pilot 和正式实验将按 Gate
+> 逐步完成。
+
+## Status
+
+- Phase: Phase 1.1 host-only runtime kernel
+- Contract status: frozen for the first implementation milestone
+- Starting point: `main@043e1bb`
+- Synchronous functional baseline: `61db058`
+- Physical motion: disabled and outside this phase
+- UART and STM32 firmware: unchanged
+
+The contract was reviewed before the host-only implementation began. Later
+implementation findings may require an explicit contract revision, but the
+contract must not be changed silently after formal data collection starts.
+
+## Research objective
+
+Phase 1 investigates whether slow ASR, LLM, and VLM work can be separated from
+time-constrained Jetson work without allowing unbounded backlog or invalid
+results to escape into downstream consumers.
+
+The main research claims will concern observed behavior:
+
+1. a bounded runtime can keep slow work from owning the fast execution path;
+2. every admitted task can be assigned one closed lifecycle;
+3. expired, cancelled, superseded, mismatched, or old-generation results can
+   be rejected before consumption;
+4. the runtime overhead can be measured against a direct synchronous call that
+   uses the same workload adapter;
+5. the same kernel can express different admission policies without hiding
+   their workload-specific semantics.
+
+Python threads are not hard-real-time threads. Phase 1 reports measured period,
+lateness, gaps, and deadline misses. It does not provide a worst-case execution
+time or operating-system scheduling guarantee.
+
+## Scope and exclusions
+
+Phase 1 includes:
+
+- an immutable task and result model;
+- one bounded single-consumer inference lane per experiment;
+- bounded input and accepted-result storage;
+- scoped state generations and result freshness checks;
+- explicit queued, in-flight, and post-completion cancellation semantics;
+- a 100 ms software periodic probe;
+- privacy-preserving event traces and independent lifecycle replay;
+- simulated, VLM, ASR, and LLM adapters introduced in that order;
+- synchronous and asynchronous experimental conditions sharing one adapter.
+
+Phase 1 excludes:
+
+- physical motion and automatic UART access;
+- changes to the STM32 firmware, watchdog, or wire protocol;
+- encoder feedback control and mecanum kinematics;
+- CPU affinity, real-time priority, model residency comparisons, and
+  simultaneous LLM/VLM inference;
+- upgrades to JetPack, CUDA, PyTorch, ONNX Runtime, or model weights;
+- replacement or removal of the validated synchronous `jetson.app` path.
+
+## Safety boundary
+
+All Phase 1 automated tests and initial Jetson experiments must satisfy:
+
+- `ROBOT_ENABLE_MOTION` is unset or explicitly false;
+- an unrecognized motion value causes the runner to refuse startup;
+- the Phase 1 runtime does not import `jetson.robot_comm`,
+  `jetson.motion_planner`, or `jetson.app`;
+- `/dev/ttyTHS1` is not opened;
+- no STM32 or motor power is required;
+- Phase 0 run directories, schemas, reports, and archives are never modified;
+- new data uses a Phase 1 run root and schema identity.
+
+Any UART access or physical motion output is a stop condition. Performance
+results cannot compensate for a safety-boundary failure.
+
+## Time model
+
+Durations, queue waits, result ages, and scheduling metrics use
+`time.monotonic_ns()` only. Wall time is recorded only for human correlation.
+
+For one task:
+
+```text
+source <= created <= enqueued <= started <= finished <= consumed
+source <= deadline
+```
+
+Some later timestamps do not exist for tasks rejected or cancelled earlier.
+The deadline is a consume-by validity boundary; it does not claim that Python,
+an HTTP client, or a model backend can be forcibly preempted at that instant.
+
+Cross-run and cross-device absolute monotonic timestamps are not compared.
+Only within-run differences are meaningful.
+
+## Identity model
+
+### StateToken
+
+A bare integer generation is insufficient when independent conversations or
+task scopes coexist. Each task therefore carries:
+
+| Field | Meaning |
+| --- | --- |
+| `scope_id` | Bounded identifier for the state domain, such as one interaction |
+| `generation` | Non-negative generation within that scope |
+
+Changing one scope must not invalidate an unrelated scope.
+
+### PayloadRef
+
+| Field | Meaning |
+| --- | --- |
+| `ref` | Private file or immutable-object reference used by the worker |
+| `sha256` | Content identity captured before admission |
+| `size_bytes` | Expected bounded payload size |
+| `media_type` | Bounded media type such as `image/jpeg` or `audio/wav` |
+
+The event trace records the hash, size, and media type, not the raw payload or
+private absolute path. A file payload is verified before admission and again
+before execution.
+
+Live acquisition must create a unique immutable file per task. The current
+single `scene_vlm.jpg` path must not be reused by an asynchronous producer,
+because a later capture could overwrite data referenced by a queued or running
+task.
+
+## TaskEnvelope
+
+The initial immutable task envelope contains:
+
+| Field | Requirement |
+| --- | --- |
+| `task_id` | Unique, stable, 1 to 128 characters |
+| `task_kind` | `simulated`, `vlm`, `asr`, or `llm` |
+| `parent_task_id` | Optional bounded parent interaction ID |
+| `supersession_key` | Optional key for coalescing related pending tasks |
+| `source_monotonic_ns` | Source observation or utterance completion time |
+| `created_monotonic_ns` | Envelope construction time |
+| `deadline_monotonic_ns` | Last valid consumption time |
+| `state_token` | Scoped generation captured at creation |
+| `payload` | `PayloadRef` identity |
+| `metadata` | Small bounded scalar metadata only |
+
+Metadata must not become an unbounded escape hatch. The initial implementation
+will reject non-scalar values, excessive keys, oversized strings, and a
+serialized representation above a fixed byte limit. Prompts, responses,
+images, audio, tracebacks, and secrets are never metadata.
+
+## ResultEnvelope
+
+The immutable result envelope contains:
+
+| Field | Requirement |
+| --- | --- |
+| `task_id` | Must match the admitted task |
+| `task_kind` | Must match the admitted task |
+| `state_token` | Propagated without worker modification |
+| `source_monotonic_ns` | Propagated without worker modification |
+| `deadline_monotonic_ns` | Propagated without worker modification |
+| `input_sha256` | Must match the admitted payload identity |
+| `started_monotonic_ns` | Worker claim time |
+| `finished_monotonic_ns` | Execution completion time |
+| `execution_outcome` | `ok`, `error`, `timeout`, or `cancel_observed` |
+| `output_sha256` | Optional privacy-preserving output identity |
+| `output_length` | Optional bounded output length |
+| `output_ref` | Optional private result reference |
+| `error_code` | Optional bounded error category |
+| `cancellation_report` | What was requested, observed, and confirmed |
+
+The worker may carry a private in-memory output for a later safe consumer. The
+event serializer exposes only its bounded descriptor.
+
+## Two orthogonal outcomes
+
+Execution and delivery are different facts. A VLM request may execute
+successfully and still be rejected because its result is old.
+
+Execution outcomes are:
+
+```text
+not_started | ok | error | timeout | cancel_observed
+```
+
+Final dispositions are:
+
+```text
+consumed
+dropped_overflow
+rejected_busy
+cancelled_queued
+rejected_cancelled
+rejected_expired
+rejected_state
+rejected_identity
+execution_error
+result_backpressure
+shutdown_cancelled
+```
+
+Every admitted task receives exactly one final disposition. A submission
+rejected before admission is counted separately and never appears as a live
+runtime task.
+
+## Lifecycle
+
+The broker owns all task-location transitions:
+
+```text
+submission attempt
+    |-- rejected at ingress --------------------------> terminal accounting
+    `-- admitted -> QUEUED -> RUNNING -> RESULT_PENDING -> TERMINAL
+                       |          |             |
+                       |          |             `------> stale/cancelled
+                       |          `--------------------> error/stale/cancelled
+                       `-------------------------------> dropped/cancelled
+```
+
+The runtime keeps queue membership, the active task, the result mailbox,
+state generations, and lifecycle records under one condition lock. This avoids
+snapshots assembled from incompatible locks.
+
+Expected accounting is:
+
+```text
+submission_attempts = admitted + rejected_at_ingress
+
+admitted = queued + running + result_pending + terminal_admitted
+```
+
+After a successful shutdown:
+
+```text
+queued = running = result_pending = 0
+```
+
+The terminal-record cache and scoped-generation table are themselves bounded.
+Evicted terminal records remain represented by cumulative counters and the
+append-only event trace, preventing the task registry from becoming a hidden
+unbounded queue. A lane refuses a new scope when its configured scope table is
+full rather than silently forgetting an older generation.
+
+## Admission and overflow policies
+
+The kernel provides policies; workload adapters select them explicitly.
+
+### VLM
+
+- pending capacity: 1;
+- coalesce related pending tasks by `supersession_key`;
+- replacement emits a dropped disposition for the replaced pending task;
+- a new image does not silently claim to stop an active backend request;
+- active result invalidation requires an explicit cancel or state-generation
+  change.
+
+This distinction matters because continuously superseding a roughly 70-second
+VLM request with camera frames could otherwise prevent any result from ever
+being consumable.
+
+### ASR
+
+- pending capacity: 2;
+- FIFO ordering;
+- reject-new on overflow;
+- return an explicit busy outcome to the producer;
+- never silently replace an already completed utterance.
+
+### LLM
+
+- one active and at most one pending request;
+- reject-new on overflow;
+- carry a conversation-history snapshot in the private payload identity;
+- update shared history only after the result is consumed, never merely after
+  inference completes.
+
+The pending capacity excludes the one active task. The accepted-result mailbox
+also has an independently configured capacity and full policy.
+
+## Freshness and identity validation
+
+Validation happens twice.
+
+At worker completion, the broker checks:
+
+- the task still exists in the expected running state;
+- task, kind, input hash, source time, deadline, and state token match;
+- cancellation or supersession has not invalidated the task;
+- the result has not already expired;
+- the result mailbox has capacity.
+
+Immediately before consumption, the broker checks again:
+
+- current monotonic time is not after the deadline;
+- the scoped generation still matches;
+- cancellation or supersession has not occurred since completion;
+- the result identity still matches the original task.
+
+Only then can the result receive the `consumed` disposition. In Phase 1 the
+consumer has no physical-motion side effects. A future Phase 2 motion
+supervisor must perform its own final authorization before actuation.
+
+## State-generation update
+
+Advancing one state scope is atomic under the broker lock:
+
+1. increment the scope generation;
+2. cancel matching queued tasks;
+3. request cancellation/invalidation for a matching active task;
+4. reject matching result-pending tasks;
+5. record one bounded state-change reason and all resulting transitions.
+
+The operation is observable and cannot partially update the three task
+locations.
+
+## Cancellation semantics
+
+Cancellation reports separate:
+
+| Fact | Meaning |
+| --- | --- |
+| `requested` | The runtime requested cancellation or invalidation |
+| `client_wait_stopped` | The local process or transport stopped waiting |
+| `worker_observed` | Cooperative code observed the token |
+| `backend_stop_confirmed` | Backend computation is known to have stopped |
+
+Queued cancellation removes the task before execution. Simulated work can
+cooperate fully. A Whisper child process may be terminated and reaped. Closing
+or timing out an HTTP request does not by itself prove that llama.cpp or Ollama
+stopped model computation; that fact remains `unknown` unless independently
+confirmed.
+
+Result invalidation is always available even when backend cancellation is not.
+Documentation must say "result rejected" rather than "GPU inference
+cancelled" in that case.
+
+## Shutdown contract
+
+The lane has `OPEN`, `CLOSING`, and `CLOSED` states. It supports:
+
+- `drain`: reject new submissions and finish admitted work;
+- `cancel`: reject new submissions, cancel pending work, signal active work,
+  and reject pending results.
+
+Shutdown returns a report containing join latency, remaining task identity,
+and cancellation capability. A join timeout is a failed Gate, not a successful
+shutdown. Real HTTP adapters use finite transport and overall budgets so that
+failure is eventually observable, but Phase 1 does not claim instantaneous
+backend preemption.
+
+## Periodic probe contract
+
+The nominal period is 100 ms. Releases use an absolute schedule:
+
+```text
+release[n] = start + n * period
+```
+
+The probe records scheduled, started, and finished monotonic timestamps,
+start lateness, execution time, actual period, signed and absolute period
+error, skipped releases, and deadline misses.
+
+If delayed across multiple releases, the probe records skipped releases and
+moves to the next future release. It does not emit a burst of catch-up ticks,
+which would hide the real scheduling gap.
+
+The experiment layer provides both:
+
+- an inline probe representing the blocking synchronous orchestration path;
+- an independent threaded probe representing the isolated fast timing domain.
+
+The probe is a software scheduling proxy, not a motor controller.
+
+## Event and replay requirements
+
+Phase 1 creates a new event schema and run root. Phase 0 schema version `0.1.0`
+remains frozen.
+
+Every lifecycle event includes enough bounded information to replay:
+
+- submission and admission result;
+- transition from/to state and reason;
+- queue/result depth before and after;
+- configured capacity and policy;
+- task identity, source, deadline, and state token;
+- execution outcome and final disposition;
+- cancellation facts;
+- probe releases, ticks, skips, and misses;
+- shutdown request and worker join outcome.
+
+An independent offline validator reconstructs task states and queue depths from
+the trace without calling runtime internals. It rejects impossible transitions,
+capacity violations, duplicate terminals, identity mismatches, missing final
+states, non-monotonic sequence/timestamps, or a consumed stale result.
+
+Runtime counters alone are not accepted as correctness evidence.
+
+## Experimental decomposition
+
+Correctness, responsiveness, and runtime overhead are separate protocols.
+
+### Semantic correctness
+
+Deterministic simulated schedules cover overflow, cancellation at each
+lifecycle location, deadline expiry, state changes, result-mailbox pressure,
+executor failure, shutdown races, and duplicate IDs. These are zero-tolerance
+tests, not inferential performance comparisons.
+
+### Responsiveness
+
+The planned conditions are:
+
+| Condition | Probe | Slow work | Runtime |
+| --- | --- | --- | --- |
+| `R0` | independent | none | none |
+| `R1` | inline | direct synchronous | none |
+| `R2` | independent | direct synchronous | none |
+| `R3` | independent | worker | bounded runtime |
+| `R4` | independent | worker plus invalidation/overflow | bounded runtime |
+
+`R2` separates the benefit of an independent fast timing domain from the
+additional semantics and overhead of the full broker.
+
+### Runtime overhead
+
+A queue-empty, single-task direct condition is compared with a queue-empty,
+single-task worker condition. Both invoke the same workload adapter. ASR is the
+sensitive low-variance control; LLM retains token-normalized metrics; VLM
+retains module-import, Moondream, rewrite/fallback, and unload stages.
+
+Formal analysis treats a run or paired block as the experimental unit. Probe
+ticks within one run are temporally dependent and are not treated as hundreds
+of independent experimental samples.
+
+## Gates
+
+The following correctness thresholds are fixed before the pilot:
+
+- zero stale or identity-mismatched results consumed;
+- zero queue or result-mailbox capacity violations;
+- zero duplicate final dispositions;
+- zero live admitted tasks after successful shutdown;
+- zero worker or child-process leaks;
+- zero UART access and physical motion output;
+- zero unexplained telemetry parse errors;
+- zero Phase 0 artifact modifications.
+
+Numerical jitter and non-inferiority thresholds are frozen after an independent
+pilot and before formal data. The current 300 ms unchanged-command refresh
+target is a Phase 2 readiness reference; the STM32 1.2 s watchdog is a last
+defense and must not be used as the Jetson scheduling success target.
+
+## Phase 1 completion boundary
+
+Phase 1 is complete only when:
+
+1. host-only concurrency and lifecycle replay pass;
+2. safe Jetson simulation passes with valid telemetry;
+3. real VLM, ASR, and LLM slices pass their Gates;
+4. a pre-registered synchronous/asynchronous comparison is completed;
+5. results and limitations are published without hard-real-time claims;
+6. at least one opt-in, motion-disabled application slice uses the validated
+   runtime while the synchronous baseline remains available.

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -1,0 +1,105 @@
+# Phase 1 Asynchronous Runtime Research
+
+This directory contains the host tests and will contain the experiment harness,
+workload adapters, validation tools, and analysis for the Phase 1 asynchronous
+runtime study. The immutable task/result model and bounded broker are the first
+implementation milestone. Worker threads, Jetson pilots, and Phase 1
+performance results have not been completed yet.
+
+> 中文简介：本目录用于 Phase 1 异步运行时研究。当前已冻结首个运行时契约并实现
+> host-only 数据模型和有界 broker；尚未接入工作线程、Jetson 模型或 Phase 1 正式数据。
+
+## Current status
+
+- Phase 0 synchronous baseline: complete
+- Phase 1.0 runtime contract: frozen for the first implementation milestone
+- Host-only task/result model and bounded broker: implemented and tested
+- Worker and periodic probe: not implemented
+- Jetson simulation pilot: not started
+- Real VLM/ASR/LLM slices: not started
+- Formal Phase 1 data: not collected
+- Physical motion and UART: excluded
+
+The detailed contract is documented in
+[`docs/architecture/phase1-runtime-contract.md`](../../docs/architecture/phase1-runtime-contract.md).
+
+Run the current host-only tests from the repository root:
+
+```bash
+python3 -m unittest \
+  experiments.phase1.tests.test_model \
+  experiments.phase1.tests.test_broker
+```
+
+## Planned implementation order
+
+1. freeze the task, result, lifecycle, queue, cancellation, and freshness
+   contract;
+2. implement and stress-test the host-only runtime kernel;
+3. add the periodic probe, Phase 1 event schema, and independent trace replay;
+4. run safe simulated loads on the Jetson with `ROBOT_ENABLE_MOTION=0`;
+5. integrate the fixed-input VLM slice;
+6. extend the same adapter/runtime boundary to ASR and LLM;
+7. freeze formal thresholds and collect balanced synchronous/asynchronous data;
+8. add an opt-in motion-disabled application slice after the research Gates
+   pass.
+
+Contract changes are reviewed before implementation, and the formal protocol
+is frozen before data collection.
+
+## Safety rules
+
+Phase 1 automated tests and initial experiments:
+
+- do not import or call `jetson.robot_comm`;
+- do not open `/dev/ttyTHS1`;
+- refuse to run if physical motion is enabled or the motion setting is
+  unrecognized;
+- do not require the STM32, motor power, or the assembled chassis;
+- do not modify Phase 0 schemas, run directories, reports, or archives;
+- use a new Phase 1 schema and ignored run root;
+- keep raw audio, images, prompts, model outputs, and private paths out of event
+  details.
+
+Any violation stops the experiment regardless of its performance result.
+
+## Planned code boundary
+
+The reusable, hardware-independent kernel will live under
+`jetson/phase1_runtime/`. Experiment-specific code will remain here:
+
+```text
+experiments/phase1/
+├── schemas/
+├── workloads/
+├── tests/
+├── manifest.py
+├── telemetry.py
+├── scenarios.py
+├── run_simulation.py
+├── run_workload.py
+├── validate_run.py
+├── replay_lifecycle.py
+├── summarize_run.py
+└── analyze_formal_runs.py
+```
+
+The kernel package must remain import-safe on a host without Jetson models,
+camera, microphone, serial device, or NVIDIA tools. Real workload dependencies
+are imported lazily only by their explicit Jetson experiment adapters.
+
+## Evidence standard
+
+Phase 1 correctness is not established by console output or runtime counters
+alone. A separate validator must replay the append-only event trace and prove:
+
+- queue and result-mailbox bounds were respected;
+- each admitted task reached exactly one final disposition;
+- cancellation and state changes produced legal transitions;
+- no stale, cancelled, superseded, or mismatched result was consumed;
+- shutdown closed all live lifecycle locations;
+- event sequence and monotonic timestamps remained valid.
+
+Pilot runs are descriptive. Numerical success thresholds, sample sizes,
+condition order, exclusions, and statistical methods are frozen before formal
+data collection.

--- a/experiments/phase1/__init__.py
+++ b/experiments/phase1/__init__.py
@@ -1,0 +1,1 @@
+"""Experiment support for the Phase 1 asynchronous runtime study."""

--- a/experiments/phase1/tests/__init__.py
+++ b/experiments/phase1/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Host-only tests for the Phase 1 runtime and experiment tools."""

--- a/experiments/phase1/tests/test_broker.py
+++ b/experiments/phase1/tests/test_broker.py
@@ -1,0 +1,618 @@
+"""Deterministic lifecycle tests for the bounded Phase 1 broker."""
+
+from __future__ import annotations
+
+import threading
+import unittest
+
+from jetson.phase1_runtime.broker import BrokerState, BrokerStateError
+from jetson.phase1_runtime.model import (
+    ExecutionOutcome,
+    FinalDisposition,
+    PayloadRef,
+    ResultEnvelope,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+)
+from jetson.phase1_runtime import BoundedTaskBroker, LaneConfig, OverflowPolicy
+
+
+INPUT_SHA256 = "a" * 64
+OTHER_SHA256 = "c" * 64
+OUTPUT_SHA256 = "b" * 64
+
+
+class ManualClock:
+    def __init__(self, now_ns: int = 100) -> None:
+        self.now_ns = now_ns
+
+    def __call__(self) -> int:
+        return self.now_ns
+
+    def advance(self, delta_ns: int) -> int:
+        self.now_ns += delta_ns
+        return self.now_ns
+
+
+def make_task(
+    task_id: str,
+    *,
+    generation: int = 0,
+    scope_id: str = "interaction-1",
+    created_ns: int = 100,
+    deadline_ns: int = 1000,
+    supersession_key: str | None = None,
+) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id=task_id,
+        task_kind=TaskKind.SIMULATED,
+        source_monotonic_ns=created_ns - 10,
+        created_monotonic_ns=created_ns,
+        deadline_monotonic_ns=deadline_ns,
+        state_token=StateToken(scope_id, generation),
+        payload=PayloadRef(
+            ref=f"private/{task_id}.bin",
+            sha256=INPUT_SHA256,
+            size_bytes=16,
+            media_type="application/octet-stream",
+        ),
+        supersession_key=supersession_key,
+    )
+
+
+def make_result(
+    task: TaskEnvelope,
+    *,
+    started_ns: int = 110,
+    finished_ns: int = 120,
+    input_sha256: str = INPUT_SHA256,
+    outcome: ExecutionOutcome = ExecutionOutcome.OK,
+) -> ResultEnvelope:
+    error_code = None
+    output_sha256: str | None = OUTPUT_SHA256
+    output_length: int | None = 4
+    if outcome in {ExecutionOutcome.ERROR, ExecutionOutcome.TIMEOUT}:
+        error_code = "simulated_failure"
+        output_sha256 = None
+        output_length = None
+    return ResultEnvelope(
+        task_id=task.task_id,
+        task_kind=task.task_kind,
+        state_token=task.state_token,
+        source_monotonic_ns=task.source_monotonic_ns,
+        deadline_monotonic_ns=task.deadline_monotonic_ns,
+        input_sha256=input_sha256,
+        started_monotonic_ns=started_ns,
+        finished_monotonic_ns=finished_ns,
+        execution_outcome=outcome,
+        output_sha256=output_sha256,
+        output_length=output_length,
+        error_code=error_code,
+    )
+
+
+def make_broker(
+    clock: ManualClock,
+    *,
+    pending_capacity: int = 2,
+    result_capacity: int = 1,
+    terminal_capacity: int = 16,
+    state_scope_capacity: int = 8,
+    policy: OverflowPolicy = OverflowPolicy.REJECT_NEW,
+) -> BoundedTaskBroker:
+    return BoundedTaskBroker(
+        LaneConfig(
+            task_kind=TaskKind.SIMULATED,
+            pending_capacity=pending_capacity,
+            result_capacity=result_capacity,
+            terminal_record_capacity=terminal_capacity,
+            state_scope_capacity=state_scope_capacity,
+            overflow_policy=policy,
+        ),
+        clock_ns=clock,
+    )
+
+
+def run_to_result(
+    broker: BoundedTaskBroker,
+    task: TaskEnvelope,
+    clock: ManualClock,
+) -> None:
+    self_submit = broker.submit(task)
+    if not self_submit.admitted:
+        raise AssertionError(self_submit)
+    claim = broker.claim_next()
+    if claim.claimed is None:
+        raise AssertionError("task was not claimed")
+    clock.advance(1)
+    completion = broker.complete(
+        make_result(
+            task,
+            started_ns=claim.claimed.started_monotonic_ns,
+            finished_ns=clock.now_ns,
+        )
+    )
+    if not completion.result_pending:
+        raise AssertionError(completion)
+
+
+class AdmissionPolicyTests(unittest.TestCase):
+    def test_lane_capacity_has_a_finite_configuration_limit(self) -> None:
+        with self.assertRaisesRegex(ValueError, "between 1"):
+            LaneConfig(
+                task_kind=TaskKind.SIMULATED,
+                pending_capacity=100_001,
+            )
+
+    def test_reject_new_keeps_queue_bounded_and_accounting_closed(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock, pending_capacity=1)
+
+        first = broker.submit(make_task("task-1"))
+        second = broker.submit(make_task("task-2"))
+
+        self.assertTrue(first.admitted)
+        self.assertFalse(second.admitted)
+        self.assertEqual(second.disposition, FinalDisposition.REJECTED_BUSY)
+        snapshot = broker.snapshot()
+        self.assertEqual(snapshot.queued_ids, ("task-1",))
+        self.assertEqual(snapshot.submission_attempts, 2)
+        self.assertEqual(snapshot.rejected_at_ingress_total, 1)
+        self.assertTrue(snapshot.accounting_holds)
+
+    def test_drop_oldest_terminalizes_replaced_task(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(
+            clock,
+            pending_capacity=1,
+            policy=OverflowPolicy.DROP_OLDEST,
+        )
+        broker.submit(make_task("task-1"))
+        result = broker.submit(make_task("task-2"))
+
+        self.assertTrue(result.admitted)
+        self.assertEqual(len(result.terminalized), 1)
+        self.assertEqual(
+            result.terminalized[0].disposition,
+            FinalDisposition.DROPPED_OVERFLOW,
+        )
+        self.assertEqual(broker.snapshot().queued_ids, ("task-2",))
+
+    def test_coalesce_replaces_only_a_matching_pending_key(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(
+            clock,
+            pending_capacity=2,
+            policy=OverflowPolicy.COALESCE_BY_KEY,
+        )
+        broker.submit(make_task("frame-1", supersession_key="camera-front"))
+        replacement = broker.submit(
+            make_task("frame-2", supersession_key="camera-front")
+        )
+        broker.submit(make_task("frame-side", supersession_key="camera-side"))
+        rejected = broker.submit(
+            make_task("frame-other", supersession_key="camera-other")
+        )
+
+        self.assertEqual(len(replacement.terminalized), 1)
+        self.assertEqual(
+            broker.snapshot().queued_ids,
+            ("frame-2", "frame-side"),
+        )
+        self.assertFalse(rejected.admitted)
+        self.assertEqual(rejected.disposition, FinalDisposition.REJECTED_BUSY)
+
+    def test_duplicate_retained_task_id_is_rejected_as_contract_error(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        task = make_task("duplicate")
+        broker.submit(task)
+        with self.assertRaisesRegex(ValueError, "duplicate retained"):
+            broker.submit(task)
+
+    def test_expired_pending_task_is_pruned_before_claim(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        broker.submit(make_task("expired", deadline_ns=101))
+        clock.advance(2)
+
+        claim = broker.claim_next()
+
+        self.assertIsNone(claim.claimed)
+        self.assertEqual(len(claim.terminalized), 1)
+        self.assertEqual(
+            claim.terminalized[0].disposition,
+            FinalDisposition.REJECTED_EXPIRED,
+        )
+        self.assertTrue(broker.snapshot().accounting_holds)
+
+    def test_task_creation_time_cannot_be_in_the_future(self) -> None:
+        clock = ManualClock(now_ns=100)
+        broker = make_broker(clock)
+
+        with self.assertRaisesRegex(ValueError, "creation time"):
+            broker.submit(
+                make_task(
+                    "future",
+                    created_ns=101,
+                    deadline_ns=1000,
+                )
+            )
+
+        snapshot = broker.snapshot()
+        self.assertEqual(snapshot.submission_attempts, 0)
+        self.assertTrue(snapshot.accounting_holds)
+
+    def test_state_scope_table_is_bounded_without_forgetting_generations(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(
+            clock,
+            pending_capacity=2,
+            state_scope_capacity=1,
+        )
+        first = broker.submit(make_task("first", scope_id="scope-1"))
+        second = broker.submit(make_task("second", scope_id="scope-2"))
+
+        self.assertTrue(first.admitted)
+        self.assertFalse(second.admitted)
+        self.assertEqual(second.disposition, FinalDisposition.REJECTED_BUSY)
+        self.assertEqual(broker.snapshot().state_generations, (("scope-1", 0),))
+        with self.assertRaisesRegex(BrokerStateError, "scope capacity"):
+            broker.advance_state("scope-2", reason="new_state")
+
+
+class LifecycleTests(unittest.TestCase):
+    def test_valid_result_is_revalidated_and_consumed(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        task = make_task("task-1")
+        run_to_result(broker, task, clock)
+
+        consumed = broker.consume_next()
+
+        self.assertIsNotNone(consumed)
+        assert consumed is not None
+        self.assertTrue(consumed.consumed)
+        self.assertEqual(consumed.disposition, FinalDisposition.CONSUMED)
+        snapshot = broker.snapshot()
+        self.assertEqual(snapshot.live, 0)
+        self.assertEqual(snapshot.terminal_admitted_total, 1)
+        self.assertTrue(snapshot.accounting_holds)
+
+    def test_result_identity_mismatch_is_never_queued_for_consumption(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        task = make_task("task-1")
+        broker.submit(task)
+        claim = broker.claim_next().claimed
+        assert claim is not None
+
+        completion = broker.complete(
+            make_result(
+                task,
+                started_ns=claim.started_monotonic_ns,
+                finished_ns=clock.advance(1),
+                input_sha256=OTHER_SHA256,
+            )
+        )
+
+        self.assertFalse(completion.result_pending)
+        self.assertEqual(
+            completion.disposition,
+            FinalDisposition.REJECTED_IDENTITY,
+        )
+        self.assertIsNone(broker.consume_next())
+
+    def test_result_worker_start_must_match_the_claim(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        task = make_task("task-1")
+        broker.submit(task)
+        claim = broker.claim_next().claimed
+        assert claim is not None
+        clock.advance(2)
+
+        completion = broker.complete(
+            make_result(
+                task,
+                started_ns=claim.started_monotonic_ns + 1,
+                finished_ns=clock.now_ns,
+            )
+        )
+
+        self.assertEqual(
+            completion.disposition,
+            FinalDisposition.REJECTED_IDENTITY,
+        )
+
+    def test_result_can_expire_after_completion_before_consumption(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        task = make_task("task-1", deadline_ns=130)
+        run_to_result(broker, task, clock)
+        clock.now_ns = 131
+
+        consumed = broker.consume_next()
+
+        assert consumed is not None
+        self.assertFalse(consumed.consumed)
+        self.assertEqual(
+            consumed.disposition,
+            FinalDisposition.REJECTED_EXPIRED,
+        )
+
+    def test_result_mailbox_backpressure_is_a_terminal_disposition(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock, result_capacity=1)
+        first = make_task("task-1")
+        second = make_task("task-2")
+        run_to_result(broker, first, clock)
+        broker.submit(second)
+        claim = broker.claim_next().claimed
+        assert claim is not None
+
+        completion = broker.complete(
+            make_result(
+                second,
+                started_ns=claim.started_monotonic_ns,
+                finished_ns=clock.advance(1),
+            )
+        )
+
+        self.assertEqual(
+            completion.disposition,
+            FinalDisposition.RESULT_BACKPRESSURE,
+        )
+        self.assertEqual(broker.snapshot().result_pending_ids, ("task-1",))
+
+    def test_execution_error_is_separate_from_result_freshness(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        task = make_task("task-1")
+        broker.submit(task)
+        claim = broker.claim_next().claimed
+        assert claim is not None
+
+        completion = broker.complete(
+            make_result(
+                task,
+                started_ns=claim.started_monotonic_ns,
+                finished_ns=clock.advance(1),
+                outcome=ExecutionOutcome.ERROR,
+            )
+        )
+
+        self.assertEqual(
+            completion.disposition,
+            FinalDisposition.EXECUTION_ERROR,
+        )
+        self.assertIsNone(broker.consume_next())
+
+
+class CancellationAndStateTests(unittest.TestCase):
+    def test_cancel_and_state_change_validate_reason_without_live_tasks(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+
+        with self.assertRaisesRegex(ValueError, "1 to 128"):
+            broker.cancel("missing", reason="")
+        with self.assertRaisesRegex(ValueError, "printable"):
+            broker.advance_state("interaction-1", reason=" invalid ")
+
+    def test_cancel_handles_queued_running_and_result_pending_locations(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock, pending_capacity=3, result_capacity=2)
+
+        queued = make_task("queued")
+        broker.submit(queued)
+        queued_cancel = broker.cancel("queued", reason="user_cancel")
+        assert queued_cancel.transition is not None
+        self.assertEqual(
+            queued_cancel.transition.disposition,
+            FinalDisposition.CANCELLED_QUEUED,
+        )
+
+        running = make_task("running")
+        broker.submit(running)
+        claim = broker.claim_next().claimed
+        assert claim is not None
+        running_cancel = broker.cancel("running", reason="user_cancel")
+        self.assertTrue(running_cancel.request_changed)
+        self.assertTrue(claim.cancellation_token.is_requested())
+        completion = broker.complete(
+            make_result(
+                running,
+                started_ns=claim.started_monotonic_ns,
+                finished_ns=clock.advance(1),
+            )
+        )
+        self.assertEqual(
+            completion.disposition,
+            FinalDisposition.REJECTED_CANCELLED,
+        )
+
+        pending_result = make_task("result")
+        run_to_result(broker, pending_result, clock)
+        result_cancel = broker.cancel("result", reason="user_cancel")
+        assert result_cancel.transition is not None
+        self.assertEqual(
+            result_cancel.transition.disposition,
+            FinalDisposition.REJECTED_CANCELLED,
+        )
+        self.assertEqual(broker.snapshot().live, 0)
+
+    def test_state_advance_invalidates_only_the_matching_scope(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock, pending_capacity=4, result_capacity=2)
+
+        result_task = make_task("old-result")
+        run_to_result(broker, result_task, clock)
+        active_task = make_task("old-active")
+        queued_task = make_task("old-queued")
+        other_scope = make_task("other", scope_id="interaction-2")
+        broker.submit(active_task)
+        broker.submit(queued_task)
+        broker.submit(other_scope)
+        claim = broker.claim_next().claimed
+        assert claim is not None
+        self.assertEqual(claim.task.task_id, "old-active")
+
+        advanced = broker.advance_state(
+            "interaction-1",
+            reason="new_interaction_state",
+        )
+
+        self.assertEqual(advanced.state_token.generation, 1)
+        self.assertTrue(advanced.active_cancellation_requested)
+        terminal_ids = {item.task_id for item in advanced.terminalized}
+        self.assertEqual(terminal_ids, {"old-result", "old-queued"})
+        self.assertEqual(broker.snapshot().queued_ids, ("other",))
+
+        completion = broker.complete(
+            make_result(
+                active_task,
+                started_ns=claim.started_monotonic_ns,
+                finished_ns=clock.advance(1),
+            )
+        )
+        self.assertEqual(
+            completion.disposition,
+            FinalDisposition.REJECTED_STATE,
+        )
+
+    def test_old_generation_is_rejected_at_ingress(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        broker.advance_state("interaction-1", reason="reset")
+
+        rejected = broker.submit(make_task("old", generation=0))
+        accepted = broker.submit(make_task("current", generation=1))
+
+        self.assertFalse(rejected.admitted)
+        self.assertEqual(rejected.disposition, FinalDisposition.REJECTED_STATE)
+        self.assertTrue(accepted.admitted)
+
+
+class BoundsAndShutdownTests(unittest.TestCase):
+    def test_broker_rejects_monotonic_clock_regression(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        broker.submit(make_task("active"))
+        clock.advance(10)
+        claim = broker.claim_next().claimed
+        assert claim is not None
+
+        clock.now_ns = 109
+        with self.assertRaisesRegex(ValueError, "moved backwards"):
+            broker.cancel("active", reason="user_cancel")
+        self.assertFalse(claim.cancellation_token.is_requested())
+
+        clock.now_ns = 111
+        cancelled = broker.cancel("active", reason="user_cancel")
+        self.assertTrue(cancelled.request_changed)
+
+    def test_terminal_record_retention_is_bounded_without_losing_accounting(
+        self,
+    ) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock, terminal_capacity=2)
+
+        for index in range(5):
+            task = make_task(f"task-{index}")
+            run_to_result(broker, task, clock)
+            consumed = broker.consume_next()
+            assert consumed is not None and consumed.consumed
+
+        snapshot = broker.snapshot()
+        self.assertEqual(snapshot.terminal_admitted_total, 5)
+        self.assertEqual(len(snapshot.retained_terminal_ids), 2)
+        self.assertEqual(snapshot.retained_terminal_ids, ("task-3", "task-4"))
+        self.assertTrue(snapshot.accounting_holds)
+
+    def test_cancel_shutdown_closes_after_active_task_finishes(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock, pending_capacity=2)
+        active = make_task("active")
+        queued = make_task("queued")
+        broker.submit(active)
+        broker.submit(queued)
+        claim = broker.claim_next().claimed
+        assert claim is not None
+
+        shutdown = broker.begin_shutdown(cancel_live=True)
+
+        self.assertEqual(shutdown.state, BrokerState.CLOSING)
+        self.assertTrue(shutdown.active_cancellation_requested)
+        self.assertEqual(
+            shutdown.terminalized[0].disposition,
+            FinalDisposition.SHUTDOWN_CANCELLED,
+        )
+        with self.assertRaisesRegex(BrokerStateError, "does not match"):
+            broker.complete(make_result(queued))
+
+        completion = broker.complete(
+            make_result(
+                active,
+                started_ns=claim.started_monotonic_ns,
+                finished_ns=clock.advance(1),
+            )
+        )
+        self.assertEqual(
+            completion.disposition,
+            FinalDisposition.REJECTED_CANCELLED,
+        )
+        self.assertEqual(broker.snapshot().state, BrokerState.CLOSED)
+
+    def test_submissions_after_shutdown_are_rejected(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(clock)
+        broker.begin_shutdown(cancel_live=False)
+
+        result = broker.submit(make_task("late"))
+
+        self.assertFalse(result.admitted)
+        self.assertEqual(
+            result.disposition,
+            FinalDisposition.SHUTDOWN_CANCELLED,
+        )
+        self.assertEqual(broker.snapshot().state, BrokerState.CLOSED)
+
+    def test_concurrent_producers_preserve_capacity_and_accounting(self) -> None:
+        clock = ManualClock()
+        broker = make_broker(
+            clock,
+            pending_capacity=200,
+            terminal_capacity=256,
+        )
+        errors: list[BaseException] = []
+
+        def producer(worker_index: int) -> None:
+            try:
+                for item_index in range(50):
+                    result = broker.submit(
+                        make_task(f"task-{worker_index}-{item_index}")
+                    )
+                    if not result.admitted:
+                        raise AssertionError(result)
+            except BaseException as exc:  # reported after all threads join
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=producer, args=(index,)) for index in range(4)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(errors, [])
+        snapshot = broker.snapshot()
+        self.assertEqual(snapshot.queued, 200)
+        self.assertEqual(snapshot.max_pending_depth, 200)
+        self.assertTrue(snapshot.accounting_holds)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_model.py
+++ b/experiments/phase1/tests/test_model.py
@@ -1,0 +1,164 @@
+"""Unit tests for immutable Phase 1 task and result contracts."""
+
+from __future__ import annotations
+
+import math
+import sys
+import unittest
+
+from jetson.phase1_runtime.model import (
+    CancellationReport,
+    CancellationToken,
+    ExecutionOutcome,
+    PayloadRef,
+    ResultEnvelope,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+)
+
+
+INPUT_SHA256 = "a" * 64
+OUTPUT_SHA256 = "b" * 64
+
+
+def make_payload() -> PayloadRef:
+    return PayloadRef(
+        ref="private/input.bin",
+        sha256=INPUT_SHA256,
+        size_bytes=32,
+        media_type="application/octet-stream",
+    )
+
+
+def make_task(**overrides: object) -> TaskEnvelope:
+    values: dict[str, object] = {
+        "task_id": "task-001",
+        "task_kind": TaskKind.SIMULATED,
+        "source_monotonic_ns": 90,
+        "created_monotonic_ns": 100,
+        "deadline_monotonic_ns": 1000,
+        "state_token": StateToken("interaction-1", 0),
+        "payload": make_payload(),
+        "metadata": {"duration_ms": 10, "cooperative": True},
+    }
+    values.update(overrides)
+    return TaskEnvelope(**values)  # type: ignore[arg-type]
+
+
+def make_result(**overrides: object) -> ResultEnvelope:
+    values: dict[str, object] = {
+        "task_id": "task-001",
+        "task_kind": TaskKind.SIMULATED,
+        "state_token": StateToken("interaction-1", 0),
+        "source_monotonic_ns": 90,
+        "deadline_monotonic_ns": 1000,
+        "input_sha256": INPUT_SHA256,
+        "started_monotonic_ns": 110,
+        "finished_monotonic_ns": 120,
+        "execution_outcome": ExecutionOutcome.OK,
+        "output_sha256": OUTPUT_SHA256,
+        "output_length": 4,
+    }
+    values.update(overrides)
+    return ResultEnvelope(**values)  # type: ignore[arg-type]
+
+
+class TaskModelTests(unittest.TestCase):
+    def test_runtime_import_does_not_cross_the_motion_boundary(self) -> None:
+        self.assertNotIn("jetson.robot_comm", sys.modules)
+        self.assertNotIn("jetson.motion_planner", sys.modules)
+        self.assertNotIn("serial", sys.modules)
+
+    def test_valid_task_freezes_metadata_and_hides_payload_reference(self) -> None:
+        metadata = {"duration_ms": 10}
+        task = make_task(metadata=metadata)
+        metadata["duration_ms"] = 99
+
+        self.assertEqual(task.metadata["duration_ms"], 10)
+        with self.assertRaises(TypeError):
+            task.metadata["duration_ms"] = 20  # type: ignore[index]
+        self.assertNotIn("private/input.bin", repr(task.payload))
+
+    def test_task_rejects_invalid_timestamp_order(self) -> None:
+        with self.assertRaisesRegex(ValueError, "after creation"):
+            make_task(source_monotonic_ns=101)
+        with self.assertRaisesRegex(ValueError, "before creation"):
+            make_task(deadline_monotonic_ns=99)
+
+    def test_payload_requires_lowercase_sha256_and_media_type(self) -> None:
+        with self.assertRaisesRegex(ValueError, "lowercase SHA-256"):
+            PayloadRef("input", "A" * 64, 1, "application/octet-stream")
+        with self.assertRaisesRegex(ValueError, "MIME"):
+            PayloadRef("input", INPUT_SHA256, 1, "Application/JSON")
+
+    def test_metadata_rejects_nested_oversized_and_non_finite_values(self) -> None:
+        with self.assertRaisesRegex(TypeError, "JSON scalar"):
+            make_task(metadata={"nested": {"value": 1}})
+        with self.assertRaisesRegex(ValueError, "must not exceed"):
+            make_task(metadata={"message": "x" * 257})
+        with self.assertRaisesRegex(ValueError, "finite"):
+            make_task(metadata={"value": math.inf})
+
+    def test_result_requires_consistent_output_descriptor(self) -> None:
+        with self.assertRaisesRegex(ValueError, "present together"):
+            make_result(output_sha256=None)
+        with self.assertRaisesRegex(ValueError, "present together"):
+            make_result(output_length=None)
+
+    def test_error_and_timeout_results_require_bounded_error_code(self) -> None:
+        with self.assertRaisesRegex(ValueError, "require error_code"):
+            make_result(
+                execution_outcome=ExecutionOutcome.ERROR,
+                output_sha256=None,
+                output_length=None,
+            )
+        result = make_result(
+            execution_outcome=ExecutionOutcome.TIMEOUT,
+            output_sha256=None,
+            output_length=None,
+            error_code="adapter_timeout",
+        )
+        self.assertEqual(result.error_code, "adapter_timeout")
+
+    def test_cancel_observed_requires_matching_report(self) -> None:
+        with self.assertRaisesRegex(ValueError, "worker_observed"):
+            make_result(
+                execution_outcome=ExecutionOutcome.CANCEL_OBSERVED,
+                output_sha256=None,
+                output_length=None,
+            )
+        result = make_result(
+            execution_outcome=ExecutionOutcome.CANCEL_OBSERVED,
+            output_sha256=None,
+            output_length=None,
+            cancellation_report=CancellationReport(
+                requested=True,
+                worker_observed=True,
+                backend_stop_confirmed=True,
+            ),
+        )
+        self.assertTrue(result.cancellation_report.worker_observed)
+
+    def test_cancellation_report_does_not_infer_backend_stop(self) -> None:
+        report = CancellationReport(requested=True)
+        self.assertIsNone(report.backend_stop_confirmed)
+        with self.assertRaisesRegex(ValueError, "requested=True"):
+            CancellationReport(requested=False, client_wait_stopped=True)
+        with self.assertRaisesRegex(ValueError, "requested=True"):
+            CancellationReport(
+                requested=False,
+                backend_stop_confirmed=False,
+            )
+
+    def test_cancellation_token_is_idempotent(self) -> None:
+        token = CancellationToken()
+        self.assertTrue(token.request("user_cancel", 200))
+        self.assertFalse(token.request("new_reason", 300))
+        self.assertTrue(token.is_requested())
+        self.assertEqual(token.reason, "user_cancel")
+        self.assertEqual(token.requested_at_ns, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -1,8 +1,8 @@
 # Jetson Runtime
 
-The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32.
+The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel, which is not yet connected to the robot application or model services.
 
-It was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. The application is a synchronous reference implementation; the planned asynchronous runtime will be developed from this baseline rather than presented as an existing feature.
+The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 kernel currently covers host-only task identity, bounded ownership and lifecycle correctness; worker threads, Jetson pilots and application integration remain research work.
 
 > 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前代码是已经完成整机验证的同步毕设基线，异步推理框架尚未合入。
 
@@ -16,6 +16,7 @@ It was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python
 | `vision_color.py` | HSV segmentation and target extraction |
 | `motion_planner.py` | Discrete visual feedback loop for approaching a colored object |
 | `robot_comm.py` | Command mapping, UART transport, STM32 responses and motion log |
+| `phase1_runtime/` | Host-testable task/result contracts and bounded lifecycle broker |
 | `assets/` | sherpa-onnx keyword configuration and wake acknowledgment audio |
 | `scripts/` | One-time environment setup helpers |
 
@@ -111,6 +112,7 @@ Audio, ASR text, captured images and communication logs are written beneath `ROB
 ## Baseline limitations
 
 - The orchestration path is blocking and single-process; inference tasks do not have explicit deadlines or cancellation.
+- The Phase 1 host-only kernel is not yet connected to acquisition, inference services, TTS or the synchronous application loop.
 - llama.cpp and Ollama are managed outside the application.
 - The color tracker uses fixed HSV ranges and discrete motion commands tuned on the thesis robot.
 - The Jetson sends speed percentages, while the STM32 applies open-loop PWM rather than closed-loop wheel velocity.

--- a/jetson/phase1_runtime/__init__.py
+++ b/jetson/phase1_runtime/__init__.py
@@ -1,0 +1,58 @@
+"""Host-testable runtime contracts for Phase 1 asynchronous inference."""
+
+from .broker import (
+    BoundedTaskBroker,
+    BrokerSnapshot,
+    BrokerState,
+    BrokerStateError,
+    CancellationResult,
+    ClaimedTask,
+    ClaimResult,
+    CompletionResult,
+    ConsumptionResult,
+    ShutdownResult,
+    StateAdvanceResult,
+    SubmissionResult,
+    TerminalTransition,
+)
+from .model import (
+    CancellationReport,
+    CancellationToken,
+    ExecutionOutcome,
+    FinalDisposition,
+    PayloadRef,
+    ResultEnvelope,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+    TaskLocation,
+)
+from .policies import LaneConfig, OverflowPolicy
+
+__all__ = [
+    "BoundedTaskBroker",
+    "BrokerSnapshot",
+    "BrokerState",
+    "BrokerStateError",
+    "CancellationResult",
+    "CancellationReport",
+    "CancellationToken",
+    "ClaimedTask",
+    "ClaimResult",
+    "CompletionResult",
+    "ConsumptionResult",
+    "ExecutionOutcome",
+    "FinalDisposition",
+    "LaneConfig",
+    "OverflowPolicy",
+    "PayloadRef",
+    "ResultEnvelope",
+    "ShutdownResult",
+    "StateToken",
+    "StateAdvanceResult",
+    "SubmissionResult",
+    "TaskEnvelope",
+    "TaskKind",
+    "TaskLocation",
+    "TerminalTransition",
+]

--- a/jetson/phase1_runtime/broker.py
+++ b/jetson/phase1_runtime/broker.py
@@ -1,0 +1,796 @@
+"""Thread-safe bounded task ownership for the Phase 1 runtime kernel."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import Counter, deque
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+from .model import (
+    CancellationToken,
+    ExecutionOutcome,
+    FinalDisposition,
+    ResultEnvelope,
+    StateToken,
+    TaskEnvelope,
+    TaskLocation,
+)
+from .policies import LaneConfig, OverflowPolicy
+
+
+class BrokerState(str, Enum):
+    """Admission and shutdown state of one inference lane."""
+
+    OPEN = "open"
+    CLOSING = "closing"
+    CLOSED = "closed"
+
+
+class BrokerStateError(RuntimeError):
+    """A caller attempted an impossible lifecycle operation."""
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalTransition:
+    task_id: str
+    previous_location: TaskLocation
+    disposition: FinalDisposition
+    terminal_monotonic_ns: int
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionResult:
+    task_id: str
+    admitted: bool
+    disposition: FinalDisposition | None
+    terminalized: tuple[TerminalTransition, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimedTask:
+    task: TaskEnvelope
+    cancellation_token: CancellationToken
+    started_monotonic_ns: int
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimResult:
+    claimed: ClaimedTask | None
+    terminalized: tuple[TerminalTransition, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CompletionResult:
+    task_id: str
+    result_pending: bool
+    disposition: FinalDisposition | None
+    transition: TerminalTransition | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsumptionResult:
+    task: TaskEnvelope
+    result: ResultEnvelope
+    consumed: bool
+    disposition: FinalDisposition
+    transition: TerminalTransition
+
+
+@dataclass(frozen=True, slots=True)
+class CancellationResult:
+    task_id: str
+    found: bool
+    request_changed: bool = False
+    already_terminal: bool = False
+    transition: TerminalTransition | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StateAdvanceResult:
+    state_token: StateToken
+    terminalized: tuple[TerminalTransition, ...]
+    active_cancellation_requested: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ShutdownResult:
+    state: BrokerState
+    terminalized: tuple[TerminalTransition, ...]
+    active_cancellation_requested: bool
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerSnapshot:
+    state: BrokerState
+    submission_attempts: int
+    admitted_total: int
+    rejected_at_ingress_total: int
+    queued_ids: tuple[str, ...]
+    active_id: str | None
+    result_pending_ids: tuple[str, ...]
+    terminal_admitted_total: int
+    retained_terminal_ids: tuple[str, ...]
+    max_pending_depth: int
+    max_result_depth: int
+    state_generations: tuple[tuple[str, int], ...]
+    disposition_counts: tuple[tuple[FinalDisposition, int], ...]
+
+    @property
+    def queued(self) -> int:
+        return len(self.queued_ids)
+
+    @property
+    def running(self) -> int:
+        return int(self.active_id is not None)
+
+    @property
+    def result_pending(self) -> int:
+        return len(self.result_pending_ids)
+
+    @property
+    def live(self) -> int:
+        return self.queued + self.running + self.result_pending
+
+    @property
+    def accounting_holds(self) -> bool:
+        attempts_close = self.submission_attempts == (
+            self.admitted_total + self.rejected_at_ingress_total
+        )
+        admitted_close = self.admitted_total == (
+            self.live + self.terminal_admitted_total
+        )
+        dispositions_close = sum(count for _, count in self.disposition_counts) == (
+            self.rejected_at_ingress_total + self.terminal_admitted_total
+        )
+        return attempts_close and admitted_close and dispositions_close
+
+
+@dataclass(slots=True)
+class _TaskRecord:
+    task: TaskEnvelope
+    location: TaskLocation
+    admitted_monotonic_ns: int
+    cancellation_token: CancellationToken
+    started_monotonic_ns: int | None = None
+    result: ResultEnvelope | None = None
+    disposition: FinalDisposition | None = None
+    terminal_monotonic_ns: int | None = None
+
+
+class BoundedTaskBroker:
+    """Own all live locations for one bounded, single-consumer lane."""
+
+    def __init__(
+        self,
+        config: LaneConfig,
+        *,
+        clock_ns: Callable[[], int] = time.monotonic_ns,
+    ) -> None:
+        if not isinstance(config, LaneConfig):
+            raise TypeError("config must be a LaneConfig")
+        if not callable(clock_ns):
+            raise TypeError("clock_ns must be callable")
+
+        self.config = config
+        self._clock_ns = clock_ns
+        self._condition = threading.Condition(threading.RLock())
+        self._state = BrokerState.OPEN
+        self._pending: deque[str] = deque()
+        self._active_id: str | None = None
+        self._result_pending: deque[str] = deque()
+        self._records: dict[str, _TaskRecord] = {}
+        self._terminal_order: deque[str] = deque()
+        self._state_generations: dict[str, int] = {}
+        self._submission_attempts = 0
+        self._admitted_total = 0
+        self._rejected_at_ingress_total = 0
+        self._terminal_admitted_total = 0
+        self._disposition_counts: Counter[FinalDisposition] = Counter()
+        self._max_pending_depth = 0
+        self._max_result_depth = 0
+        self._last_monotonic_ns = 0
+
+    def _now_locked(self, supplied: int | None) -> int:
+        value = self._clock_ns() if supplied is None else supplied
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError("monotonic timestamp must be a non-negative integer")
+        if value < self._last_monotonic_ns:
+            raise ValueError("broker monotonic time moved backwards")
+        self._last_monotonic_ns = value
+        return value
+
+    @staticmethod
+    def _validate_reason(reason: object) -> str:
+        if not isinstance(reason, str):
+            raise TypeError("reason must be a string")
+        if not 1 <= len(reason) <= 128:
+            raise ValueError("reason must contain 1 to 128 characters")
+        if reason != reason.strip() or not reason.isprintable():
+            raise ValueError("reason must be printable without outer whitespace")
+        return reason
+
+    def current_state_token(self, scope_id: str) -> StateToken:
+        probe = StateToken(scope_id=scope_id, generation=0)
+        with self._condition:
+            return StateToken(
+                scope_id=probe.scope_id,
+                generation=self._state_generations.get(probe.scope_id, 0),
+            )
+
+    def _state_matches(self, task: TaskEnvelope) -> bool:
+        current = self._state_generations.get(task.state_token.scope_id, 0)
+        return task.state_token.generation == current
+
+    def _reject_ingress(
+        self,
+        task_id: str,
+        disposition: FinalDisposition,
+        terminalized: tuple[TerminalTransition, ...] = (),
+    ) -> SubmissionResult:
+        self._rejected_at_ingress_total += 1
+        self._disposition_counts[disposition] += 1
+        return SubmissionResult(
+            task_id=task_id,
+            admitted=False,
+            disposition=disposition,
+            terminalized=terminalized,
+        )
+
+    def _terminalize(
+        self,
+        record: _TaskRecord,
+        disposition: FinalDisposition,
+        now_ns: int,
+    ) -> TerminalTransition:
+        if record.location is TaskLocation.TERMINAL:
+            raise BrokerStateError(f"task is already terminal: {record.task.task_id}")
+        previous = record.location
+        record.location = TaskLocation.TERMINAL
+        record.disposition = disposition
+        record.terminal_monotonic_ns = now_ns
+        self._terminal_admitted_total += 1
+        self._disposition_counts[disposition] += 1
+        self._terminal_order.append(record.task.task_id)
+
+        while len(self._terminal_order) > self.config.terminal_record_capacity:
+            evicted_id = self._terminal_order.popleft()
+            evicted = self._records.get(evicted_id)
+            if evicted is not None and evicted.location is TaskLocation.TERMINAL:
+                del self._records[evicted_id]
+
+        return TerminalTransition(
+            task_id=record.task.task_id,
+            previous_location=previous,
+            disposition=disposition,
+            terminal_monotonic_ns=now_ns,
+        )
+
+    def _remove_pending(self, task_id: str) -> None:
+        try:
+            self._pending.remove(task_id)
+        except ValueError as exc:
+            raise BrokerStateError(
+                f"task is not in the pending queue: {task_id}"
+            ) from exc
+
+    def _remove_result_pending(self, task_id: str) -> None:
+        try:
+            self._result_pending.remove(task_id)
+        except ValueError as exc:
+            raise BrokerStateError(
+                f"task is not in the result mailbox: {task_id}"
+            ) from exc
+
+    def _prune_pending(self, now_ns: int) -> tuple[TerminalTransition, ...]:
+        transitions: list[TerminalTransition] = []
+        for task_id in tuple(self._pending):
+            record = self._records[task_id]
+            disposition: FinalDisposition | None = None
+            if record.cancellation_token.is_requested():
+                disposition = FinalDisposition.REJECTED_CANCELLED
+            elif not self._state_matches(record.task):
+                disposition = FinalDisposition.REJECTED_STATE
+            elif now_ns > record.task.deadline_monotonic_ns:
+                disposition = FinalDisposition.REJECTED_EXPIRED
+            if disposition is None:
+                continue
+            self._remove_pending(task_id)
+            transitions.append(self._terminalize(record, disposition, now_ns))
+        return tuple(transitions)
+
+    def submit(
+        self,
+        task: TaskEnvelope,
+        *,
+        now_ns: int | None = None,
+    ) -> SubmissionResult:
+        """Attempt to admit one task without blocking the producer."""
+
+        if not isinstance(task, TaskEnvelope):
+            raise TypeError("task must be a TaskEnvelope")
+        if task.task_kind is not self.config.task_kind:
+            raise ValueError(
+                f"lane accepts {self.config.task_kind.value}, not {task.task_kind.value}"
+            )
+
+        with self._condition:
+            now = self._now_locked(now_ns)
+            if now < task.created_monotonic_ns:
+                raise ValueError("task creation time must not be in the future")
+            if task.task_id in self._records:
+                raise ValueError(f"duplicate retained task_id: {task.task_id}")
+
+            self._submission_attempts += 1
+            terminalized = list(self._prune_pending(now))
+
+            if self._state is not BrokerState.OPEN:
+                return self._reject_ingress(
+                    task.task_id,
+                    FinalDisposition.SHUTDOWN_CANCELLED,
+                    tuple(terminalized),
+                )
+            scope_id = task.state_token.scope_id
+            if scope_id not in self._state_generations:
+                if len(self._state_generations) >= self.config.state_scope_capacity:
+                    return self._reject_ingress(
+                        task.task_id,
+                        FinalDisposition.REJECTED_BUSY,
+                        tuple(terminalized),
+                    )
+                self._state_generations[scope_id] = 0
+            if not self._state_matches(task):
+                return self._reject_ingress(
+                    task.task_id,
+                    FinalDisposition.REJECTED_STATE,
+                    tuple(terminalized),
+                )
+            if now > task.deadline_monotonic_ns:
+                return self._reject_ingress(
+                    task.task_id,
+                    FinalDisposition.REJECTED_EXPIRED,
+                    tuple(terminalized),
+                )
+
+            if (
+                self.config.overflow_policy is OverflowPolicy.COALESCE_BY_KEY
+                and task.supersession_key is not None
+            ):
+                replaced_id = next(
+                    (
+                        task_id
+                        for task_id in self._pending
+                        if self._records[task_id].task.supersession_key
+                        == task.supersession_key
+                    ),
+                    None,
+                )
+                if replaced_id is not None:
+                    self._remove_pending(replaced_id)
+                    terminalized.append(
+                        self._terminalize(
+                            self._records[replaced_id],
+                            FinalDisposition.DROPPED_OVERFLOW,
+                            now,
+                        )
+                    )
+
+            if len(self._pending) >= self.config.pending_capacity:
+                if self.config.overflow_policy is OverflowPolicy.DROP_OLDEST:
+                    replaced_id = self._pending.popleft()
+                    terminalized.append(
+                        self._terminalize(
+                            self._records[replaced_id],
+                            FinalDisposition.DROPPED_OVERFLOW,
+                            now,
+                        )
+                    )
+                else:
+                    return self._reject_ingress(
+                        task.task_id,
+                        FinalDisposition.REJECTED_BUSY,
+                        tuple(terminalized),
+                    )
+
+            self._records[task.task_id] = _TaskRecord(
+                task=task,
+                location=TaskLocation.QUEUED,
+                admitted_monotonic_ns=now,
+                cancellation_token=CancellationToken(),
+            )
+            self._pending.append(task.task_id)
+            self._admitted_total += 1
+            self._max_pending_depth = max(
+                self._max_pending_depth,
+                len(self._pending),
+            )
+            self._condition.notify_all()
+            return SubmissionResult(
+                task_id=task.task_id,
+                admitted=True,
+                disposition=None,
+                terminalized=tuple(terminalized),
+            )
+
+    def claim_next(self, *, now_ns: int | None = None) -> ClaimResult:
+        """Claim the next valid pending task for the single worker."""
+
+        with self._condition:
+            now = self._now_locked(now_ns)
+            terminalized = self._prune_pending(now)
+            if self._active_id is not None:
+                return ClaimResult(claimed=None, terminalized=terminalized)
+            if not self._pending:
+                self._maybe_close()
+                return ClaimResult(claimed=None, terminalized=terminalized)
+
+            task_id = self._pending.popleft()
+            record = self._records[task_id]
+            if record.location is not TaskLocation.QUEUED:
+                raise BrokerStateError(f"pending task has wrong location: {task_id}")
+            record.location = TaskLocation.RUNNING
+            record.started_monotonic_ns = now
+            self._active_id = task_id
+            self._condition.notify_all()
+            return ClaimResult(
+                claimed=ClaimedTask(
+                    task=record.task,
+                    cancellation_token=record.cancellation_token,
+                    started_monotonic_ns=now,
+                ),
+                terminalized=terminalized,
+            )
+
+    @staticmethod
+    def _identity_matches(record: _TaskRecord, result: ResultEnvelope) -> bool:
+        task = record.task
+        return all(
+            (
+                task.task_id == result.task_id,
+                task.task_kind is result.task_kind,
+                task.state_token == result.state_token,
+                task.source_monotonic_ns == result.source_monotonic_ns,
+                task.deadline_monotonic_ns == result.deadline_monotonic_ns,
+                task.payload.sha256 == result.input_sha256,
+                record.started_monotonic_ns == result.started_monotonic_ns,
+            )
+        )
+
+    def complete(
+        self,
+        result: ResultEnvelope,
+        *,
+        now_ns: int | None = None,
+    ) -> CompletionResult:
+        """Finish the active task and either reject or enqueue its result."""
+
+        if not isinstance(result, ResultEnvelope):
+            raise TypeError("result must be a ResultEnvelope")
+        with self._condition:
+            now = self._now_locked(now_ns)
+            if self._active_id is None:
+                raise BrokerStateError("no active task to complete")
+            if result.task_id != self._active_id:
+                raise BrokerStateError(
+                    f"result task_id {result.task_id!r} does not match active "
+                    f"task {self._active_id!r}"
+                )
+            if now < result.finished_monotonic_ns:
+                raise ValueError("result finish time must not be in the future")
+
+            record = self._records[self._active_id]
+            if record.location is not TaskLocation.RUNNING:
+                raise BrokerStateError("active task is not in running state")
+
+            self._active_id = None
+            disposition: FinalDisposition | None = None
+            if not self._identity_matches(record, result):
+                disposition = FinalDisposition.REJECTED_IDENTITY
+            elif not self._state_matches(record.task):
+                disposition = FinalDisposition.REJECTED_STATE
+            elif record.cancellation_token.is_requested():
+                disposition = FinalDisposition.REJECTED_CANCELLED
+            elif (
+                result.finished_monotonic_ns > result.deadline_monotonic_ns
+                or now > result.deadline_monotonic_ns
+            ):
+                disposition = FinalDisposition.REJECTED_EXPIRED
+            elif result.execution_outcome is ExecutionOutcome.CANCEL_OBSERVED:
+                disposition = FinalDisposition.REJECTED_CANCELLED
+            elif result.execution_outcome is not ExecutionOutcome.OK:
+                disposition = FinalDisposition.EXECUTION_ERROR
+            elif len(self._result_pending) >= self.config.result_capacity:
+                disposition = FinalDisposition.RESULT_BACKPRESSURE
+
+            if disposition is not None:
+                transition = self._terminalize(record, disposition, now)
+                self._maybe_close()
+                self._condition.notify_all()
+                return CompletionResult(
+                    task_id=record.task.task_id,
+                    result_pending=False,
+                    disposition=disposition,
+                    transition=transition,
+                )
+
+            record.result = result
+            record.location = TaskLocation.RESULT_PENDING
+            self._result_pending.append(record.task.task_id)
+            self._max_result_depth = max(
+                self._max_result_depth,
+                len(self._result_pending),
+            )
+            self._condition.notify_all()
+            return CompletionResult(
+                task_id=record.task.task_id,
+                result_pending=True,
+                disposition=None,
+            )
+
+    def consume_next(
+        self,
+        *,
+        now_ns: int | None = None,
+    ) -> ConsumptionResult | None:
+        """Revalidate and consume or reject the oldest completed result."""
+
+        with self._condition:
+            now = self._now_locked(now_ns)
+            if not self._result_pending:
+                self._maybe_close()
+                return None
+
+            task_id = self._result_pending.popleft()
+            record = self._records[task_id]
+            if record.location is not TaskLocation.RESULT_PENDING:
+                raise BrokerStateError(f"result task has wrong location: {task_id}")
+            if record.result is None:
+                raise BrokerStateError(f"result task has no envelope: {task_id}")
+
+            disposition = FinalDisposition.CONSUMED
+            if not self._state_matches(record.task):
+                disposition = FinalDisposition.REJECTED_STATE
+            elif record.cancellation_token.is_requested():
+                disposition = FinalDisposition.REJECTED_CANCELLED
+            elif now > record.task.deadline_monotonic_ns:
+                disposition = FinalDisposition.REJECTED_EXPIRED
+            elif not self._identity_matches(record, record.result):
+                disposition = FinalDisposition.REJECTED_IDENTITY
+
+            transition = self._terminalize(record, disposition, now)
+            self._maybe_close()
+            self._condition.notify_all()
+            return ConsumptionResult(
+                task=record.task,
+                result=record.result,
+                consumed=disposition is FinalDisposition.CONSUMED,
+                disposition=disposition,
+                transition=transition,
+            )
+
+    def cancel(
+        self,
+        task_id: str,
+        *,
+        reason: str,
+        now_ns: int | None = None,
+    ) -> CancellationResult:
+        """Cancel queued work, signal running work, or reject a pending result."""
+
+        checked_reason = self._validate_reason(reason)
+        with self._condition:
+            now = self._now_locked(now_ns)
+            record = self._records.get(task_id)
+            if record is None:
+                return CancellationResult(task_id=task_id, found=False)
+            if record.location is TaskLocation.TERMINAL:
+                return CancellationResult(
+                    task_id=task_id,
+                    found=True,
+                    already_terminal=True,
+                )
+
+            changed = record.cancellation_token.request(checked_reason, now)
+            transition: TerminalTransition | None = None
+            if record.location is TaskLocation.QUEUED:
+                self._remove_pending(task_id)
+                transition = self._terminalize(
+                    record,
+                    FinalDisposition.CANCELLED_QUEUED,
+                    now,
+                )
+            elif record.location is TaskLocation.RESULT_PENDING:
+                self._remove_result_pending(task_id)
+                transition = self._terminalize(
+                    record,
+                    FinalDisposition.REJECTED_CANCELLED,
+                    now,
+                )
+            elif record.location is not TaskLocation.RUNNING:
+                raise BrokerStateError(f"unsupported task location: {record.location}")
+
+            self._maybe_close()
+            self._condition.notify_all()
+            return CancellationResult(
+                task_id=task_id,
+                found=True,
+                request_changed=changed,
+                transition=transition,
+            )
+
+    def advance_state(
+        self,
+        scope_id: str,
+        *,
+        reason: str,
+        now_ns: int | None = None,
+    ) -> StateAdvanceResult:
+        """Atomically invalidate old tasks in one independent state scope."""
+
+        checked_reason = self._validate_reason(reason)
+        checked_scope = StateToken(scope_id=scope_id, generation=0).scope_id
+        with self._condition:
+            now = self._now_locked(now_ns)
+            if checked_scope not in self._state_generations:
+                if len(self._state_generations) >= self.config.state_scope_capacity:
+                    raise BrokerStateError("state scope capacity exceeded")
+                self._state_generations[checked_scope] = 0
+            current = self._state_generations[checked_scope]
+            next_token = StateToken(
+                scope_id=checked_scope,
+                generation=current + 1,
+            )
+            self._state_generations[checked_scope] = next_token.generation
+            transitions: list[TerminalTransition] = []
+            active_requested = False
+
+            for task_id in tuple(self._pending):
+                record = self._records[task_id]
+                if record.task.state_token.scope_id != checked_scope:
+                    continue
+                self._remove_pending(task_id)
+                record.cancellation_token.request(checked_reason, now)
+                transitions.append(
+                    self._terminalize(
+                        record,
+                        FinalDisposition.REJECTED_STATE,
+                        now,
+                    )
+                )
+
+            if self._active_id is not None:
+                active = self._records[self._active_id]
+                if active.task.state_token.scope_id == checked_scope:
+                    active_requested = active.cancellation_token.request(
+                        checked_reason, now
+                    )
+
+            for task_id in tuple(self._result_pending):
+                record = self._records[task_id]
+                if record.task.state_token.scope_id != checked_scope:
+                    continue
+                self._remove_result_pending(task_id)
+                record.cancellation_token.request(checked_reason, now)
+                transitions.append(
+                    self._terminalize(
+                        record,
+                        FinalDisposition.REJECTED_STATE,
+                        now,
+                    )
+                )
+
+            self._maybe_close()
+            self._condition.notify_all()
+            return StateAdvanceResult(
+                state_token=next_token,
+                terminalized=tuple(transitions),
+                active_cancellation_requested=active_requested,
+            )
+
+    def begin_shutdown(
+        self,
+        *,
+        cancel_live: bool,
+        now_ns: int | None = None,
+    ) -> ShutdownResult:
+        """Stop admission and optionally cancel every live lifecycle location."""
+
+        with self._condition:
+            now = self._now_locked(now_ns)
+            if self._state is BrokerState.CLOSED:
+                return ShutdownResult(
+                    state=self._state,
+                    terminalized=(),
+                    active_cancellation_requested=False,
+                )
+            self._state = BrokerState.CLOSING
+            transitions: list[TerminalTransition] = []
+            active_requested = False
+
+            if cancel_live:
+                for task_id in tuple(self._pending):
+                    self._remove_pending(task_id)
+                    record = self._records[task_id]
+                    record.cancellation_token.request("shutdown", now)
+                    transitions.append(
+                        self._terminalize(
+                            record,
+                            FinalDisposition.SHUTDOWN_CANCELLED,
+                            now,
+                        )
+                    )
+
+                if self._active_id is not None:
+                    active_requested = self._records[
+                        self._active_id
+                    ].cancellation_token.request("shutdown", now)
+
+                for task_id in tuple(self._result_pending):
+                    self._remove_result_pending(task_id)
+                    record = self._records[task_id]
+                    record.cancellation_token.request("shutdown", now)
+                    transitions.append(
+                        self._terminalize(
+                            record,
+                            FinalDisposition.SHUTDOWN_CANCELLED,
+                            now,
+                        )
+                    )
+
+            self._maybe_close()
+            self._condition.notify_all()
+            return ShutdownResult(
+                state=self._state,
+                terminalized=tuple(transitions),
+                active_cancellation_requested=active_requested,
+            )
+
+    def _maybe_close(self) -> None:
+        if (
+            self._state is BrokerState.CLOSING
+            and not self._pending
+            and self._active_id is None
+            and not self._result_pending
+        ):
+            self._state = BrokerState.CLOSED
+
+    def snapshot(self) -> BrokerSnapshot:
+        """Return one lock-consistent accounting snapshot."""
+
+        with self._condition:
+            snapshot = BrokerSnapshot(
+                state=self._state,
+                submission_attempts=self._submission_attempts,
+                admitted_total=self._admitted_total,
+                rejected_at_ingress_total=self._rejected_at_ingress_total,
+                queued_ids=tuple(self._pending),
+                active_id=self._active_id,
+                result_pending_ids=tuple(self._result_pending),
+                terminal_admitted_total=self._terminal_admitted_total,
+                retained_terminal_ids=tuple(self._terminal_order),
+                max_pending_depth=self._max_pending_depth,
+                max_result_depth=self._max_result_depth,
+                state_generations=tuple(sorted(self._state_generations.items())),
+                disposition_counts=tuple(
+                    sorted(
+                        self._disposition_counts.items(),
+                        key=lambda item: item[0].value,
+                    )
+                ),
+            )
+            if not snapshot.accounting_holds:
+                raise BrokerStateError("broker accounting invariant failed")
+            if snapshot.queued > self.config.pending_capacity:
+                raise BrokerStateError("pending capacity invariant failed")
+            if snapshot.result_pending > self.config.result_capacity:
+                raise BrokerStateError("result capacity invariant failed")
+            if (
+                len(snapshot.retained_terminal_ids)
+                > self.config.terminal_record_capacity
+            ):
+                raise BrokerStateError("terminal retention invariant failed")
+            if len(snapshot.state_generations) > self.config.state_scope_capacity:
+                raise BrokerStateError("state scope capacity invariant failed")
+            return snapshot

--- a/jetson/phase1_runtime/model.py
+++ b/jetson/phase1_runtime/model.py
@@ -1,0 +1,414 @@
+"""Immutable task and result contracts for the Phase 1 runtime."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Mapping, TypeAlias
+
+
+MAX_IDENTIFIER_LENGTH = 128
+MAX_REFERENCE_LENGTH = 1024
+MAX_MEDIA_TYPE_LENGTH = 128
+MAX_METADATA_KEYS = 16
+MAX_METADATA_KEY_LENGTH = 64
+MAX_METADATA_STRING_LENGTH = 256
+MAX_METADATA_BYTES = 1024
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_MEDIA_TYPE_RE = re.compile(r"^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$")
+_METADATA_KEY_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_ERROR_CODE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+MetadataScalar: TypeAlias = str | int | float | bool | None
+
+
+class TaskKind(str, Enum):
+    """Workload identity accepted by the first runtime version."""
+
+    SIMULATED = "simulated"
+    VLM = "vlm"
+    ASR = "asr"
+    LLM = "llm"
+
+
+class ExecutionOutcome(str, Enum):
+    """What happened while the workload adapter executed."""
+
+    OK = "ok"
+    ERROR = "error"
+    TIMEOUT = "timeout"
+    CANCEL_OBSERVED = "cancel_observed"
+
+
+class TaskLocation(str, Enum):
+    """The one runtime-owned location of an admitted task."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    RESULT_PENDING = "result_pending"
+    TERMINAL = "terminal"
+
+
+class FinalDisposition(str, Enum):
+    """The single final delivery decision assigned to one task."""
+
+    CONSUMED = "consumed"
+    DROPPED_OVERFLOW = "dropped_overflow"
+    REJECTED_BUSY = "rejected_busy"
+    CANCELLED_QUEUED = "cancelled_queued"
+    REJECTED_CANCELLED = "rejected_cancelled"
+    REJECTED_EXPIRED = "rejected_expired"
+    REJECTED_STATE = "rejected_state"
+    REJECTED_IDENTITY = "rejected_identity"
+    EXECUTION_ERROR = "execution_error"
+    RESULT_BACKPRESSURE = "result_backpressure"
+    SHUTDOWN_CANCELLED = "shutdown_cancelled"
+
+
+def _require_non_negative_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+    return value
+
+
+def _require_bounded_text(
+    value: object,
+    field_name: str,
+    *,
+    max_length: int,
+    optional: bool = False,
+) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not 1 <= len(value) <= max_length:
+        raise ValueError(f"{field_name} must contain 1 to {max_length} characters")
+    if value != value.strip() or not value.isprintable():
+        raise ValueError(f"{field_name} must be printable without outer whitespace")
+    return value
+
+
+def _require_sha256(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not _SHA256_RE.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase SHA-256 hex digest")
+    return value
+
+
+def _freeze_metadata(
+    metadata: Mapping[str, MetadataScalar],
+) -> Mapping[str, MetadataScalar]:
+    if not isinstance(metadata, Mapping):
+        raise TypeError("metadata must be a mapping")
+    if len(metadata) > MAX_METADATA_KEYS:
+        raise ValueError(f"metadata must contain at most {MAX_METADATA_KEYS} keys")
+
+    copied: dict[str, MetadataScalar] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not _METADATA_KEY_RE.fullmatch(key):
+            raise ValueError("metadata keys must use lower_snake_case")
+        if len(key) > MAX_METADATA_KEY_LENGTH:
+            raise ValueError(
+                f"metadata keys must not exceed {MAX_METADATA_KEY_LENGTH} characters"
+            )
+        if not isinstance(value, (str, int, float, bool, type(None))):
+            raise TypeError("metadata values must be JSON scalar values")
+        if isinstance(value, str) and len(value) > MAX_METADATA_STRING_LENGTH:
+            raise ValueError(
+                "metadata string values must not exceed "
+                f"{MAX_METADATA_STRING_LENGTH} characters"
+            )
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("metadata floats must be finite")
+        copied[key] = value
+
+    encoded = json.dumps(
+        copied,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if len(encoded) > MAX_METADATA_BYTES:
+        raise ValueError(
+            f"serialized metadata must not exceed {MAX_METADATA_BYTES} bytes"
+        )
+    return MappingProxyType(copied)
+
+
+@dataclass(frozen=True, slots=True)
+class StateToken:
+    """A generation within one independent state scope."""
+
+    scope_id: str
+    generation: int
+
+    def __post_init__(self) -> None:
+        _require_bounded_text(
+            self.scope_id,
+            "scope_id",
+            max_length=MAX_IDENTIFIER_LENGTH,
+        )
+        _require_non_negative_int(self.generation, "generation")
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadRef:
+    """Private payload reference plus immutable content identity."""
+
+    ref: str = field(repr=False)
+    sha256: str
+    size_bytes: int
+    media_type: str
+
+    def __post_init__(self) -> None:
+        _require_bounded_text(
+            self.ref,
+            "ref",
+            max_length=MAX_REFERENCE_LENGTH,
+        )
+        _require_sha256(self.sha256, "sha256")
+        _require_non_negative_int(self.size_bytes, "size_bytes")
+        if (
+            not isinstance(self.media_type, str)
+            or len(self.media_type) > MAX_MEDIA_TYPE_LENGTH
+            or not _MEDIA_TYPE_RE.fullmatch(self.media_type)
+        ):
+            raise ValueError("media_type must be a bounded lowercase MIME type")
+
+
+@dataclass(frozen=True, slots=True)
+class TaskEnvelope:
+    """Immutable task admitted to one bounded inference lane."""
+
+    task_id: str
+    task_kind: TaskKind
+    source_monotonic_ns: int
+    created_monotonic_ns: int
+    deadline_monotonic_ns: int
+    state_token: StateToken
+    payload: PayloadRef
+    parent_task_id: str | None = None
+    supersession_key: str | None = None
+    metadata: Mapping[str, MetadataScalar] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _require_bounded_text(
+            self.task_id,
+            "task_id",
+            max_length=MAX_IDENTIFIER_LENGTH,
+        )
+        if not isinstance(self.task_kind, TaskKind):
+            raise TypeError("task_kind must be a TaskKind")
+        source = _require_non_negative_int(
+            self.source_monotonic_ns,
+            "source_monotonic_ns",
+        )
+        created = _require_non_negative_int(
+            self.created_monotonic_ns,
+            "created_monotonic_ns",
+        )
+        deadline = _require_non_negative_int(
+            self.deadline_monotonic_ns,
+            "deadline_monotonic_ns",
+        )
+        if source > created:
+            raise ValueError("source_monotonic_ns must not be after creation")
+        if created > deadline:
+            raise ValueError("deadline_monotonic_ns must not be before creation")
+        if not isinstance(self.state_token, StateToken):
+            raise TypeError("state_token must be a StateToken")
+        if not isinstance(self.payload, PayloadRef):
+            raise TypeError("payload must be a PayloadRef")
+        _require_bounded_text(
+            self.parent_task_id,
+            "parent_task_id",
+            max_length=MAX_IDENTIFIER_LENGTH,
+            optional=True,
+        )
+        _require_bounded_text(
+            self.supersession_key,
+            "supersession_key",
+            max_length=MAX_IDENTIFIER_LENGTH,
+            optional=True,
+        )
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class CancellationReport:
+    """Separate local cancellation facts from backend-stop confirmation."""
+
+    requested: bool = False
+    client_wait_stopped: bool = False
+    worker_observed: bool = False
+    backend_stop_confirmed: bool | None = None
+
+    def __post_init__(self) -> None:
+        values = (
+            self.requested,
+            self.client_wait_stopped,
+            self.worker_observed,
+        )
+        if not all(isinstance(value, bool) for value in values):
+            raise TypeError("cancellation flags must be booleans")
+        if self.backend_stop_confirmed is not None and not isinstance(
+            self.backend_stop_confirmed, bool
+        ):
+            raise TypeError("backend_stop_confirmed must be bool or None")
+        if not self.requested and any(
+            (
+                self.client_wait_stopped,
+                self.worker_observed,
+                self.backend_stop_confirmed is not None,
+            )
+        ):
+            raise ValueError("cancellation effects require requested=True")
+
+
+@dataclass(frozen=True, slots=True)
+class ResultEnvelope:
+    """Privacy-preserving descriptor returned by a workload adapter."""
+
+    task_id: str
+    task_kind: TaskKind
+    state_token: StateToken
+    source_monotonic_ns: int
+    deadline_monotonic_ns: int
+    input_sha256: str
+    started_monotonic_ns: int
+    finished_monotonic_ns: int
+    execution_outcome: ExecutionOutcome
+    output_sha256: str | None = None
+    output_length: int | None = None
+    output_ref: str | None = field(default=None, repr=False)
+    error_code: str | None = None
+    cancellation_report: CancellationReport = field(default_factory=CancellationReport)
+
+    def __post_init__(self) -> None:
+        _require_bounded_text(
+            self.task_id,
+            "task_id",
+            max_length=MAX_IDENTIFIER_LENGTH,
+        )
+        if not isinstance(self.task_kind, TaskKind):
+            raise TypeError("task_kind must be a TaskKind")
+        if not isinstance(self.state_token, StateToken):
+            raise TypeError("state_token must be a StateToken")
+        source = _require_non_negative_int(
+            self.source_monotonic_ns,
+            "source_monotonic_ns",
+        )
+        deadline = _require_non_negative_int(
+            self.deadline_monotonic_ns,
+            "deadline_monotonic_ns",
+        )
+        started = _require_non_negative_int(
+            self.started_monotonic_ns,
+            "started_monotonic_ns",
+        )
+        finished = _require_non_negative_int(
+            self.finished_monotonic_ns,
+            "finished_monotonic_ns",
+        )
+        if source > started:
+            raise ValueError("source_monotonic_ns must not be after worker start")
+        if started > finished:
+            raise ValueError("finished_monotonic_ns must not be before worker start")
+        if source > deadline:
+            raise ValueError("deadline_monotonic_ns must not be before source")
+        _require_sha256(self.input_sha256, "input_sha256")
+        if not isinstance(self.execution_outcome, ExecutionOutcome):
+            raise TypeError("execution_outcome must be an ExecutionOutcome")
+
+        if (self.output_sha256 is None) != (self.output_length is None):
+            raise ValueError("output_sha256 and output_length must be present together")
+        if self.output_sha256 is not None:
+            _require_sha256(self.output_sha256, "output_sha256")
+            _require_non_negative_int(self.output_length, "output_length")
+        _require_bounded_text(
+            self.output_ref,
+            "output_ref",
+            max_length=MAX_REFERENCE_LENGTH,
+            optional=True,
+        )
+        if self.error_code is not None:
+            if (
+                not isinstance(self.error_code, str)
+                or len(self.error_code) > MAX_METADATA_KEY_LENGTH
+                or not _ERROR_CODE_RE.fullmatch(self.error_code)
+            ):
+                raise ValueError("error_code must be bounded lower_snake_case")
+        if (
+            self.execution_outcome
+            in {
+                ExecutionOutcome.ERROR,
+                ExecutionOutcome.TIMEOUT,
+            }
+            and self.error_code is None
+        ):
+            raise ValueError("error and timeout outcomes require error_code")
+        if not isinstance(self.cancellation_report, CancellationReport):
+            raise TypeError("cancellation_report must be a CancellationReport")
+        if (
+            self.execution_outcome is ExecutionOutcome.CANCEL_OBSERVED
+            and not self.cancellation_report.worker_observed
+        ):
+            raise ValueError(
+                "cancel_observed outcome requires worker_observed cancellation"
+            )
+
+
+class CancellationToken:
+    """Thread-safe cooperative cancellation signal owned by one task record."""
+
+    __slots__ = ("_event", "_lock", "_reason", "_requested_at_ns")
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._reason: str | None = None
+        self._requested_at_ns: int | None = None
+
+    def request(self, reason: str, requested_at_ns: int) -> bool:
+        """Request cancellation once and return whether this call changed it."""
+
+        checked_reason = _require_bounded_text(
+            reason,
+            "reason",
+            max_length=MAX_IDENTIFIER_LENGTH,
+        )
+        checked_time = _require_non_negative_int(
+            requested_at_ns,
+            "requested_at_ns",
+        )
+        assert checked_reason is not None
+        with self._lock:
+            if self._event.is_set():
+                return False
+            self._reason = checked_reason
+            self._requested_at_ns = checked_time
+            self._event.set()
+            return True
+
+    def is_requested(self) -> bool:
+        return self._event.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._event.wait(timeout)
+
+    @property
+    def reason(self) -> str | None:
+        with self._lock:
+            return self._reason
+
+    @property
+    def requested_at_ns(self) -> int | None:
+        with self._lock:
+            return self._requested_at_ns

--- a/jetson/phase1_runtime/policies.py
+++ b/jetson/phase1_runtime/policies.py
@@ -1,0 +1,56 @@
+"""Bounded-lane policies for the Phase 1 runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .model import TaskKind
+
+
+MAX_CAPACITY = 100_000
+
+
+class OverflowPolicy(str, Enum):
+    """How a lane handles a submission that cannot be appended directly."""
+
+    REJECT_NEW = "reject_new"
+    DROP_OLDEST = "drop_oldest"
+    COALESCE_BY_KEY = "coalesce_by_key"
+
+
+def _positive_capacity(value: object, field_name: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= MAX_CAPACITY
+    ):
+        raise ValueError(
+            f"{field_name} must be an integer between 1 and {MAX_CAPACITY}"
+        )
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class LaneConfig:
+    """All in-memory capacities required by one single-consumer lane."""
+
+    task_kind: TaskKind
+    pending_capacity: int
+    result_capacity: int = 1
+    terminal_record_capacity: int = 1024
+    state_scope_capacity: int = 64
+    overflow_policy: OverflowPolicy = OverflowPolicy.REJECT_NEW
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.task_kind, TaskKind):
+            raise TypeError("task_kind must be a TaskKind")
+        _positive_capacity(self.pending_capacity, "pending_capacity")
+        _positive_capacity(self.result_capacity, "result_capacity")
+        _positive_capacity(
+            self.terminal_record_capacity,
+            "terminal_record_capacity",
+        )
+        _positive_capacity(self.state_scope_capacity, "state_scope_capacity")
+        if not isinstance(self.overflow_policy, OverflowPolicy):
+            raise TypeError("overflow_policy must be an OverflowPolicy")


### PR DESCRIPTION
## Summary

- define immutable task, result, state, and payload-reference contracts for the Phase 1 asynchronous runtime
- implement bounded pending queues, result mailboxes, terminal retention, and state-scope tracking
- support reject-new, drop-oldest, and coalesce-by-key admission policies with consistent lifecycle accounting
- enforce scoped generation invalidation, queued/in-flight/result-pending cancellation, and two-stage freshness validation
- document the runtime contract, current implementation boundary, and planned research sequence

## Validation

- `python -m unittest -v experiments.phase0.test_telemetry experiments.phase0.test_runner_support experiments.phase0.test_formal_analysis experiments.phase1.tests.test_model experiments.phase1.tests.test_broker` (62 tests)
- Black, Pyflakes, `compileall`, and `git diff --check` passed
- bounded-capacity, concurrent-producer, cancellation, stale-result, shutdown, and clock-regression cases passed
- local Markdown links, UTF-8 encoding, and runtime import boundaries were checked

## Scope and safety

- host-only runtime kernel; worker threads, workload adapters, Jetson pilots, and formal Phase 1 data are not included
- no UART access, physical motion, or changes to Phase 0 experiment artifacts
- raw inputs, experiment outputs, models, and private research notes are not committed