### PR TITLE
feat(runtime): add observable executor and trace replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository began with my bachelor's thesis on speech interaction and visual perception for a wheeled robot. The thesis system runs fully local speech and vision pipelines on a Jetson Orin Nano, while an STM32F407 executes motion commands and enforces a communication watchdog. The same platform will now be used to study how long-running perception and inference can coexist with predictable control timing.
 
-> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 正从 host-only 运行时内核开始推进，尚未接入整机应用。
+> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立 host-only 有界运行时、可观测 worker 和周期探针，尚未接入 Jetson 模型或整机应用。
 
 ## Project status
 
@@ -15,7 +15,7 @@ This repository began with my bachelor's thesis on speech interaction and visual
 | Bachelor's thesis software and firmware | Complete and hardware validated |
 | Custom base-driver PCB | Published and tested on the physical robot |
 | Jetson–STM32 command link | Validated with ACK/error responses and a 1.2 s command watchdog |
-| Asynchronous inference runtime | Phase 1 host-only kernel under development; not yet integrated |
+| Asynchronous inference runtime | Host-only bounded executor, periodic probe and trace replay implemented; Jetson integration pending |
 
 The validated Jetson–STM32 code is preserved at [`v0.1.0-thesis-baseline`](https://github.com/yuzhang-robotics/embodied-robot-heterogeneous-control/tree/v0.1.0-thesis-baseline). The current `main` branch also includes the reviewed hardware documentation and editable PCB export.
 
@@ -61,10 +61,11 @@ The STM32 currently applies open-loop PWM commands. Encoder measurements are ava
 
 The current Jetson application is synchronous: wake-word detection, recording, ASR, dialogue or VLM inference, speech output and target tracking run as blocking stages. This is straightforward to reproduce, but inference latency can delay unrelated work and there is no explicit deadline or data-age policy.
 
-Phase 1 has started with an immutable task/result model, bounded task ownership,
-scoped state generations and host-only lifecycle tests. These components are
-not yet connected to the Jetson application or model services. The broader
-research stage will investigate:
+Phase 1 now has an immutable task/result model, bounded task ownership, scoped
+state generations, a single-worker observable executor, an absolute-schedule
+periodic probe and independent lifecycle trace replay. These components remain
+host-only and are not yet connected to the Jetson application or model
+services. The broader research stage will investigate:
 
 - independent acquisition, inference, planning and control workers;
 - timestamped bounded queues, cancellation and stale-result rejection;
@@ -86,7 +87,7 @@ These are research objectives, not claims about the current implementation. The 
 | [`docs/hardware/`](docs/hardware/) | Physical platform, wiring, pin assignments, power and safety notes |
 | [`docs/architecture/`](docs/architecture/) | Current timing model and the boundary of the planned asynchronous architecture |
 | [`experiments/phase0/`](experiments/phase0/) | Synchronous fixed-input measurement, validation and formal analysis tools |
-| [`experiments/phase1/`](experiments/phase1/) | Host tests and planned experiment tools for the asynchronous runtime study |
+| [`experiments/phase1/`](experiments/phase1/) | Host tests, Phase 1 trace schema, recorder and independent lifecycle replay |
 
 ## Reproducing the baseline
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -99,9 +99,9 @@ The first experiments will address these questions:
 The proposed task model, lifecycle invariants, queue policies, cancellation
 semantics, and Phase 1 safety Gates are specified in the
 [Phase 1 runtime contract](phase1-runtime-contract.md). That document is a
-design and correctness boundary. The initial host-only task model and bounded
-broker do not yet constitute a validated Jetson runtime or a performance
-result.
+design and correctness boundary. The host-only model, bounded broker,
+observable worker, periodic probe and lifecycle replay do not yet constitute a
+validated Jetson runtime or a performance result.
 
 ## Evaluation plan
 

--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -1,19 +1,20 @@
 # Phase 1 Runtime Contract
 
-This document defines the proposed correctness and safety contract for the
-first asynchronous runtime used by the Octopus robot research platform. It is
-a design specification, not a claim that the runtime has already been
-implemented or validated.
+This document defines the correctness and safety contract for the first
+asynchronous runtime used by the Octopus robot research platform. The
+host-only model, broker, observable executor, periodic probe and trace replay
+have been implemented. Jetson behavior and performance remain unvalidated.
 
 > 中文简介：本文冻结 Phase 1 异步运行时的任务模型、生命周期、队列、取消、结果新鲜度、
-> 快速周期代理和安全边界。当前状态仍是设计草案；实现、Jetson pilot 和正式实验将按 Gate
-> 逐步完成。
+> 快速周期代理和安全边界。host-only worker、周期探针和 trace replay 已实现；Jetson pilot、
+> 真实模型接入和正式实验仍需按 Gate 逐步完成。
 
 ## Status
 
-- Phase: Phase 1.1 host-only runtime kernel
-- Contract status: frozen for the first implementation milestone
-- Starting point: `main@043e1bb`
+- Phase: Phase 1.2 host-only observable executor
+- Contract status: frozen and implemented for the host-only boundary
+- Observable-executor starting point: `main@1d29b14`
+- Initial runtime-kernel starting point: `main@043e1bb`
 - Synchronous functional baseline: `61db058`
 - Physical motion: disabled and outside this phase
 - UART and STM32 firmware: unchanged
@@ -21,6 +22,18 @@ implemented or validated.
 The contract was reviewed before the host-only implementation began. Later
 implementation findings may require an explicit contract revision, but the
 contract must not be changed silently after formal data collection starts.
+
+The current host implementation includes:
+
+- immutable task, result, state and payload-reference contracts;
+- bounded pending, active, result-mailbox, state-scope and terminal ownership;
+- one non-daemon worker with cooperative cancellation and finite join reports;
+- a simulated adapter with finite service time and explicit cancellation facts;
+- an independent absolute-schedule periodic probe;
+- schema `0.2.0` JSONL recording and offline lifecycle replay.
+
+It does not include the Jetson simulation runner, real workload adapters,
+resource telemetry integration or formal performance data.
 
 ## Research objective
 
@@ -356,6 +369,30 @@ shutdown. Real HTTP adapters use finite transport and overall budgets so that
 failure is eventually observable, but Phase 1 does not claim instantaneous
 backend preemption.
 
+## Observable executor boundary
+
+`ObservableExecutor` is the only traced orchestration entry for one broker.
+Producers submit, cancel, advance state and consume results through this
+facade; the worker uses the same boundary for claim and completion. Callers
+must not mutate the owned broker directly while claiming a replayable trace.
+
+The short boundary lock covers one broker operation, its before/after depth
+accounting and synchronous event emission. It never covers workload adapter
+execution. This makes concurrent producer operations totally ordered in the
+trace without serializing the slow inference interval.
+
+The worker does not automatically consume a successful result. Consumption is
+an explicit upper-layer action so result-mailbox pressure and the second
+freshness check remain observable. Normal adapter exceptions become bounded
+`adapter_exception` execution results; exception messages and tracebacks are
+not written to events. An event-sink failure stops admission and requests
+cancel shutdown. A closed broker with a worker, probe or event-recording error
+is not reported as a successful run.
+
+The simulated adapter can model finite service time, execution errors,
+timeouts, cooperative cancellation and a finite non-cooperative interval. It
+does not model GPU work or prove backend preemption.
+
 ## Periodic probe contract
 
 The nominal period is 100 ms. Releases use an absolute schedule:
@@ -379,10 +416,20 @@ The experiment layer provides both:
 
 The probe is a software scheduling proxy, not a motor controller.
 
+The independent threaded probe and its pure release/tick calculations are now
+implemented. The inline condition belongs to the next simulation-runner
+milestone so that both paths can invoke the same scenario workload.
+
 ## Event and replay requirements
 
 Phase 1 creates a new event schema and run root. Phase 0 schema version `0.1.0`
 remains frozen.
+
+Schema `0.2.0` uses one shared recorder lock to assign contiguous
+sequence numbers and primary monotonic timestamps. Runtime and probe threads
+may share that recorder. Payload references, raw inputs, prompts, model output,
+secrets and exception tracebacks are excluded; only bounded scalar event
+details are accepted.
 
 Every lifecycle event includes enough bounded information to replay:
 
@@ -402,6 +449,23 @@ capacity violations, duplicate terminals, identity mismatches, missing final
 states, non-monotonic sequence/timestamps, or a consumed stale result.
 
 Runtime counters alone are not accepted as correctness evidence.
+
+The implemented lifecycle vocabulary is:
+
+- `task.enqueued`, `task.rejected`, `task.started`, `task.finished` and
+  `task.terminal`;
+- `task.cancel_requested`, `task.cancel_missing` and `state.advanced`;
+- `result.accepted` and `result.rejected`;
+- `shutdown.requested`, `worker.started`, `worker.failed`, `worker.stopped`
+  and `worker.joined`;
+- `probe.started`, `probe.skipped`, `probe.tick`, `probe.failed`,
+  `probe.stopped` and `probe.joined`.
+
+The replay implementation imports no runtime classes. It validates the
+serialized schema fields, reconstructs every task location and state
+generation, checks recorded depths against its own counts, enforces pending,
+active and result capacities, and rejects stale consumption or incomplete
+shutdown.
 
 ## Experimental decomposition
 

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -1,20 +1,23 @@
 # Phase 1 Asynchronous Runtime Research
 
-This directory contains the host tests and will contain the experiment harness,
-workload adapters, validation tools, and analysis for the Phase 1 asynchronous
-runtime study. The immutable task/result model and bounded broker are the first
-implementation milestone. Worker threads, Jetson pilots, and Phase 1
-performance results have not been completed yet.
+This directory contains the host tests, trace recorder, event schema and
+independent lifecycle replay for the Phase 1 asynchronous runtime study. The
+reusable package now includes a bounded single-worker executor, simulated
+adapter and periodic probe. Jetson pilots and Phase 1 performance results have
+not been completed yet.
 
-> 中文简介：本目录用于 Phase 1 异步运行时研究。当前已冻结首个运行时契约并实现
-> host-only 数据模型和有界 broker；尚未接入工作线程、Jetson 模型或 Phase 1 正式数据。
+> 中文简介：本目录用于 Phase 1 异步运行时研究。当前已实现 host-only 有界 broker、
+> 单 worker 执行层、100 ms 周期探针和独立 trace replay；尚未开展 Jetson pilot、
+> 真实模型接入或 Phase 1 正式数据采集。
 
 ## Current status
 
 - Phase 0 synchronous baseline: complete
-- Phase 1.0 runtime contract: frozen for the first implementation milestone
+- Phase 1 host runtime contract: frozen for the current host-only boundary
 - Host-only task/result model and bounded broker: implemented and tested
-- Worker and periodic probe: not implemented
+- Observable worker and simulated adapter: implemented and tested
+- Independent periodic probe: implemented and tested
+- Phase 1 schema `0.2.0`, JSONL recorder and lifecycle replay: implemented
 - Jetson simulation pilot: not started
 - Real VLM/ASR/LLM slices: not started
 - Formal Phase 1 data: not collected
@@ -28,15 +31,25 @@ Run the current host-only tests from the repository root:
 ```bash
 python3 -m unittest \
   experiments.phase1.tests.test_model \
-  experiments.phase1.tests.test_broker
+  experiments.phase1.tests.test_broker \
+  experiments.phase1.tests.test_executor \
+  experiments.phase1.tests.test_probe \
+  experiments.phase1.tests.test_trace
+```
+
+Replay a completed trace without importing the runtime implementation:
+
+```bash
+python3 -m experiments.phase1.replay_lifecycle /path/to/events.jsonl
 ```
 
 ## Planned implementation order
 
 1. freeze the task, result, lifecycle, queue, cancellation, and freshness
-   contract;
-2. implement and stress-test the host-only runtime kernel;
-3. add the periodic probe, Phase 1 event schema, and independent trace replay;
+   contract — complete;
+2. implement and stress-test the host-only runtime kernel — complete;
+3. add the observable worker, periodic probe, Phase 1 event schema, and
+   independent trace replay — complete;
 4. run safe simulated loads on the Jetson with `ROBOT_ENABLE_MOTION=0`;
 5. integrate the fixed-input VLM slice;
 6. extend the same adapter/runtime boundary to ASR and LLM;
@@ -63,26 +76,24 @@ Phase 1 automated tests and initial experiments:
 
 Any violation stops the experiment regardless of its performance result.
 
-## Planned code boundary
+## Code boundary
 
-The reusable, hardware-independent kernel will live under
-`jetson/phase1_runtime/`. Experiment-specific code will remain here:
+The reusable, hardware-independent kernel lives under
+`jetson/phase1_runtime/`. The current experiment-specific files are:
 
 ```text
 experiments/phase1/
-├── schemas/
-├── workloads/
+├── schemas/event.schema.json
 ├── tests/
-├── manifest.py
 ├── telemetry.py
-├── scenarios.py
-├── run_simulation.py
-├── run_workload.py
-├── validate_run.py
 ├── replay_lifecycle.py
-├── summarize_run.py
-└── analyze_formal_runs.py
+└── README.md
 ```
+
+Future simulation runners, workload adapters, manifests, validation,
+summaries and formal analysis remain experiment-layer work. The executor owns
+all traced broker mutations, while result consumption remains explicit so the
+result-mailbox capacity and second freshness check stay measurable.
 
 The kernel package must remain import-safe on a host without Jetson models,
 camera, microphone, serial device, or NVIDIA tools. Real workload dependencies
@@ -91,7 +102,8 @@ are imported lazily only by their explicit Jetson experiment adapters.
 ## Evidence standard
 
 Phase 1 correctness is not established by console output or runtime counters
-alone. A separate validator must replay the append-only event trace and prove:
+alone. `replay_lifecycle.py` reconstructs the append-only event trace without
+importing runtime classes and proves:
 
 - queue and result-mailbox bounds were respected;
 - each admitted task reached exactly one final disposition;

--- a/experiments/phase1/replay_lifecycle.py
+++ b/experiments/phase1/replay_lifecycle.py
@@ -1,0 +1,756 @@
+"""Independent replay of Phase 1 JSONL lifecycle traces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+SCHEMA_VERSION = "0.2.0"
+_LIVE_LOCATIONS = {"queued", "running", "result_pending"}
+_TERMINAL = "terminal"
+_DISPOSITIONS = {
+    "consumed",
+    "dropped_overflow",
+    "rejected_busy",
+    "cancelled_queued",
+    "rejected_cancelled",
+    "rejected_expired",
+    "rejected_state",
+    "rejected_identity",
+    "execution_error",
+    "result_backpressure",
+    "shutdown_cancelled",
+}
+_EVENT_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+_RUN_ID_RE = re.compile(
+    r"^[0-9]{8}T[0-9]{6}Z_phase1_[a-z][a-z0-9_]{0,31}_"
+    r"(?:simulated|vlm|asr|llm)_[0-9]{3}$"
+)
+_DETAIL_KEY_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_COMPONENTS = {"executor", "worker", "probe"}
+_TASK_KINDS = {"simulated", "vlm", "asr", "llm"}
+_OVERFLOW_POLICIES = {"reject_new", "drop_oldest", "coalesce_by_key"}
+_STATUSES = {
+    "started",
+    "ok",
+    "error",
+    "timeout",
+    "cancelled",
+    "dropped",
+    "stale",
+    "rejected",
+    "info",
+}
+_OPTIONAL_FIELDS = {
+    "task_id",
+    "task_kind",
+    "parent_task_id",
+    "source_monotonic_ns",
+    "deadline_monotonic_ns",
+    "state_scope_id",
+    "state_generation",
+}
+
+
+class ReplayError(ValueError):
+    """A trace cannot represent a legal bounded runtime history."""
+
+
+@dataclass(slots=True)
+class _ReplayTask:
+    admitted: bool
+    location: str
+    task_kind: str
+    source_ns: int
+    created_ns: int
+    deadline_ns: int
+    scope_id: str
+    generation: int
+    payload_sha256: str
+    started_ns: int | None = None
+    cancellation_requested: bool = False
+    disposition: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReplaySummary:
+    run_id: str
+    event_count: int
+    submission_attempts: int
+    admitted_total: int
+    terminal_admitted_total: int
+    accepted_result_count: int
+    stale_consumed_count: int
+    max_pending_depth: int
+    max_result_depth: int
+    probe_tick_count: int
+    probe_skipped_releases: int
+    probe_deadline_miss_count: int
+    disposition_counts: tuple[tuple[str, int], ...]
+    worker_joined: bool
+    final_broker_state: str | None
+
+
+def load_events(path: Path | str) -> list[dict[str, object]]:
+    """Load a non-empty JSONL trace without importing runtime code."""
+
+    events: list[dict[str, object]] = []
+    with Path(path).open("r", encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, start=1):
+            if not line.endswith("\n"):
+                raise ReplayError(f"line {line_number} is not newline terminated")
+            if not line.strip():
+                raise ReplayError(f"line {line_number} is blank")
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ReplayError(f"line {line_number} is not valid JSON") from exc
+            if not isinstance(item, dict):
+                raise ReplayError(f"line {line_number} must contain an object")
+            events.append(item)
+    if not events:
+        raise ReplayError("trace must contain at least one event")
+    return events
+
+
+def _require_int(
+    mapping: Mapping[str, object],
+    key: str,
+    *,
+    minimum: int = 0,
+) -> int:
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ReplayError(f"{key} must be an integer of at least {minimum}")
+    return value
+
+
+def _require_str(mapping: Mapping[str, object], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise ReplayError(f"{key} must be a non-empty string")
+    return value
+
+
+class _LifecycleReplay:
+    def __init__(self) -> None:
+        self.run_id: str | None = None
+        self.last_monotonic_ns = 0
+        self.tasks: dict[str, _ReplayTask] = {}
+        self.state_generations: dict[str, int] = {}
+        self.dispositions: Counter[str] = Counter()
+        self.submission_attempts = 0
+        self.admitted_total = 0
+        self.accepted_results = 0
+        self.max_pending = 0
+        self.max_result = 0
+        self.probe_ticks = 0
+        self.probe_misses = 0
+        self.last_probe_index: int | None = None
+        self.shutdown_seen = False
+        self.worker_stopped = False
+        self.worker_joined = False
+        self.final_broker_state: str | None = None
+        self.broker_state = "open"
+        self.worker_error = False
+        self.probe_started = False
+        self.probe_joined = False
+        self.probe_error = False
+        self.probe_period_ns: int | None = None
+        self.probe_deadline_ns: int | None = None
+        self.probe_previous_started_ns: int | None = None
+        self.probe_skipped_releases = 0
+
+    def _depths(self) -> tuple[int, int, int]:
+        pending = sum(task.location == "queued" for task in self.tasks.values())
+        active = sum(task.location == "running" for task in self.tasks.values())
+        result = sum(task.location == "result_pending" for task in self.tasks.values())
+        return pending, active, result
+
+    def _check_depths(self, details: Mapping[str, object]) -> None:
+        if "pending_depth" not in details:
+            return
+        observed = (
+            _require_int(details, "pending_depth"),
+            _require_int(details, "active_count"),
+            _require_int(details, "result_depth"),
+        )
+        expected = self._depths()
+        if observed != expected:
+            raise ReplayError(
+                f"recorded lifecycle depths {observed} do not match replay {expected}"
+            )
+        pending_capacity = _require_int(details, "pending_capacity", minimum=1)
+        result_capacity = _require_int(details, "result_capacity", minimum=1)
+        if _require_str(details, "overflow_policy") not in _OVERFLOW_POLICIES:
+            raise ReplayError("overflow policy is not supported")
+        if observed[0] > pending_capacity:
+            raise ReplayError("pending queue capacity was exceeded")
+        if observed[1] > 1:
+            raise ReplayError("single-worker active capacity was exceeded")
+        if observed[2] > result_capacity:
+            raise ReplayError("result mailbox capacity was exceeded")
+        self.max_pending = max(self.max_pending, observed[0])
+        self.max_result = max(self.max_result, observed[2])
+
+    def _identity_from_event(
+        self,
+        event: Mapping[str, object],
+        details: Mapping[str, object],
+    ) -> _ReplayTask:
+        task_kind = _require_str(event, "task_kind")
+        source = _require_int(event, "source_monotonic_ns")
+        created = _require_int(details, "created_monotonic_ns")
+        deadline = _require_int(event, "deadline_monotonic_ns")
+        scope_id = _require_str(event, "state_scope_id")
+        generation = _require_int(event, "state_generation")
+        payload_sha256 = _require_str(details, "payload_sha256")
+        if not source <= created <= deadline:
+            raise ReplayError("task source, creation, and deadline order is invalid")
+        if not _SHA256_RE.fullmatch(payload_sha256):
+            raise ReplayError("payload_sha256 must be lowercase SHA-256 hex")
+        return _ReplayTask(
+            admitted=event["event"] == "task.enqueued",
+            location="queued" if event["event"] == "task.enqueued" else _TERMINAL,
+            task_kind=task_kind,
+            source_ns=source,
+            created_ns=created,
+            deadline_ns=deadline,
+            scope_id=scope_id,
+            generation=generation,
+            payload_sha256=payload_sha256,
+        )
+
+    def _get_task(self, event: Mapping[str, object]) -> tuple[str, _ReplayTask]:
+        task_id = _require_str(event, "task_id")
+        task = self.tasks.get(task_id)
+        if task is None:
+            raise ReplayError(f"event references unknown task: {task_id}")
+        return task_id, task
+
+    def _transition(
+        self,
+        task: _ReplayTask,
+        details: Mapping[str, object],
+        *,
+        expected_previous: str | None = None,
+    ) -> str:
+        previous = _require_str(details, "previous_location")
+        next_location = _require_str(details, "next_location")
+        if previous != task.location:
+            raise ReplayError(
+                f"transition starts at {previous}, but task is at {task.location}"
+            )
+        if expected_previous is not None and previous != expected_previous:
+            raise ReplayError(f"transition must start at {expected_previous}")
+        if next_location not in _LIVE_LOCATIONS | {_TERMINAL}:
+            raise ReplayError(f"unknown next lifecycle location: {next_location}")
+        task.location = next_location
+        return next_location
+
+    @staticmethod
+    def _result_identity_matches(
+        task: _ReplayTask,
+        details: Mapping[str, object],
+    ) -> bool:
+        return all(
+            (
+                details.get("result_input_sha256") == task.payload_sha256,
+                details.get("result_task_kind") == task.task_kind,
+                details.get("result_source_monotonic_ns") == task.source_ns,
+                details.get("result_deadline_monotonic_ns") == task.deadline_ns,
+                details.get("result_state_scope_id") == task.scope_id,
+                details.get("result_state_generation") == task.generation,
+            )
+        )
+
+    def apply(self, event: Mapping[str, object], expected_seq: int) -> None:
+        required = {
+            "schema_version",
+            "run_id",
+            "seq",
+            "event",
+            "component",
+            "status",
+            "monotonic_ns",
+            "wall_time_ns",
+            "pid",
+            "thread_id",
+            "details",
+        }
+        missing = sorted(required - event.keys())
+        if missing:
+            raise ReplayError(f"event is missing fields: {', '.join(missing)}")
+        unknown = sorted(event.keys() - required - _OPTIONAL_FIELDS)
+        if unknown:
+            raise ReplayError(f"event has unknown fields: {', '.join(unknown)}")
+        if event.get("schema_version") != SCHEMA_VERSION:
+            raise ReplayError("trace schema version is not supported")
+        run_id = _require_str(event, "run_id")
+        if not _RUN_ID_RE.fullmatch(run_id):
+            raise ReplayError("trace run ID does not match the Phase 1 format")
+        if self.run_id is None:
+            self.run_id = run_id
+        elif run_id != self.run_id:
+            raise ReplayError("trace mixes run IDs")
+        if _require_int(event, "seq") != expected_seq:
+            raise ReplayError("event sequence must be contiguous from zero")
+        monotonic_ns = _require_int(event, "monotonic_ns")
+        if monotonic_ns < self.last_monotonic_ns:
+            raise ReplayError("primary event timestamps moved backwards")
+        self.last_monotonic_ns = monotonic_ns
+        event_name = _require_str(event, "event")
+        if not _EVENT_RE.fullmatch(event_name):
+            raise ReplayError("event name is not a dotted lower_snake_case name")
+        if _require_str(event, "component") not in _COMPONENTS:
+            raise ReplayError("event component is not supported")
+        if _require_str(event, "status") not in _STATUSES:
+            raise ReplayError("event status is not supported")
+        _require_int(event, "wall_time_ns")
+        _require_int(event, "pid", minimum=1)
+        thread_id = event.get("thread_id")
+        if isinstance(thread_id, bool) or not isinstance(thread_id, (int, str)):
+            raise ReplayError("thread_id must be an integer or string")
+        details_value = event.get("details")
+        if not isinstance(details_value, dict):
+            raise ReplayError("details must be an object")
+        details: Mapping[str, object] = details_value
+        if len(details) > 32:
+            raise ReplayError("details contains more than 32 fields")
+        for key, value in details.items():
+            if not isinstance(key, str) or not _DETAIL_KEY_RE.fullmatch(key):
+                raise ReplayError("detail keys must use lower_snake_case")
+            if not isinstance(value, (str, int, float, bool, type(None))):
+                raise ReplayError("detail values must be JSON scalars")
+            if isinstance(value, str) and not 1 <= len(value) <= 256:
+                raise ReplayError("detail strings must be bounded and non-empty")
+            if isinstance(value, float) and not math.isfinite(value):
+                raise ReplayError("detail floats must be finite")
+        encoded_details = json.dumps(
+            details,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if len(encoded_details) > 4096:
+            raise ReplayError("serialized details exceeds 4096 bytes")
+        for key in ("task_id", "parent_task_id", "state_scope_id"):
+            if key not in event:
+                continue
+            value = event[key]
+            if (
+                not isinstance(value, str)
+                or not 1 <= len(value) <= 128
+                or value != value.strip()
+                or not value.isprintable()
+            ):
+                raise ReplayError(f"{key} must be a bounded printable string")
+        if "task_kind" in event and event["task_kind"] not in _TASK_KINDS:
+            raise ReplayError("task_kind is not supported")
+        for key in (
+            "source_monotonic_ns",
+            "deadline_monotonic_ns",
+            "state_generation",
+        ):
+            if key in event:
+                _require_int(event, key)
+        if ("state_scope_id" in event) != ("state_generation" in event):
+            raise ReplayError("state scope and generation must be recorded together")
+
+        if event_name in {"task.enqueued", "task.rejected"}:
+            task_id = _require_str(event, "task_id")
+            if task_id in self.tasks:
+                raise ReplayError(f"duplicate task submission: {task_id}")
+            task = self._identity_from_event(event, details)
+            if task.created_ns > monotonic_ns:
+                raise ReplayError("task creation is later than its trace event")
+            if task.admitted and self.broker_state != "open":
+                raise ReplayError("task was admitted after shutdown began")
+            current_generation = self.state_generations.get(task.scope_id, 0)
+            if task.admitted and task.generation != current_generation:
+                raise ReplayError("admitted task used a non-current state generation")
+            if not task.admitted:
+                disposition = _require_str(details, "disposition")
+                if disposition not in _DISPOSITIONS:
+                    raise ReplayError("rejected task has an unknown disposition")
+                if disposition == "consumed":
+                    raise ReplayError("rejected task cannot use consumed disposition")
+                task.disposition = disposition
+                self.dispositions[disposition] += 1
+            self.tasks[task_id] = task
+            self.submission_attempts += 1
+            self.admitted_total += int(task.admitted)
+
+        elif event_name == "task.started":
+            _, task = self._get_task(event)
+            if self._depths()[1] != 0:
+                raise ReplayError("a task started while another task was active")
+            self._transition(task, details, expected_previous="queued")
+            started_ns = _require_int(details, "started_monotonic_ns")
+            if started_ns < task.created_ns:
+                raise ReplayError("worker start precedes task creation")
+            if started_ns > monotonic_ns:
+                raise ReplayError("worker start is later than its trace event")
+            task.started_ns = started_ns
+
+        elif event_name == "task.finished":
+            _, task = self._get_task(event)
+            next_location = self._transition(task, details, expected_previous="running")
+            started_ns = _require_int(details, "started_monotonic_ns")
+            finished_ns = _require_int(details, "finished_monotonic_ns")
+            if finished_ns < started_ns:
+                raise ReplayError("result finished before worker start")
+            if task.started_ns != started_ns:
+                raise ReplayError("result worker start does not match the claim")
+            if finished_ns > monotonic_ns:
+                raise ReplayError("result finish is later than its trace event")
+            identity_matches = self._result_identity_matches(task, details)
+            if next_location == "result_pending":
+                if not identity_matches:
+                    raise ReplayError("identity-mismatched result entered the mailbox")
+                if details.get("execution_outcome") != "ok":
+                    raise ReplayError("non-success result entered the mailbox")
+                if finished_ns > task.deadline_ns:
+                    raise ReplayError("expired result entered the mailbox")
+            elif next_location == _TERMINAL:
+                disposition = _require_str(details, "disposition")
+                if disposition not in _DISPOSITIONS:
+                    raise ReplayError("finished task has an unknown disposition")
+                if disposition == "consumed":
+                    raise ReplayError("worker completion cannot consume a result")
+                transition_ns = _require_int(details, "transition_monotonic_ns")
+                if transition_ns > monotonic_ns:
+                    raise ReplayError("task transition is later than its trace event")
+                if not identity_matches and disposition != "rejected_identity":
+                    raise ReplayError("result identity mismatch was misclassified")
+                task.disposition = disposition
+                self.dispositions[disposition] += 1
+            else:
+                raise ReplayError("finished task must enter result_pending or terminal")
+
+        elif event_name in {"result.accepted", "result.rejected"}:
+            _, task = self._get_task(event)
+            self._transition(task, details, expected_previous="result_pending")
+            if task.location != _TERMINAL:
+                raise ReplayError("result decision must be terminal")
+            disposition = _require_str(details, "disposition")
+            if disposition not in _DISPOSITIONS:
+                raise ReplayError("result decision has an unknown disposition")
+            if not self._result_identity_matches(task, details):
+                raise ReplayError("result decision contains mismatched identity")
+            task.disposition = disposition
+            self.dispositions[disposition] += 1
+            if event_name == "result.accepted":
+                if disposition != "consumed":
+                    raise ReplayError("accepted result must use consumed disposition")
+                transition_ns = _require_int(details, "transition_monotonic_ns")
+                if transition_ns > monotonic_ns:
+                    raise ReplayError("result transition is later than its trace event")
+                current_generation = self.state_generations.get(task.scope_id, 0)
+                if (
+                    task.cancellation_requested
+                    or task.generation != current_generation
+                    or transition_ns > task.deadline_ns
+                ):
+                    raise ReplayError("a stale or cancelled result was consumed")
+                self.accepted_results += 1
+            elif disposition == "consumed":
+                raise ReplayError("rejected result cannot use consumed disposition")
+
+        elif event_name == "task.terminal":
+            _, task = self._get_task(event)
+            self._transition(task, details)
+            if task.location != _TERMINAL:
+                raise ReplayError("task.terminal must enter terminal state")
+            disposition = _require_str(details, "disposition")
+            if disposition not in _DISPOSITIONS:
+                raise ReplayError("terminal event has an unknown disposition")
+            if disposition == "consumed":
+                raise ReplayError("task.terminal cannot consume a result")
+            if task.disposition is not None:
+                raise ReplayError("task received duplicate final dispositions")
+            transition_ns = _require_int(details, "transition_monotonic_ns")
+            if transition_ns > monotonic_ns:
+                raise ReplayError("task transition is later than its trace event")
+            task.disposition = disposition
+            self.dispositions[disposition] += 1
+
+        elif event_name == "task.cancel_requested":
+            _, task = self._get_task(event)
+            if details.get("found") is not True:
+                raise ReplayError("cancel_requested event must refer to a found task")
+            if details.get("request_changed") is True:
+                task.cancellation_requested = True
+
+        elif event_name == "task.cancel_missing":
+            if details.get("found") is not False:
+                raise ReplayError("cancel_missing event must report found=false")
+
+        elif event_name == "state.advanced":
+            scope_id = _require_str(details, "state_scope_id")
+            previous = _require_int(details, "previous_generation")
+            generation = _require_int(details, "state_generation")
+            current = self.state_generations.get(scope_id, 0)
+            if previous != current or generation != previous + 1:
+                raise ReplayError("state generation did not advance by exactly one")
+            self.state_generations[scope_id] = generation
+            if details.get("active_cancellation_requested") is True:
+                for task in self.tasks.values():
+                    if task.location == "running" and task.scope_id == scope_id:
+                        task.cancellation_requested = True
+
+        elif event_name == "shutdown.requested":
+            self.shutdown_seen = True
+            self.final_broker_state = _require_str(details, "broker_state")
+            self.broker_state = self.final_broker_state
+            if details.get("cancel_live") is True:
+                for task in self.tasks.values():
+                    if task.location in _LIVE_LOCATIONS:
+                        task.cancellation_requested = True
+
+        elif event_name == "worker.stopped":
+            self.worker_stopped = True
+            if event.get("status") == "error":
+                self.worker_error = True
+
+        elif event_name == "worker.failed":
+            self.worker_error = True
+
+        elif event_name == "worker.joined":
+            if details.get("joined") is True:
+                self.worker_joined = True
+            self.final_broker_state = _require_str(details, "broker_state")
+            self.broker_state = self.final_broker_state
+            if (
+                details.get("worker_error_code") is not None
+                or details.get("event_error_code") is not None
+            ):
+                self.worker_error = True
+
+        elif event_name == "probe.started":
+            if self.probe_started:
+                raise ReplayError("probe.started appeared more than once")
+            _require_int(details, "origin_monotonic_ns")
+            self.probe_period_ns = _require_int(details, "period_ns", minimum=1)
+            self.probe_deadline_ns = _require_int(details, "deadline_ns", minimum=1)
+            self.probe_started = True
+
+        elif event_name == "probe.skipped":
+            if not self.probe_started:
+                raise ReplayError("probe.skipped appeared before probe.started")
+            from_index = _require_int(details, "from_index")
+            to_index = _require_int(details, "to_index")
+            skipped = _require_int(details, "skipped_releases", minimum=1)
+            if to_index - from_index != skipped:
+                raise ReplayError("probe skipped-release count is inconsistent")
+            self.probe_skipped_releases += skipped
+
+        elif event_name == "probe.stopped":
+            if _require_int(details, "tick_count") != self.probe_ticks:
+                raise ReplayError("probe stopped with an inconsistent tick count")
+            if _require_int(details, "skipped_releases") != self.probe_skipped_releases:
+                raise ReplayError("probe stopped with an inconsistent skip count")
+            if _require_int(details, "deadline_miss_count") != self.probe_misses:
+                raise ReplayError("probe stopped with an inconsistent miss count")
+
+        elif event_name == "probe.joined":
+            if details.get("joined") is True:
+                self.probe_joined = True
+            if details.get("error_code") is not None:
+                self.probe_error = True
+            if _require_int(details, "tick_count") != self.probe_ticks:
+                raise ReplayError("probe joined with an inconsistent tick count")
+            if _require_int(details, "skipped_releases") != self.probe_skipped_releases:
+                raise ReplayError("probe joined with an inconsistent skip count")
+            if _require_int(details, "deadline_miss_count") != self.probe_misses:
+                raise ReplayError("probe joined with an inconsistent miss count")
+
+        elif event_name == "probe.failed":
+            self.probe_error = True
+
+        elif event_name == "probe.tick":
+            if not self.probe_started:
+                raise ReplayError("probe tick appeared before probe.started")
+            assert self.probe_period_ns is not None
+            assert self.probe_deadline_ns is not None
+            index = _require_int(details, "tick_index")
+            scheduled = _require_int(details, "scheduled_monotonic_ns")
+            started = _require_int(details, "started_monotonic_ns")
+            finished = _require_int(details, "finished_monotonic_ns")
+            if not scheduled <= started <= finished:
+                raise ReplayError("probe tick timestamps are not ordered")
+            if details.get("start_lateness_ns") != started - scheduled:
+                raise ReplayError("probe start lateness is inconsistent")
+            if details.get("execution_ns") != finished - started:
+                raise ReplayError("probe execution duration is inconsistent")
+            actual_period = (
+                None
+                if self.probe_previous_started_ns is None
+                else started - self.probe_previous_started_ns
+            )
+            if details.get("actual_period_ns") != actual_period:
+                raise ReplayError("probe actual period is inconsistent")
+            signed_error = (
+                None if actual_period is None else actual_period - self.probe_period_ns
+            )
+            if details.get("signed_period_error_ns") != signed_error:
+                raise ReplayError("probe signed period error is inconsistent")
+            absolute_error = None if signed_error is None else abs(signed_error)
+            if details.get("absolute_period_error_ns") != absolute_error:
+                raise ReplayError("probe absolute period error is inconsistent")
+            if self.last_probe_index is not None and index <= self.last_probe_index:
+                raise ReplayError("probe tick indices must increase")
+            self.last_probe_index = index
+            deadline_miss = details.get("deadline_miss")
+            if not isinstance(deadline_miss, bool):
+                raise ReplayError("probe deadline_miss must be a boolean")
+            expected_miss = finished > scheduled + self.probe_deadline_ns
+            if deadline_miss != expected_miss:
+                raise ReplayError("probe deadline miss is inconsistent")
+            self.probe_ticks += 1
+            self.probe_misses += int(deadline_miss)
+            self.probe_previous_started_ns = started
+
+        known_non_lifecycle = {"worker.started"}
+        if (
+            event_name
+            not in {
+                "task.enqueued",
+                "task.rejected",
+                "task.started",
+                "task.finished",
+                "result.accepted",
+                "result.rejected",
+                "task.terminal",
+                "task.cancel_requested",
+                "task.cancel_missing",
+                "state.advanced",
+                "shutdown.requested",
+                "worker.failed",
+                "worker.stopped",
+                "worker.joined",
+                "probe.started",
+                "probe.skipped",
+                "probe.stopped",
+                "probe.failed",
+                "probe.joined",
+                "probe.tick",
+            }
+            | known_non_lifecycle
+        ):
+            raise ReplayError(f"unknown Phase 1 event: {event_name}")
+
+        self._check_depths(details)
+
+    def finish(self, event_count: int, *, require_complete: bool) -> ReplaySummary:
+        terminal_admitted = sum(
+            task.admitted and task.location == _TERMINAL for task in self.tasks.values()
+        )
+        terminal_tasks = [
+            task for task in self.tasks.values() if task.location == _TERMINAL
+        ]
+        if any(task.disposition is None for task in terminal_tasks):
+            raise ReplayError("terminal task is missing a final disposition")
+        if sum(self.dispositions.values()) != len(terminal_tasks):
+            raise ReplayError("final disposition accounting does not close")
+        if require_complete:
+            if not self.shutdown_seen:
+                raise ReplayError("complete trace is missing shutdown.requested")
+            if not self.worker_stopped or not self.worker_joined:
+                raise ReplayError("complete trace is missing a successful worker join")
+            live = [
+                task_id
+                for task_id, task in self.tasks.items()
+                if task.admitted and task.location != _TERMINAL
+            ]
+            if live:
+                raise ReplayError(f"complete trace retains live tasks: {live}")
+            if self.final_broker_state != "closed":
+                raise ReplayError("complete trace did not close the broker")
+            if self.worker_error:
+                raise ReplayError("complete trace contains a runtime worker error")
+            if self.probe_started and not self.probe_joined:
+                raise ReplayError("complete trace is missing a successful probe join")
+            if self.probe_error:
+                raise ReplayError("complete trace contains a periodic probe error")
+        assert self.run_id is not None
+        return ReplaySummary(
+            run_id=self.run_id,
+            event_count=event_count,
+            submission_attempts=self.submission_attempts,
+            admitted_total=self.admitted_total,
+            terminal_admitted_total=terminal_admitted,
+            accepted_result_count=self.accepted_results,
+            stale_consumed_count=0,
+            max_pending_depth=self.max_pending,
+            max_result_depth=self.max_result,
+            probe_tick_count=self.probe_ticks,
+            probe_skipped_releases=self.probe_skipped_releases,
+            probe_deadline_miss_count=self.probe_misses,
+            disposition_counts=tuple(sorted(self.dispositions.items())),
+            worker_joined=self.worker_joined,
+            final_broker_state=self.final_broker_state,
+        )
+
+
+def replay_events(
+    events: Iterable[Mapping[str, object]],
+    *,
+    require_complete: bool = True,
+) -> ReplaySummary:
+    """Reconstruct one trace using only serialized public event fields."""
+
+    replay = _LifecycleReplay()
+    count = 0
+    for count, event in enumerate(events, start=1):
+        if not isinstance(event, Mapping):
+            raise ReplayError("each trace item must be a mapping")
+        replay.apply(event, count - 1)
+    if count == 0:
+        raise ReplayError("trace must contain at least one event")
+    return replay.finish(count, require_complete=require_complete)
+
+
+def replay_file(
+    path: Path | str,
+    *,
+    require_complete: bool = True,
+) -> ReplaySummary:
+    return replay_events(load_events(path), require_complete=require_complete)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Replay and validate one Phase 1 lifecycle trace."
+    )
+    parser.add_argument("events", type=Path, help="path to events.jsonl")
+    parser.add_argument(
+        "--allow-incomplete",
+        action="store_true",
+        help="validate the recorded prefix without requiring closed shutdown",
+    )
+    args = parser.parse_args(argv)
+    try:
+        summary = replay_file(
+            args.events,
+            require_complete=not args.allow_incomplete,
+        )
+    except (OSError, ReplayError) as exc:
+        print(f"INVALID: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(asdict(summary), ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/phase1/schemas/event.schema.json
+++ b/experiments/phase1/schemas/event.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/embodied-robot/phase1-event.schema.json",
+  "title": "Phase 1 Asynchronous Runtime Trace Event",
+  "description": "One bounded UTF-8 JSON object per line. Primary ordering uses seq and monotonic_ns; workload durations use the explicit monotonic timestamps in details.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "seq",
+    "event",
+    "component",
+    "status",
+    "monotonic_ns",
+    "wall_time_ns",
+    "pid",
+    "thread_id",
+    "details"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.2.0"
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[0-9]{8}T[0-9]{6}Z_phase1_[a-z][a-z0-9_]{0,31}_(simulated|vlm|asr|llm)_[0-9]{3}$"
+    },
+    "seq": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "event": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$"
+    },
+    "component": {
+      "enum": ["executor", "worker", "probe"]
+    },
+    "status": {
+      "enum": [
+        "started",
+        "ok",
+        "error",
+        "timeout",
+        "cancelled",
+        "dropped",
+        "stale",
+        "rejected",
+        "info"
+      ]
+    },
+    "monotonic_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "wall_time_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pid": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "thread_id": {
+      "type": ["integer", "string"]
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "task_kind": {
+      "enum": ["simulated", "vlm", "asr", "llm"]
+    },
+    "parent_task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "source_monotonic_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "deadline_monotonic_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "state_scope_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "state_generation": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "details": {
+      "type": "object",
+      "maxProperties": 32,
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "description": "Bounded scalar metadata only. Raw payloads, paths, prompts, model outputs, secrets, and tracebacks are forbidden."
+    }
+  }
+}

--- a/experiments/phase1/telemetry.py
+++ b/experiments/phase1/telemetry.py
@@ -1,0 +1,118 @@
+"""UTF-8 JSONL recording for Phase 1 runtime and probe observations."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+from pathlib import Path
+from typing import TextIO
+
+from jetson.phase1_runtime.events import RuntimeEvent
+
+
+SCHEMA_VERSION = "0.2.0"
+
+_RUN_ID_RE = re.compile(
+    r"^[0-9]{8}T[0-9]{6}Z_phase1_[a-z][a-z0-9_]{0,31}_"
+    r"(?:simulated|vlm|asr|llm)_[0-9]{3}$"
+)
+
+
+class EventRecorder:
+    """Append ordered Phase 1 observations to one buffered trace file."""
+
+    def __init__(self, run_dir: Path | str, run_id: str) -> None:
+        if not isinstance(run_id, str) or not _RUN_ID_RE.fullmatch(run_id):
+            raise ValueError(f"invalid Phase 1 run_id: {run_id!r}")
+        self.run_dir = Path(run_dir)
+        self.run_id = run_id
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.path = self.run_dir / "events.jsonl"
+        if self.path.exists():
+            raise FileExistsError(f"refusing to overwrite trace: {self.path}")
+        self._stream: TextIO = self.path.open(
+            "w", encoding="utf-8", buffering=64 * 1024, newline="\n"
+        )
+        self._sequence = 0
+        self._last_monotonic_ns = 0
+        self._closed = False
+        self._lock = threading.Lock()
+
+    def emit(self, event: RuntimeEvent) -> None:
+        """Record one event with sequence and correlation timestamps."""
+
+        if not isinstance(event, RuntimeEvent):
+            raise TypeError("event must be a RuntimeEvent")
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("event recorder is closed")
+            monotonic_ns = time.monotonic_ns()
+            if monotonic_ns < self._last_monotonic_ns:
+                raise RuntimeError("event recorder monotonic time moved backwards")
+
+            item: dict[str, object] = {
+                "schema_version": SCHEMA_VERSION,
+                "run_id": self.run_id,
+                "seq": self._sequence,
+                "event": event.event,
+                "component": event.component,
+                "status": event.status.value,
+                "monotonic_ns": monotonic_ns,
+                "wall_time_ns": time.time_ns(),
+                "pid": os.getpid(),
+                "thread_id": threading.get_ident(),
+                "details": dict(event.details),
+            }
+            optional: dict[str, object | None] = {
+                "task_id": event.task_id,
+                "task_kind": (
+                    event.task_kind.value if event.task_kind is not None else None
+                ),
+                "parent_task_id": event.parent_task_id,
+                "source_monotonic_ns": event.source_monotonic_ns,
+                "deadline_monotonic_ns": event.deadline_monotonic_ns,
+                "state_scope_id": (
+                    event.state_token.scope_id
+                    if event.state_token is not None
+                    else None
+                ),
+                "state_generation": (
+                    event.state_token.generation
+                    if event.state_token is not None
+                    else None
+                ),
+            }
+            item.update(
+                {key: value for key, value in optional.items() if value is not None}
+            )
+            line = json.dumps(
+                item,
+                ensure_ascii=False,
+                allow_nan=False,
+                separators=(",", ":"),
+            )
+            self._stream.write(line + "\n")
+            self._sequence += 1
+            self._last_monotonic_ns = monotonic_ns
+
+    def flush(self) -> None:
+        with self._lock:
+            if not self._closed:
+                self._stream.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._stream.flush()
+            self._stream.close()
+            self._closed = True
+
+    def __enter__(self) -> "EventRecorder":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()

--- a/experiments/phase1/tests/test_executor.py
+++ b/experiments/phase1/tests/test_executor.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+
+from jetson.phase1_runtime import (
+    BoundedTaskBroker,
+    ClaimedTask,
+    ExecutionOutcome,
+    FinalDisposition,
+    LaneConfig,
+    ObservableExecutor,
+    OverflowPolicy,
+    PayloadRef,
+    ResultEnvelope,
+    RuntimeEvent,
+    SimulatedAdapter,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+)
+
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self._events: list[RuntimeEvent] = []
+        self._lock = threading.Lock()
+
+    def emit(self, event: RuntimeEvent) -> None:
+        with self._lock:
+            self._events.append(event)
+
+    def snapshot(self) -> tuple[RuntimeEvent, ...]:
+        with self._lock:
+            return tuple(self._events)
+
+
+class FailOnEventSink(RecordingSink):
+    def __init__(self, event_name: str) -> None:
+        super().__init__()
+        self._event_name = event_name
+
+    def emit(self, event: RuntimeEvent) -> None:
+        with self._lock:
+            if event.event == self._event_name:
+                raise OSError("simulated recorder failure")
+            self._events.append(event)
+
+
+def make_task(
+    task_id: str,
+    *,
+    state_token: StateToken | None = None,
+    lifetime_s: float = 2.0,
+) -> TaskEnvelope:
+    now = time.monotonic_ns()
+    return TaskEnvelope(
+        task_id=task_id,
+        task_kind=TaskKind.SIMULATED,
+        source_monotonic_ns=now,
+        created_monotonic_ns=now,
+        deadline_monotonic_ns=now + int(lifetime_s * 1_000_000_000),
+        state_token=state_token or StateToken("test", 0),
+        payload=PayloadRef(
+            ref=f"private/{task_id}.bin",
+            sha256=SHA_A,
+            size_bytes=1,
+            media_type="application/octet-stream",
+        ),
+    )
+
+
+def make_executor(
+    adapter,
+    *,
+    sink: RecordingSink | None = None,
+    pending_capacity: int = 4,
+    result_capacity: int = 4,
+) -> ObservableExecutor:
+    broker = BoundedTaskBroker(
+        LaneConfig(
+            task_kind=TaskKind.SIMULATED,
+            pending_capacity=pending_capacity,
+            result_capacity=result_capacity,
+            terminal_record_capacity=128,
+            overflow_policy=OverflowPolicy.REJECT_NEW,
+        )
+    )
+    return ObservableExecutor(broker, adapter, event_sink=sink)
+
+
+class ExecutorTests(unittest.TestCase):
+    def wait_for(self, predicate, *, timeout_s: float = 1.0) -> None:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            threading.Event().wait(0.001)
+        self.fail("condition did not become true before timeout")
+
+    def stop_if_alive(self, executor: ObservableExecutor) -> None:
+        if executor.is_alive:
+            executor.shutdown(cancel_live=True, join_timeout_s=1.0)
+
+    def test_valid_result_is_explicitly_consumed_and_worker_joins(self) -> None:
+        sink = RecordingSink()
+        executor = make_executor(SimulatedAdapter(0), sink=sink)
+        executor.start()
+        self.addCleanup(self.stop_if_alive, executor)
+
+        submission = executor.submit(make_task("valid"))
+        self.assertTrue(submission.admitted)
+        self.wait_for(lambda: executor.snapshot().result_pending == 1)
+
+        consumption = executor.consume_next()
+        self.assertIsNotNone(consumption)
+        assert consumption is not None
+        self.assertTrue(consumption.consumed)
+        self.assertEqual(consumption.disposition, FinalDisposition.CONSUMED)
+
+        report = executor.shutdown(cancel_live=False, join_timeout_s=1.0)
+        self.assertTrue(report.complete)
+        self.assertIsNone(report.worker_error_code)
+        self.assertTrue(executor.snapshot().accounting_holds)
+        names = [event.event for event in sink.snapshot()]
+        for expected in (
+            "worker.started",
+            "task.enqueued",
+            "task.started",
+            "task.finished",
+            "result.accepted",
+            "shutdown.requested",
+            "worker.stopped",
+            "worker.joined",
+        ):
+            self.assertIn(expected, names)
+
+    def test_running_cancellation_is_observed_without_backend_overclaim(self) -> None:
+        executor = make_executor(
+            SimulatedAdapter(1.0, poll_interval_s=0.001),
+            result_capacity=1,
+        )
+        executor.start()
+        self.addCleanup(self.stop_if_alive, executor)
+        executor.submit(make_task("cancel-running"))
+        self.wait_for(lambda: executor.snapshot().running == 1)
+
+        cancellation = executor.cancel("cancel-running", reason="superseded")
+        self.assertTrue(cancellation.request_changed)
+        self.wait_for(lambda: executor.snapshot().live == 0)
+
+        snapshot = executor.snapshot()
+        counts = dict(snapshot.disposition_counts)
+        self.assertEqual(counts[FinalDisposition.REJECTED_CANCELLED], 1)
+        report = executor.shutdown(cancel_live=False, join_timeout_s=1.0)
+        self.assertTrue(report.complete)
+
+    def test_adapter_exception_becomes_execution_error_and_worker_survives(
+        self,
+    ) -> None:
+        def failing_adapter(claimed: ClaimedTask) -> ResultEnvelope:
+            raise RuntimeError("private failure details must not escape")
+
+        sink = RecordingSink()
+        executor = make_executor(failing_adapter, sink=sink)
+        executor.start()
+        self.addCleanup(self.stop_if_alive, executor)
+
+        executor.submit(make_task("failure-one"))
+        self.wait_for(lambda: executor.snapshot().terminal_admitted_total == 1)
+        executor.submit(make_task("failure-two"))
+        self.wait_for(lambda: executor.snapshot().terminal_admitted_total == 2)
+
+        snapshot = executor.snapshot()
+        self.assertEqual(
+            dict(snapshot.disposition_counts)[FinalDisposition.EXECUTION_ERROR],
+            2,
+        )
+        self.assertTrue(executor.is_alive)
+        self.assertIsNone(executor.worker_error_code)
+        serialized_details = " ".join(
+            str(dict(event.details)) for event in sink.snapshot()
+        )
+        self.assertNotIn("private failure", serialized_details)
+        self.assertTrue(
+            executor.shutdown(cancel_live=False, join_timeout_s=1.0).complete
+        )
+
+    def test_identity_mismatch_is_terminal_and_never_enters_mailbox(self) -> None:
+        def mismatched_adapter(claimed: ClaimedTask) -> ResultEnvelope:
+            task = claimed.task
+            now = time.monotonic_ns()
+            return ResultEnvelope(
+                task_id=task.task_id,
+                task_kind=task.task_kind,
+                state_token=task.state_token,
+                source_monotonic_ns=task.source_monotonic_ns,
+                deadline_monotonic_ns=task.deadline_monotonic_ns,
+                input_sha256=SHA_B,
+                started_monotonic_ns=claimed.started_monotonic_ns,
+                finished_monotonic_ns=max(claimed.started_monotonic_ns, now),
+                execution_outcome=ExecutionOutcome.OK,
+                output_sha256=SHA_A,
+                output_length=1,
+            )
+
+        executor = make_executor(mismatched_adapter)
+        executor.start()
+        self.addCleanup(self.stop_if_alive, executor)
+        executor.submit(make_task("mismatch"))
+        self.wait_for(lambda: executor.snapshot().terminal_admitted_total == 1)
+
+        snapshot = executor.snapshot()
+        self.assertEqual(snapshot.result_pending, 0)
+        self.assertEqual(
+            dict(snapshot.disposition_counts)[FinalDisposition.REJECTED_IDENTITY],
+            1,
+        )
+        self.assertTrue(
+            executor.shutdown(cancel_live=False, join_timeout_s=1.0).complete
+        )
+
+    def test_shutdown_timeout_reports_live_noncooperative_adapter(self) -> None:
+        executor = make_executor(
+            SimulatedAdapter(
+                0.05,
+                observe_cancellation=False,
+                poll_interval_s=0.001,
+            )
+        )
+        executor.start()
+        self.addCleanup(self.stop_if_alive, executor)
+        executor.submit(make_task("slow-stop"))
+        self.wait_for(lambda: executor.snapshot().running == 1)
+
+        first = executor.shutdown(cancel_live=True, join_timeout_s=0)
+        self.assertFalse(first.joined)
+        self.assertEqual(first.active_id, "slow-stop")
+        second = executor.shutdown(cancel_live=True, join_timeout_s=1.0)
+        self.assertTrue(second.complete)
+        self.assertIsNone(second.active_id)
+
+    def test_concurrent_submissions_preserve_replayable_depth_sequence(self) -> None:
+        sink = RecordingSink()
+        executor = make_executor(
+            SimulatedAdapter(0),
+            sink=sink,
+            pending_capacity=8,
+            result_capacity=8,
+        )
+        executor.start()
+        self.addCleanup(self.stop_if_alive, executor)
+
+        barrier = threading.Barrier(17)
+        threads = []
+
+        def submit_one(value: int) -> None:
+            barrier.wait()
+            executor.submit(make_task(f"concurrent-{value}"))
+
+        for index in range(16):
+            thread = threading.Thread(
+                target=submit_one,
+                args=(index,),
+            )
+            threads.append(thread)
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=1.0)
+            self.assertFalse(thread.is_alive())
+
+        executor.shutdown(cancel_live=True, join_timeout_s=1.0)
+        snapshot = executor.snapshot()
+        self.assertEqual(snapshot.live, 0)
+        self.assertTrue(snapshot.accounting_holds)
+        for event in sink.snapshot():
+            details = event.details
+            if "pending_depth" in details:
+                self.assertLessEqual(
+                    details["pending_depth"],
+                    details["pending_capacity"],
+                )
+                self.assertLessEqual(
+                    details["result_depth"],
+                    details["result_capacity"],
+                )
+
+    def test_event_sink_failure_stops_admission_and_is_not_success(self) -> None:
+        sink = FailOnEventSink("task.enqueued")
+        executor = make_executor(SimulatedAdapter(0), sink=sink)
+        executor.start()
+        self.addCleanup(self.stop_if_alive, executor)
+
+        with self.assertRaisesRegex(RuntimeError, "event sink failed"):
+            executor.submit(make_task("recorder-failure"))
+        report = executor.shutdown(cancel_live=True, join_timeout_s=1.0)
+
+        self.assertTrue(report.joined)
+        self.assertEqual(report.broker_state.value, "closed")
+        self.assertFalse(report.complete)
+        self.assertEqual(report.event_error_code, "event_sink_oserror")
+        self.assertEqual(executor.snapshot().live, 0)
+
+    def test_state_advance_invalidates_running_result_in_observable_path(self) -> None:
+        gate = threading.Event()
+        base_adapter = SimulatedAdapter(0)
+
+        def gated_adapter(claimed: ClaimedTask) -> ResultEnvelope:
+            if not gate.wait(timeout=1.0):
+                raise TimeoutError("test gate did not open")
+            return base_adapter(claimed)
+
+        sink = RecordingSink()
+        executor = make_executor(gated_adapter, sink=sink)
+        executor.start()
+        self.addCleanup(self.stop_if_alive, executor)
+        executor.submit(make_task("old-generation"))
+        self.wait_for(lambda: executor.snapshot().running == 1)
+
+        advanced = executor.advance_state("test", reason="new_supervisor_state")
+        self.assertEqual(advanced.state_token.generation, 1)
+        self.assertTrue(advanced.active_cancellation_requested)
+        gate.set()
+        self.wait_for(lambda: executor.snapshot().live == 0)
+
+        counts = dict(executor.snapshot().disposition_counts)
+        self.assertEqual(counts[FinalDisposition.REJECTED_STATE], 1)
+        self.assertTrue(
+            executor.shutdown(cancel_live=False, join_timeout_s=1.0).complete
+        )
+        names = [event.event for event in sink.snapshot()]
+        self.assertIn("state.advanced", names)
+        self.assertIn("task.finished", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_probe.py
+++ b/experiments/phase1/tests/test_probe.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+
+from jetson.phase1_runtime import (
+    PeriodicProbe,
+    RuntimeEvent,
+    build_probe_tick,
+    select_release,
+)
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.events: list[RuntimeEvent] = []
+        self.lock = threading.Lock()
+
+    def emit(self, event: RuntimeEvent) -> None:
+        with self.lock:
+            self.events.append(event)
+
+    def count(self, name: str) -> int:
+        with self.lock:
+            return sum(event.event == name for event in self.events)
+
+
+class ProbeTests(unittest.TestCase):
+    def wait_for(self, predicate, *, timeout_s: float = 1.0) -> None:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            threading.Event().wait(0.001)
+        self.fail("condition did not become true before timeout")
+
+    def test_release_selection_skips_without_catchup_burst(self) -> None:
+        index, scheduled, skipped = select_release(
+            origin_ns=1_000,
+            index=2,
+            started_ns=1_450,
+            period_ns=100,
+        )
+        self.assertEqual(index, 4)
+        self.assertEqual(scheduled, 1_400)
+        self.assertEqual(skipped, 2)
+        self.assertEqual(select_release(1_000, 2, 1_200, 100), (2, 1_200, 0))
+
+    def test_tick_metrics_are_derived_from_monotonic_times(self) -> None:
+        tick = build_probe_tick(
+            index=3,
+            scheduled_ns=1_300,
+            started_ns=1_325,
+            finished_ns=1_360,
+            previous_started_ns=1_210,
+            period_ns=100,
+            deadline_ns=50,
+            skipped_releases=1,
+        )
+        self.assertEqual(tick.start_lateness_ns, 25)
+        self.assertEqual(tick.execution_ns, 35)
+        self.assertEqual(tick.actual_period_ns, 115)
+        self.assertEqual(tick.signed_period_error_ns, 15)
+        self.assertEqual(tick.absolute_period_error_ns, 15)
+        self.assertTrue(tick.deadline_miss)
+
+    def test_threaded_probe_stops_without_leaking_worker(self) -> None:
+        sink = RecordingSink()
+        probe = PeriodicProbe(period_ns=2_000_000, event_sink=sink)
+        probe.start()
+        self.addCleanup(
+            lambda: probe.stop(join_timeout_s=1.0) if probe.is_alive else None
+        )
+        self.wait_for(lambda: sink.count("probe.tick") >= 3)
+
+        report = probe.stop(join_timeout_s=1.0)
+        self.assertTrue(report.joined)
+        self.assertGreaterEqual(report.tick_count, 3)
+        self.assertIsNone(report.error_code)
+        self.assertEqual(sink.count("probe.started"), 1)
+        self.assertEqual(sink.count("probe.stopped"), 1)
+        self.assertEqual(sink.count("probe.joined"), 1)
+
+    def test_probe_callback_failure_is_bounded_and_observable(self) -> None:
+        sink = RecordingSink()
+
+        def fail() -> None:
+            raise RuntimeError("unbounded private callback detail")
+
+        probe = PeriodicProbe(
+            period_ns=1_000_000,
+            work=fail,
+            event_sink=sink,
+        )
+        probe.start()
+        self.wait_for(lambda: not probe.is_alive)
+        report = probe.stop(join_timeout_s=1.0)
+
+        self.assertTrue(report.joined)
+        self.assertEqual(report.error_code, "probe_runtimeerror")
+        details = " ".join(str(dict(event.details)) for event in sink.events)
+        self.assertNotIn("unbounded private", details)
+        self.assertEqual(sink.count("probe.failed"), 1)
+
+    def test_stop_interrupts_wait_for_a_distant_release(self) -> None:
+        sink = RecordingSink()
+        probe = PeriodicProbe(period_ns=10_000_000_000, event_sink=sink)
+        probe.start()
+        self.wait_for(lambda: sink.count("probe.tick") >= 1)
+        started = time.monotonic()
+        report = probe.stop(join_timeout_s=1.0)
+        elapsed = time.monotonic() - started
+
+        self.assertTrue(report.joined)
+        self.assertLess(elapsed, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_trace.py
+++ b/experiments/phase1/tests/test_trace.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from experiments.phase1.replay_lifecycle import (
+    ReplayError,
+    load_events,
+    main,
+    replay_events,
+    replay_file,
+)
+from experiments.phase1.telemetry import EventRecorder
+from jetson.phase1_runtime import (
+    BoundedTaskBroker,
+    LaneConfig,
+    ObservableExecutor,
+    OverflowPolicy,
+    PayloadRef,
+    PeriodicProbe,
+    SimulatedAdapter,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+)
+
+
+RUN_ID = "20260827T010000Z_phase1_semantic_simulated_001"
+PRIVATE_REF = "C:/private/research/input.bin"
+
+
+def make_task(task_id: str) -> TaskEnvelope:
+    now = time.monotonic_ns()
+    return TaskEnvelope(
+        task_id=task_id,
+        task_kind=TaskKind.SIMULATED,
+        source_monotonic_ns=now,
+        created_monotonic_ns=now,
+        deadline_monotonic_ns=now + 2_000_000_000,
+        state_token=StateToken("trace", 0),
+        payload=PayloadRef(
+            ref=PRIVATE_REF,
+            sha256="c" * 64,
+            size_bytes=4,
+            media_type="application/octet-stream",
+        ),
+    )
+
+
+class TraceTests(unittest.TestCase):
+    def wait_for(self, predicate, *, timeout_s: float = 1.0) -> None:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            threading.Event().wait(0.001)
+        self.fail("condition did not become true before timeout")
+
+    def create_complete_trace(self, root: Path) -> Path:
+        recorder = EventRecorder(root, RUN_ID)
+        broker = BoundedTaskBroker(
+            LaneConfig(
+                task_kind=TaskKind.SIMULATED,
+                pending_capacity=2,
+                result_capacity=1,
+            )
+        )
+        executor = ObservableExecutor(
+            broker,
+            SimulatedAdapter(0),
+            event_sink=recorder,
+        )
+        executor.start()
+        executor.submit(make_task("trace-task"))
+        self.wait_for(lambda: executor.snapshot().result_pending == 1)
+        result = executor.consume_next()
+        self.assertIsNotNone(result)
+        self.assertTrue(
+            executor.shutdown(cancel_live=False, join_timeout_s=1.0).complete
+        )
+        recorder.close()
+        return recorder.path
+
+    def test_jsonl_trace_replays_without_runtime_internals(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.create_complete_trace(Path(temp_dir))
+            summary = replay_file(path)
+            text = path.read_text(encoding="utf-8")
+
+        self.assertEqual(summary.submission_attempts, 1)
+        self.assertEqual(summary.admitted_total, 1)
+        self.assertEqual(summary.terminal_admitted_total, 1)
+        self.assertEqual(summary.accepted_result_count, 1)
+        self.assertEqual(summary.stale_consumed_count, 0)
+        self.assertTrue(summary.worker_joined)
+        self.assertEqual(summary.final_broker_state, "closed")
+        self.assertNotIn(PRIVATE_REF, text)
+        self.assertTrue(text.endswith("\n"))
+
+    def test_replay_rejects_capacity_tampering(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.create_complete_trace(Path(temp_dir))
+            events = load_events(path)
+        enqueued = next(event for event in events if event["event"] == "task.enqueued")
+        enqueued["details"]["pending_depth"] = 99
+        with self.assertRaisesRegex(ReplayError, "depths"):
+            replay_events(events)
+
+    def test_replay_rejects_a_consumed_result_after_its_deadline(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.create_complete_trace(Path(temp_dir))
+            events = load_events(path)
+        accepted = next(
+            event for event in events if event["event"] == "result.accepted"
+        )
+        late_transition = accepted["deadline_monotonic_ns"] + 1
+        accepted["details"]["transition_monotonic_ns"] = late_transition
+        accepted_index = events.index(accepted)
+        for event in events[accepted_index:]:
+            event["monotonic_ns"] = max(event["monotonic_ns"], late_transition)
+        with self.assertRaisesRegex(ReplayError, "stale or cancelled"):
+            replay_events(events)
+
+    def test_replay_rejects_duplicate_terminal_disposition(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.create_complete_trace(Path(temp_dir))
+            events = load_events(path)
+        accepted_index = next(
+            index
+            for index, event in enumerate(events)
+            if event["event"] == "result.accepted"
+        )
+        duplicate = json.loads(json.dumps(events[accepted_index]))
+        duplicate["event"] = "task.terminal"
+        duplicate["details"]["previous_location"] = "terminal"
+        duplicate["details"]["next_location"] = "terminal"
+        duplicate["details"]["disposition"] = "rejected_state"
+        events.insert(accepted_index + 1, duplicate)
+        for index, event in enumerate(events):
+            event["seq"] = index
+        with self.assertRaisesRegex(ReplayError, "duplicate final"):
+            replay_events(events)
+
+    def test_recorder_refuses_invalid_id_and_existing_trace(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaises(ValueError):
+                EventRecorder(root, "invalid")
+            recorder = EventRecorder(root, RUN_ID)
+            recorder.close()
+            with self.assertRaises(FileExistsError):
+                EventRecorder(root, RUN_ID)
+
+    def test_replay_cli_prints_machine_readable_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = self.create_complete_trace(Path(temp_dir))
+            output = StringIO()
+            with redirect_stdout(output):
+                return_code = main([str(path)])
+            summary = json.loads(output.getvalue())
+
+        self.assertEqual(return_code, 0)
+        self.assertEqual(summary["accepted_result_count"], 1)
+        self.assertEqual(summary["final_broker_state"], "closed")
+
+    def test_probe_and_executor_share_one_ordered_trace(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            recorder = EventRecorder(Path(temp_dir), RUN_ID)
+            broker = BoundedTaskBroker(
+                LaneConfig(
+                    task_kind=TaskKind.SIMULATED,
+                    pending_capacity=2,
+                    result_capacity=1,
+                )
+            )
+            executor = ObservableExecutor(
+                broker,
+                SimulatedAdapter(0.01, poll_interval_s=0.001),
+                event_sink=recorder,
+            )
+            probe = PeriodicProbe(period_ns=1_000_000, event_sink=recorder)
+            executor.start()
+            probe.start()
+            executor.submit(make_task("interleaved"))
+            self.wait_for(lambda: executor.snapshot().result_pending == 1)
+            self.assertIsNotNone(executor.consume_next())
+            probe_report = probe.stop(join_timeout_s=1.0)
+            shutdown = executor.shutdown(
+                cancel_live=False,
+                join_timeout_s=1.0,
+            )
+            recorder.close()
+            summary = replay_file(recorder.path)
+            events = load_events(recorder.path)
+
+        self.assertTrue(probe_report.joined)
+        self.assertTrue(shutdown.complete)
+        self.assertGreater(summary.probe_tick_count, 0)
+        self.assertEqual(summary.accepted_result_count, 1)
+        tick = next(event for event in events if event["event"] == "probe.tick")
+        tick["details"]["execution_ns"] += 1
+        with self.assertRaisesRegex(ReplayError, "execution duration"):
+            replay_events(events)
+
+    def test_overflow_and_queued_cancellation_replay_to_one_terminal_each(self) -> None:
+        gate = threading.Event()
+        base_adapter = SimulatedAdapter(0)
+
+        def gated_adapter(claimed):
+            if not gate.wait(timeout=1.0):
+                raise TimeoutError("test gate did not open")
+            return base_adapter(claimed)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            recorder = EventRecorder(Path(temp_dir), RUN_ID)
+            broker = BoundedTaskBroker(
+                LaneConfig(
+                    task_kind=TaskKind.SIMULATED,
+                    pending_capacity=1,
+                    result_capacity=1,
+                    overflow_policy=OverflowPolicy.DROP_OLDEST,
+                )
+            )
+            executor = ObservableExecutor(
+                broker,
+                gated_adapter,
+                event_sink=recorder,
+            )
+            executor.start()
+            executor.submit(make_task("active"))
+            self.wait_for(lambda: executor.snapshot().running == 1)
+            executor.submit(make_task("replaced"))
+            replacement = executor.submit(make_task("queued-cancel"))
+            self.assertEqual(
+                replacement.terminalized[0].task_id,
+                "replaced",
+            )
+            executor.cancel("queued-cancel", reason="scenario_cancel")
+            gate.set()
+            self.wait_for(lambda: executor.snapshot().result_pending == 1)
+            self.assertIsNotNone(executor.consume_next())
+            self.assertTrue(
+                executor.shutdown(cancel_live=False, join_timeout_s=1.0).complete
+            )
+            recorder.close()
+            summary = replay_file(recorder.path)
+
+        dispositions = dict(summary.disposition_counts)
+        self.assertEqual(summary.admitted_total, 3)
+        self.assertEqual(summary.terminal_admitted_total, 3)
+        self.assertEqual(dispositions["dropped_overflow"], 1)
+        self.assertEqual(dispositions["cancelled_queued"], 1)
+        self.assertEqual(dispositions["consumed"], 1)
+
+    def test_concurrent_producer_trace_replays_with_exact_depths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            recorder = EventRecorder(Path(temp_dir), RUN_ID)
+            broker = BoundedTaskBroker(
+                LaneConfig(
+                    task_kind=TaskKind.SIMULATED,
+                    pending_capacity=4,
+                    result_capacity=1,
+                )
+            )
+            executor = ObservableExecutor(
+                broker,
+                SimulatedAdapter(1.0, poll_interval_s=0.001),
+                event_sink=recorder,
+            )
+            executor.start()
+            barrier = threading.Barrier(17)
+            threads = []
+
+            def submit_one(value: int) -> None:
+                barrier.wait()
+                executor.submit(make_task(f"producer-{value}"))
+
+            for index in range(16):
+                thread = threading.Thread(
+                    target=submit_one,
+                    args=(index,),
+                )
+                threads.append(thread)
+                thread.start()
+            barrier.wait()
+            for thread in threads:
+                thread.join(timeout=1.0)
+                self.assertFalse(thread.is_alive())
+            report = executor.shutdown(cancel_live=True, join_timeout_s=1.0)
+            recorder.close()
+            summary = replay_file(recorder.path)
+
+        self.assertTrue(report.complete)
+        self.assertEqual(summary.submission_attempts, 16)
+        self.assertLessEqual(summary.max_pending_depth, 4)
+        self.assertLessEqual(summary.max_result_depth, 1)
+        self.assertEqual(summary.terminal_admitted_total, summary.admitted_total)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -2,9 +2,9 @@
 
 The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel, which is not yet connected to the robot application or model services.
 
-The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 kernel currently covers host-only task identity, bounded ownership and lifecycle correctness; worker threads, Jetson pilots and application integration remain research work.
+The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-only task identity, bounded ownership, a single-worker observable executor and a software periodic probe. Jetson pilots and application integration remain research work.
 
-> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前代码是已经完成整机验证的同步毕设基线，异步推理框架尚未合入。
+> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 的 host-only worker 与周期探针尚未接入真实模型或运动控制。
 
 ## Modules
 
@@ -16,7 +16,7 @@ The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubu
 | `vision_color.py` | HSV segmentation and target extraction |
 | `motion_planner.py` | Discrete visual feedback loop for approaching a colored object |
 | `robot_comm.py` | Command mapping, UART transport, STM32 responses and motion log |
-| `phase1_runtime/` | Host-testable task/result contracts and bounded lifecycle broker |
+| `phase1_runtime/` | Host-testable contracts, bounded broker, observable worker and periodic probe |
 | `assets/` | sherpa-onnx keyword configuration and wake acknowledgment audio |
 | `scripts/` | One-time environment setup helpers |
 

--- a/jetson/phase1_runtime/__init__.py
+++ b/jetson/phase1_runtime/__init__.py
@@ -15,6 +15,19 @@ from .broker import (
     SubmissionResult,
     TerminalTransition,
 )
+from .events import (
+    EventScalar,
+    EventStatus,
+    NullEventSink,
+    RuntimeEvent,
+    RuntimeEventSink,
+)
+from .executor import (
+    ExecutorShutdownReport,
+    ObservableExecutor,
+    SimulatedAdapter,
+    WorkloadAdapter,
+)
 from .model import (
     CancellationReport,
     CancellationToken,
@@ -28,31 +41,52 @@ from .model import (
     TaskLocation,
 )
 from .policies import LaneConfig, OverflowPolicy
+from .probe import (
+    PeriodicProbe,
+    ProbeStopReport,
+    ProbeTick,
+    build_probe_tick,
+    select_release,
+)
 
 __all__ = [
     "BoundedTaskBroker",
     "BrokerSnapshot",
     "BrokerState",
     "BrokerStateError",
-    "CancellationResult",
     "CancellationReport",
+    "CancellationResult",
     "CancellationToken",
     "ClaimedTask",
     "ClaimResult",
     "CompletionResult",
     "ConsumptionResult",
+    "EventScalar",
+    "EventStatus",
     "ExecutionOutcome",
+    "ExecutorShutdownReport",
     "FinalDisposition",
     "LaneConfig",
+    "NullEventSink",
+    "ObservableExecutor",
     "OverflowPolicy",
     "PayloadRef",
+    "PeriodicProbe",
+    "ProbeStopReport",
+    "ProbeTick",
     "ResultEnvelope",
+    "RuntimeEvent",
+    "RuntimeEventSink",
     "ShutdownResult",
-    "StateToken",
     "StateAdvanceResult",
+    "StateToken",
+    "SimulatedAdapter",
     "SubmissionResult",
     "TaskEnvelope",
     "TaskKind",
     "TaskLocation",
     "TerminalTransition",
+    "WorkloadAdapter",
+    "build_probe_tick",
+    "select_release",
 ]

--- a/jetson/phase1_runtime/events.py
+++ b/jetson/phase1_runtime/events.py
@@ -1,0 +1,136 @@
+"""Bounded observations emitted by the Phase 1 runtime."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Mapping, Protocol, TypeAlias
+
+from .model import StateToken, TaskKind
+
+
+MAX_EVENT_DETAILS = 32
+MAX_EVENT_DETAIL_BYTES = 4096
+MAX_EVENT_TEXT_LENGTH = 256
+
+_EVENT_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+_COMPONENT_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_DETAIL_KEY_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+EventScalar: TypeAlias = str | int | float | bool | None
+
+
+class EventStatus(str, Enum):
+    """Portable statuses used by runtime and probe observations."""
+
+    STARTED = "started"
+    OK = "ok"
+    ERROR = "error"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+    DROPPED = "dropped"
+    STALE = "stale"
+    REJECTED = "rejected"
+    INFO = "info"
+
+
+def _freeze_details(details: Mapping[str, EventScalar]) -> Mapping[str, EventScalar]:
+    if not isinstance(details, Mapping):
+        raise TypeError("event details must be a mapping")
+    if len(details) > MAX_EVENT_DETAILS:
+        raise ValueError(f"event details must contain at most {MAX_EVENT_DETAILS} keys")
+
+    copied: dict[str, EventScalar] = {}
+    for key, value in details.items():
+        if not isinstance(key, str) or not _DETAIL_KEY_RE.fullmatch(key):
+            raise ValueError("event detail keys must use lower_snake_case")
+        if not isinstance(value, (str, int, float, bool, type(None))):
+            raise TypeError("event detail values must be JSON scalar values")
+        if isinstance(value, str) and not 1 <= len(value) <= MAX_EVENT_TEXT_LENGTH:
+            raise ValueError(
+                "event detail strings must contain 1 to "
+                f"{MAX_EVENT_TEXT_LENGTH} characters"
+            )
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("event detail floats must be finite")
+        copied[key] = value
+
+    encoded = json.dumps(
+        copied,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if len(encoded) > MAX_EVENT_DETAIL_BYTES:
+        raise ValueError(
+            f"serialized event details must not exceed {MAX_EVENT_DETAIL_BYTES} bytes"
+        )
+    return MappingProxyType(copied)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeEvent:
+    """One hardware-independent observation awaiting recorder timestamps."""
+
+    event: str
+    component: str
+    status: EventStatus
+    task_id: str | None = None
+    task_kind: TaskKind | None = None
+    parent_task_id: str | None = None
+    source_monotonic_ns: int | None = None
+    deadline_monotonic_ns: int | None = None
+    state_token: StateToken | None = None
+    details: Mapping[str, EventScalar] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event, str) or not _EVENT_RE.fullmatch(self.event):
+            raise ValueError("event must contain at least two dotted name segments")
+        if not isinstance(self.component, str) or not _COMPONENT_RE.fullmatch(
+            self.component
+        ):
+            raise ValueError("component must use lower_snake_case")
+        if not isinstance(self.status, EventStatus):
+            raise TypeError("status must be an EventStatus")
+        for field_name in ("task_id", "parent_task_id"):
+            value = getattr(self, field_name)
+            if value is not None and (
+                not isinstance(value, str)
+                or not 1 <= len(value) <= 128
+                or value != value.strip()
+                or not value.isprintable()
+            ):
+                raise ValueError(f"{field_name} must be a bounded printable string")
+        if self.task_kind is not None and not isinstance(self.task_kind, TaskKind):
+            raise TypeError("task_kind must be a TaskKind or None")
+        for field_name in ("source_monotonic_ns", "deadline_monotonic_ns"):
+            value = getattr(self, field_name)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise ValueError(f"{field_name} must be a non-negative integer")
+        if self.state_token is not None and not isinstance(
+            self.state_token, StateToken
+        ):
+            raise TypeError("state_token must be a StateToken or None")
+        object.__setattr__(self, "details", _freeze_details(self.details))
+
+
+class RuntimeEventSink(Protocol):
+    """Synchronous sink used to preserve operation and trace ordering."""
+
+    def emit(self, event: RuntimeEvent) -> None:
+        """Record one immutable event or raise on recording failure."""
+
+
+class NullEventSink:
+    """Default sink for callers that do not need a trace."""
+
+    def emit(self, event: RuntimeEvent) -> None:
+        if not isinstance(event, RuntimeEvent):
+            raise TypeError("event must be a RuntimeEvent")

--- a/jetson/phase1_runtime/executor.py
+++ b/jetson/phase1_runtime/executor.py
@@ -1,0 +1,818 @@
+"""Observable single-worker execution for one bounded inference lane."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+from .broker import (
+    BoundedTaskBroker,
+    BrokerSnapshot,
+    BrokerState,
+    CancellationResult,
+    ClaimedTask,
+    CompletionResult,
+    ConsumptionResult,
+    ShutdownResult,
+    StateAdvanceResult,
+    SubmissionResult,
+    TerminalTransition,
+)
+from .events import EventStatus, NullEventSink, RuntimeEvent, RuntimeEventSink
+from .model import (
+    CancellationReport,
+    ExecutionOutcome,
+    FinalDisposition,
+    ResultEnvelope,
+    TaskEnvelope,
+    TaskLocation,
+)
+
+
+WorkloadAdapter = Callable[[ClaimedTask], ResultEnvelope]
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutorShutdownReport:
+    """Worker join and remaining broker state after one shutdown request."""
+
+    broker_state: BrokerState
+    joined: bool
+    join_latency_ns: int
+    queued_ids: tuple[str, ...]
+    active_id: str | None
+    result_pending_ids: tuple[str, ...]
+    active_cancellation_requested: bool
+    worker_error_code: str | None
+    event_error_code: str | None
+
+    @property
+    def complete(self) -> bool:
+        return (
+            self.joined
+            and self.broker_state is BrokerState.CLOSED
+            and self.worker_error_code is None
+            and self.event_error_code is None
+        )
+
+
+@dataclass(slots=True)
+class _DepthCursor:
+    pending: int
+    active: int
+    result: int
+
+    @classmethod
+    def from_snapshot(cls, snapshot: BrokerSnapshot) -> "_DepthCursor":
+        return cls(
+            pending=snapshot.queued,
+            active=snapshot.running,
+            result=snapshot.result_pending,
+        )
+
+    def leave(self, location: TaskLocation) -> None:
+        if location is TaskLocation.QUEUED:
+            self.pending -= 1
+        elif location is TaskLocation.RUNNING:
+            self.active -= 1
+        elif location is TaskLocation.RESULT_PENDING:
+            self.result -= 1
+        else:
+            raise RuntimeError(f"cannot leave lifecycle location: {location.value}")
+        if min(self.pending, self.active, self.result) < 0:
+            raise RuntimeError("observable depth accounting moved below zero")
+
+    def enter(self, location: TaskLocation) -> None:
+        if location is TaskLocation.QUEUED:
+            self.pending += 1
+        elif location is TaskLocation.RUNNING:
+            self.active += 1
+        elif location is TaskLocation.RESULT_PENDING:
+            self.result += 1
+        elif location is not TaskLocation.TERMINAL:
+            raise RuntimeError(f"cannot enter lifecycle location: {location.value}")
+
+
+class ObservableExecutor:
+    """Run one adapter thread while emitting replayable lifecycle boundaries."""
+
+    def __init__(
+        self,
+        broker: BoundedTaskBroker,
+        adapter: WorkloadAdapter,
+        *,
+        event_sink: RuntimeEventSink | None = None,
+        clock_ns: Callable[[], int] = time.monotonic_ns,
+        worker_name: str = "phase1-worker",
+    ) -> None:
+        if not isinstance(broker, BoundedTaskBroker):
+            raise TypeError("broker must be a BoundedTaskBroker")
+        if not callable(adapter):
+            raise TypeError("adapter must be callable")
+        if event_sink is not None and not callable(getattr(event_sink, "emit", None)):
+            raise TypeError("event_sink must provide emit(event)")
+        if not callable(clock_ns):
+            raise TypeError("clock_ns must be callable")
+        if (
+            not isinstance(worker_name, str)
+            or not 1 <= len(worker_name) <= 64
+            or worker_name != worker_name.strip()
+            or not worker_name.isprintable()
+        ):
+            raise ValueError("worker_name must be a bounded printable string")
+
+        self._broker = broker
+        self._adapter = adapter
+        self._event_sink = event_sink or NullEventSink()
+        self._clock_ns = clock_ns
+        self._worker_name = worker_name
+        self._boundary_lock = threading.RLock()
+        self._lifecycle_lock = threading.Lock()
+        self._wake_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started = False
+        self._worker_error_code: str | None = None
+        self._event_error_code: str | None = None
+
+    @property
+    def worker_name(self) -> str:
+        return self._worker_name
+
+    @property
+    def worker_error_code(self) -> str | None:
+        with self._lifecycle_lock:
+            return self._worker_error_code
+
+    @property
+    def event_error_code(self) -> str | None:
+        with self._lifecycle_lock:
+            return self._event_error_code
+
+    @property
+    def is_alive(self) -> bool:
+        with self._lifecycle_lock:
+            return self._thread is not None and self._thread.is_alive()
+
+    def _depth_details(
+        self,
+        cursor: _DepthCursor,
+        **extra: str | int | float | bool | None,
+    ) -> dict[str, str | int | float | bool | None]:
+        details: dict[str, str | int | float | bool | None] = {
+            "pending_depth": cursor.pending,
+            "active_count": cursor.active,
+            "result_depth": cursor.result,
+            "pending_capacity": self._broker.config.pending_capacity,
+            "result_capacity": self._broker.config.result_capacity,
+            "overflow_policy": self._broker.config.overflow_policy.value,
+        }
+        details.update(extra)
+        return details
+
+    def _emit(
+        self,
+        event: str,
+        status: EventStatus,
+        cursor: _DepthCursor,
+        *,
+        component: str = "executor",
+        task: TaskEnvelope | None = None,
+        task_id: str | None = None,
+        details: dict[str, str | int | float | bool | None] | None = None,
+    ) -> None:
+        payload = self._depth_details(cursor, **(details or {}))
+        observation = RuntimeEvent(
+            event=event,
+            component=component,
+            status=status,
+            task_id=task.task_id if task is not None else task_id,
+            task_kind=task.task_kind if task is not None else None,
+            parent_task_id=task.parent_task_id if task is not None else None,
+            source_monotonic_ns=(
+                task.source_monotonic_ns if task is not None else None
+            ),
+            deadline_monotonic_ns=(
+                task.deadline_monotonic_ns if task is not None else None
+            ),
+            state_token=task.state_token if task is not None else None,
+            details=payload,
+        )
+        try:
+            self._event_sink.emit(observation)
+        except Exception as exc:
+            error_name = type(exc).__name__.lower()
+            error_code = "event_sink_" + "".join(
+                character if character.isalnum() else "_" for character in error_name
+            )
+            with self._lifecycle_lock:
+                if self._event_error_code is None:
+                    self._event_error_code = error_code[:64]
+            self._event_sink = NullEventSink()
+            try:
+                self._broker.begin_shutdown(cancel_live=True)
+            finally:
+                self._wake_event.set()
+            raise RuntimeError("runtime event sink failed") from exc
+
+    @staticmethod
+    def _terminal_status(disposition: FinalDisposition) -> EventStatus:
+        if disposition is FinalDisposition.DROPPED_OVERFLOW:
+            return EventStatus.DROPPED
+        if disposition in {
+            FinalDisposition.CANCELLED_QUEUED,
+            FinalDisposition.REJECTED_CANCELLED,
+            FinalDisposition.SHUTDOWN_CANCELLED,
+        }:
+            return EventStatus.CANCELLED
+        if disposition in {
+            FinalDisposition.REJECTED_EXPIRED,
+            FinalDisposition.REJECTED_STATE,
+            FinalDisposition.REJECTED_IDENTITY,
+        }:
+            return EventStatus.STALE
+        if disposition is FinalDisposition.EXECUTION_ERROR:
+            return EventStatus.ERROR
+        if disposition is FinalDisposition.CONSUMED:
+            return EventStatus.OK
+        return EventStatus.REJECTED
+
+    def _emit_terminal(
+        self,
+        transition: TerminalTransition,
+        cursor: _DepthCursor,
+    ) -> None:
+        cursor.leave(transition.previous_location)
+        self._emit(
+            "task.terminal",
+            self._terminal_status(transition.disposition),
+            cursor,
+            task_id=transition.task_id,
+            details={
+                "previous_location": transition.previous_location.value,
+                "next_location": TaskLocation.TERMINAL.value,
+                "disposition": transition.disposition.value,
+                "transition_monotonic_ns": transition.terminal_monotonic_ns,
+            },
+        )
+
+    @staticmethod
+    def _assert_depths(cursor: _DepthCursor, snapshot: BrokerSnapshot) -> None:
+        observed = (cursor.pending, cursor.active, cursor.result)
+        expected = (snapshot.queued, snapshot.running, snapshot.result_pending)
+        if observed != expected:
+            raise RuntimeError(
+                f"observable depth accounting mismatch: {observed} != {expected}"
+            )
+
+    def start(self) -> None:
+        """Start the non-daemon worker exactly once."""
+
+        with self._lifecycle_lock:
+            if self._started:
+                raise RuntimeError("executor worker has already been started")
+            self._started = True
+            self._thread = threading.Thread(
+                target=self._worker_loop,
+                name=self._worker_name,
+                daemon=False,
+            )
+            self._thread.start()
+
+    def submit(self, task: TaskEnvelope) -> SubmissionResult:
+        """Submit through the observable boundary without blocking the producer."""
+
+        with self._lifecycle_lock:
+            if not self._started:
+                raise RuntimeError("executor worker has not been started")
+        with self._boundary_lock:
+            before = self._broker.snapshot()
+            cursor = _DepthCursor.from_snapshot(before)
+            result = self._broker.submit(task)
+            after = self._broker.snapshot()
+            for transition in result.terminalized:
+                self._emit_terminal(transition, cursor)
+
+            if result.admitted:
+                cursor.enter(TaskLocation.QUEUED)
+                self._emit(
+                    "task.enqueued",
+                    EventStatus.OK,
+                    cursor,
+                    task=task,
+                    details={
+                        "created_monotonic_ns": task.created_monotonic_ns,
+                        "payload_sha256": task.payload.sha256,
+                        "payload_size_bytes": task.payload.size_bytes,
+                        "payload_media_type": task.payload.media_type,
+                        "supersession_key_present": task.supersession_key is not None,
+                    },
+                )
+            else:
+                assert result.disposition is not None
+                self._emit(
+                    "task.rejected",
+                    self._terminal_status(result.disposition),
+                    cursor,
+                    task=task,
+                    details={
+                        "created_monotonic_ns": task.created_monotonic_ns,
+                        "payload_sha256": task.payload.sha256,
+                        "disposition": result.disposition.value,
+                    },
+                )
+            self._assert_depths(cursor, after)
+        if result.admitted:
+            self._wake_event.set()
+        return result
+
+    def consume_next(self) -> ConsumptionResult | None:
+        """Revalidate and consume one result through the trace boundary."""
+
+        with self._boundary_lock:
+            before = self._broker.snapshot()
+            cursor = _DepthCursor.from_snapshot(before)
+            result = self._broker.consume_next()
+            after = self._broker.snapshot()
+            if result is None:
+                self._assert_depths(cursor, after)
+                return None
+
+            cursor.leave(TaskLocation.RESULT_PENDING)
+            event_name = "result.accepted" if result.consumed else "result.rejected"
+            self._emit(
+                event_name,
+                self._terminal_status(result.disposition),
+                cursor,
+                task=result.task,
+                details={
+                    "previous_location": TaskLocation.RESULT_PENDING.value,
+                    "next_location": TaskLocation.TERMINAL.value,
+                    "disposition": result.disposition.value,
+                    "transition_monotonic_ns": (
+                        result.transition.terminal_monotonic_ns
+                    ),
+                    "result_input_sha256": result.result.input_sha256,
+                    "result_task_kind": result.result.task_kind.value,
+                    "result_source_monotonic_ns": (result.result.source_monotonic_ns),
+                    "result_deadline_monotonic_ns": (
+                        result.result.deadline_monotonic_ns
+                    ),
+                    "result_state_scope_id": result.result.state_token.scope_id,
+                    "result_state_generation": (result.result.state_token.generation),
+                },
+            )
+            self._assert_depths(cursor, after)
+            return result
+
+    def cancel(self, task_id: str, *, reason: str) -> CancellationResult:
+        with self._boundary_lock:
+            before = self._broker.snapshot()
+            cursor = _DepthCursor.from_snapshot(before)
+            result = self._broker.cancel(task_id, reason=reason)
+            after = self._broker.snapshot()
+            self._emit(
+                "task.cancel_requested" if result.found else "task.cancel_missing",
+                EventStatus.CANCELLED if result.found else EventStatus.INFO,
+                cursor,
+                task_id=task_id,
+                details={
+                    "found": result.found,
+                    "request_changed": result.request_changed,
+                    "already_terminal": result.already_terminal,
+                    "reason": reason,
+                },
+            )
+            if result.transition is not None:
+                self._emit_terminal(result.transition, cursor)
+            self._assert_depths(cursor, after)
+        self._wake_event.set()
+        return result
+
+    def advance_state(self, scope_id: str, *, reason: str) -> StateAdvanceResult:
+        with self._boundary_lock:
+            before = self._broker.snapshot()
+            cursor = _DepthCursor.from_snapshot(before)
+            previous_generation = dict(before.state_generations).get(scope_id, 0)
+            result = self._broker.advance_state(scope_id, reason=reason)
+            after = self._broker.snapshot()
+            self._emit(
+                "state.advanced",
+                EventStatus.OK,
+                cursor,
+                details={
+                    "state_scope_id": result.state_token.scope_id,
+                    "previous_generation": previous_generation,
+                    "state_generation": result.state_token.generation,
+                    "active_cancellation_requested": (
+                        result.active_cancellation_requested
+                    ),
+                    "reason": reason,
+                },
+            )
+            for transition in result.terminalized:
+                self._emit_terminal(transition, cursor)
+            self._assert_depths(cursor, after)
+        self._wake_event.set()
+        return result
+
+    def snapshot(self) -> BrokerSnapshot:
+        with self._boundary_lock:
+            return self._broker.snapshot()
+
+    def _claim_once(self) -> tuple[ClaimedTask | None, BrokerSnapshot]:
+        with self._boundary_lock:
+            before = self._broker.snapshot()
+            cursor = _DepthCursor.from_snapshot(before)
+            result = self._broker.claim_next()
+            after = self._broker.snapshot()
+            for transition in result.terminalized:
+                self._emit_terminal(transition, cursor)
+            if result.claimed is not None:
+                cursor.leave(TaskLocation.QUEUED)
+                cursor.enter(TaskLocation.RUNNING)
+                self._emit(
+                    "task.started",
+                    EventStatus.STARTED,
+                    cursor,
+                    component="worker",
+                    task=result.claimed.task,
+                    details={
+                        "previous_location": TaskLocation.QUEUED.value,
+                        "next_location": TaskLocation.RUNNING.value,
+                        "started_monotonic_ns": (result.claimed.started_monotonic_ns),
+                        "worker_name": self._worker_name,
+                    },
+                )
+            self._assert_depths(cursor, after)
+            return result.claimed, after
+
+    def _adapter_error_result(
+        self,
+        claimed: ClaimedTask,
+        *,
+        error_code: str,
+        finished_ns: int,
+    ) -> ResultEnvelope:
+        task = claimed.task
+        return ResultEnvelope(
+            task_id=task.task_id,
+            task_kind=task.task_kind,
+            state_token=task.state_token,
+            source_monotonic_ns=task.source_monotonic_ns,
+            deadline_monotonic_ns=task.deadline_monotonic_ns,
+            input_sha256=task.payload.sha256,
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=max(claimed.started_monotonic_ns, finished_ns),
+            execution_outcome=ExecutionOutcome.ERROR,
+            error_code=error_code,
+            cancellation_report=CancellationReport(
+                requested=claimed.cancellation_token.is_requested()
+            ),
+        )
+
+    def _execute_adapter(self, claimed: ClaimedTask) -> ResultEnvelope:
+        try:
+            result = self._adapter(claimed)
+        except Exception:
+            return self._adapter_error_result(
+                claimed,
+                error_code="adapter_exception",
+                finished_ns=self._clock_ns(),
+            )
+        if not isinstance(result, ResultEnvelope):
+            return self._adapter_error_result(
+                claimed,
+                error_code="invalid_adapter_result",
+                finished_ns=self._clock_ns(),
+            )
+        observed_now = self._clock_ns()
+        if result.finished_monotonic_ns > observed_now:
+            return self._adapter_error_result(
+                claimed,
+                error_code="invalid_adapter_timestamp",
+                finished_ns=observed_now,
+            )
+        return result
+
+    def _complete(self, result: ResultEnvelope) -> CompletionResult:
+        with self._boundary_lock:
+            before = self._broker.snapshot()
+            cursor = _DepthCursor.from_snapshot(before)
+            completion = self._broker.complete(result)
+            after = self._broker.snapshot()
+            cursor.leave(TaskLocation.RUNNING)
+            next_location = (
+                TaskLocation.RESULT_PENDING
+                if completion.result_pending
+                else TaskLocation.TERMINAL
+            )
+            cursor.enter(next_location)
+            details: dict[str, str | int | float | bool | None] = {
+                "previous_location": TaskLocation.RUNNING.value,
+                "next_location": next_location.value,
+                "started_monotonic_ns": result.started_monotonic_ns,
+                "finished_monotonic_ns": result.finished_monotonic_ns,
+                "execution_outcome": result.execution_outcome.value,
+                "result_task_kind": result.task_kind.value,
+                "error_code": result.error_code,
+                "result_input_sha256": result.input_sha256,
+                "result_source_monotonic_ns": result.source_monotonic_ns,
+                "result_deadline_monotonic_ns": result.deadline_monotonic_ns,
+                "result_state_scope_id": result.state_token.scope_id,
+                "result_state_generation": result.state_token.generation,
+                "cancel_requested": result.cancellation_report.requested,
+                "cancel_worker_observed": (result.cancellation_report.worker_observed),
+                "cancel_backend_stop_confirmed": (
+                    result.cancellation_report.backend_stop_confirmed
+                ),
+            }
+            if completion.disposition is not None:
+                details["disposition"] = completion.disposition.value
+            if completion.transition is not None:
+                details["transition_monotonic_ns"] = (
+                    completion.transition.terminal_monotonic_ns
+                )
+            self._emit(
+                "task.finished",
+                (
+                    EventStatus.OK
+                    if completion.result_pending
+                    else self._terminal_status(completion.disposition)
+                ),
+                cursor,
+                component="worker",
+                task_id=result.task_id,
+                details=details,
+            )
+            self._assert_depths(cursor, after)
+            return completion
+
+    def _worker_loop(self) -> None:
+        try:
+            with self._boundary_lock:
+                snapshot = self._broker.snapshot()
+                cursor = _DepthCursor.from_snapshot(snapshot)
+                self._emit(
+                    "worker.started",
+                    EventStatus.STARTED,
+                    cursor,
+                    component="worker",
+                    details={"worker_name": self._worker_name},
+                )
+
+            while True:
+                self._wake_event.clear()
+                claimed, snapshot = self._claim_once()
+                if claimed is not None:
+                    result = self._execute_adapter(claimed)
+                    self._complete(result)
+                    continue
+                if (
+                    snapshot.state is not BrokerState.OPEN
+                    and snapshot.queued == 0
+                    and snapshot.running == 0
+                ):
+                    break
+                self._wake_event.wait()
+        except Exception as exc:
+            error_name = type(exc).__name__.lower()
+            error_code = "worker_" + "".join(
+                character if character.isalnum() else "_" for character in error_name
+            )
+            with self._lifecycle_lock:
+                self._worker_error_code = error_code[:64]
+            try:
+                with self._boundary_lock:
+                    snapshot = self._broker.snapshot()
+                    self._emit(
+                        "worker.failed",
+                        EventStatus.ERROR,
+                        _DepthCursor.from_snapshot(snapshot),
+                        component="worker",
+                        details={
+                            "worker_name": self._worker_name,
+                            "error_code": self._worker_error_code,
+                            "event_error_code": self.event_error_code,
+                        },
+                    )
+            except Exception:
+                pass
+        finally:
+            try:
+                with self._boundary_lock:
+                    snapshot = self._broker.snapshot()
+                    self._emit(
+                        "worker.stopped",
+                        (
+                            EventStatus.ERROR
+                            if (
+                                self.worker_error_code is not None
+                                or self.event_error_code is not None
+                            )
+                            else EventStatus.OK
+                        ),
+                        _DepthCursor.from_snapshot(snapshot),
+                        component="worker",
+                        details={
+                            "worker_name": self._worker_name,
+                            "error_code": self.worker_error_code,
+                            "event_error_code": self.event_error_code,
+                        },
+                    )
+            except Exception:
+                pass
+
+    def shutdown(
+        self,
+        *,
+        cancel_live: bool,
+        join_timeout_s: float,
+    ) -> ExecutorShutdownReport:
+        """Request broker shutdown, wake the worker, and join within a budget."""
+
+        if (
+            isinstance(join_timeout_s, bool)
+            or not isinstance(join_timeout_s, (int, float))
+            or not math.isfinite(join_timeout_s)
+            or join_timeout_s < 0
+        ):
+            raise ValueError("join_timeout_s must be a finite non-negative number")
+        with self._lifecycle_lock:
+            if not self._started or self._thread is None:
+                raise RuntimeError("executor worker has not been started")
+            thread = self._thread
+
+        with self._boundary_lock:
+            before = self._broker.snapshot()
+            cursor = _DepthCursor.from_snapshot(before)
+            shutdown_result: ShutdownResult = self._broker.begin_shutdown(
+                cancel_live=cancel_live
+            )
+            after = self._broker.snapshot()
+            self._emit(
+                "shutdown.requested",
+                EventStatus.CANCELLED if cancel_live else EventStatus.INFO,
+                cursor,
+                details={
+                    "cancel_live": cancel_live,
+                    "broker_state": shutdown_result.state.value,
+                    "active_cancellation_requested": (
+                        shutdown_result.active_cancellation_requested
+                    ),
+                },
+            )
+            for transition in shutdown_result.terminalized:
+                self._emit_terminal(transition, cursor)
+            self._assert_depths(cursor, after)
+
+        self._wake_event.set()
+        join_started = time.monotonic_ns()
+        thread.join(timeout=float(join_timeout_s))
+        join_latency = time.monotonic_ns() - join_started
+        joined = not thread.is_alive()
+
+        with self._boundary_lock:
+            snapshot = self._broker.snapshot()
+            cursor = _DepthCursor.from_snapshot(snapshot)
+            self._emit(
+                "worker.joined",
+                EventStatus.OK if joined else EventStatus.TIMEOUT,
+                cursor,
+                component="worker",
+                details={
+                    "worker_name": self._worker_name,
+                    "joined": joined,
+                    "join_latency_ns": join_latency,
+                    "broker_state": snapshot.state.value,
+                    "worker_error_code": self.worker_error_code,
+                    "event_error_code": self.event_error_code,
+                },
+            )
+            return ExecutorShutdownReport(
+                broker_state=snapshot.state,
+                joined=joined,
+                join_latency_ns=join_latency,
+                queued_ids=snapshot.queued_ids,
+                active_id=snapshot.active_id,
+                result_pending_ids=snapshot.result_pending_ids,
+                active_cancellation_requested=(
+                    shutdown_result.active_cancellation_requested
+                ),
+                worker_error_code=self.worker_error_code,
+                event_error_code=self.event_error_code,
+            )
+
+
+class SimulatedAdapter:
+    """Finite, cooperative slow workload used before Jetson integration."""
+
+    def __init__(
+        self,
+        service_time_s: float,
+        *,
+        outcome: ExecutionOutcome = ExecutionOutcome.OK,
+        error_code: str | None = None,
+        observe_cancellation: bool = True,
+        poll_interval_s: float = 0.01,
+        clock_ns: Callable[[], int] = time.monotonic_ns,
+    ) -> None:
+        for value, name, upper in (
+            (service_time_s, "service_time_s", 3600.0),
+            (poll_interval_s, "poll_interval_s", 1.0),
+        ):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                or value < 0
+                or value > upper
+            ):
+                raise ValueError(f"{name} must be finite and between 0 and {upper}")
+        if poll_interval_s == 0:
+            raise ValueError("poll_interval_s must be greater than zero")
+        if not isinstance(outcome, ExecutionOutcome):
+            raise TypeError("outcome must be an ExecutionOutcome")
+        if outcome is ExecutionOutcome.CANCEL_OBSERVED:
+            raise ValueError(
+                "cancel_observed is produced only by cooperative cancellation"
+            )
+        if outcome in {ExecutionOutcome.ERROR, ExecutionOutcome.TIMEOUT}:
+            if error_code is None:
+                raise ValueError("error and timeout simulations require error_code")
+        elif error_code is not None:
+            raise ValueError("successful simulation must not include error_code")
+        if not isinstance(observe_cancellation, bool):
+            raise TypeError("observe_cancellation must be a boolean")
+        if not callable(clock_ns):
+            raise TypeError("clock_ns must be callable")
+
+        self._service_time_ns = int(float(service_time_s) * 1_000_000_000)
+        self._outcome = outcome
+        self._error_code = error_code
+        self._observe_cancellation = observe_cancellation
+        self._poll_interval_s = float(poll_interval_s)
+        self._clock_ns = clock_ns
+        self._noncooperative_wait = threading.Event()
+
+    def __call__(self, claimed: ClaimedTask) -> ResultEnvelope:
+        deadline = claimed.started_monotonic_ns + self._service_time_ns
+        cancellation_observed = False
+        while True:
+            now = self._clock_ns()
+            if now >= deadline:
+                break
+            remaining_s = (deadline - now) / 1_000_000_000
+            wait_s = min(self._poll_interval_s, remaining_s)
+            if self._observe_cancellation:
+                if claimed.cancellation_token.wait(timeout=wait_s):
+                    cancellation_observed = True
+                    break
+            else:
+                self._noncooperative_wait.wait(timeout=wait_s)
+
+        finished = max(claimed.started_monotonic_ns, self._clock_ns())
+        task = claimed.task
+        if cancellation_observed:
+            outcome = ExecutionOutcome.CANCEL_OBSERVED
+            error_code = None
+            output_sha256 = None
+            output_length = None
+            cancellation = CancellationReport(
+                requested=True,
+                client_wait_stopped=True,
+                worker_observed=True,
+                backend_stop_confirmed=True,
+            )
+        else:
+            outcome = self._outcome
+            error_code = self._error_code
+            cancellation = CancellationReport(
+                requested=claimed.cancellation_token.is_requested()
+            )
+            if outcome is ExecutionOutcome.OK:
+                output = f"simulated:{task.payload.sha256}".encode("ascii")
+                output_sha256 = hashlib.sha256(output).hexdigest()
+                output_length = len(output)
+            else:
+                output_sha256 = None
+                output_length = None
+
+        return ResultEnvelope(
+            task_id=task.task_id,
+            task_kind=task.task_kind,
+            state_token=task.state_token,
+            source_monotonic_ns=task.source_monotonic_ns,
+            deadline_monotonic_ns=task.deadline_monotonic_ns,
+            input_sha256=task.payload.sha256,
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=outcome,
+            output_sha256=output_sha256,
+            output_length=output_length,
+            error_code=error_code,
+            cancellation_report=cancellation,
+        )

--- a/jetson/phase1_runtime/probe.py
+++ b/jetson/phase1_runtime/probe.py
@@ -1,0 +1,350 @@
+"""Absolute-schedule periodic probe for Phase 1 responsiveness studies."""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+from .events import EventStatus, NullEventSink, RuntimeEvent, RuntimeEventSink
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeTick:
+    index: int
+    scheduled_monotonic_ns: int
+    started_monotonic_ns: int
+    finished_monotonic_ns: int
+    start_lateness_ns: int
+    execution_ns: int
+    actual_period_ns: int | None
+    signed_period_error_ns: int | None
+    absolute_period_error_ns: int | None
+    skipped_releases: int
+    deadline_miss: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeStopReport:
+    joined: bool
+    tick_count: int
+    skipped_releases: int
+    deadline_miss_count: int
+    max_lateness_ns: int
+    max_gap_ns: int
+    error_code: str | None
+
+
+def select_release(
+    origin_ns: int,
+    index: int,
+    started_ns: int,
+    period_ns: int,
+) -> tuple[int, int, int]:
+    """Select the newest due release and report how many were skipped."""
+
+    for value, name in (
+        (origin_ns, "origin_ns"),
+        (index, "index"),
+        (started_ns, "started_ns"),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{name} must be a non-negative integer")
+    if isinstance(period_ns, bool) or not isinstance(period_ns, int) or period_ns <= 0:
+        raise ValueError("period_ns must be a positive integer")
+
+    scheduled = origin_ns + index * period_ns
+    if started_ns <= scheduled:
+        return index, scheduled, 0
+    skipped = (started_ns - scheduled) // period_ns
+    return index + skipped, scheduled + skipped * period_ns, skipped
+
+
+def build_probe_tick(
+    *,
+    index: int,
+    scheduled_ns: int,
+    started_ns: int,
+    finished_ns: int,
+    previous_started_ns: int | None,
+    period_ns: int,
+    deadline_ns: int,
+    skipped_releases: int,
+) -> ProbeTick:
+    """Build one deterministic tick record from monotonic timestamps."""
+
+    if started_ns < scheduled_ns:
+        raise ValueError("started_ns must not be before scheduled_ns")
+    if finished_ns < started_ns:
+        raise ValueError("finished_ns must not be before started_ns")
+    actual_period = (
+        None if previous_started_ns is None else started_ns - previous_started_ns
+    )
+    signed_error = None if actual_period is None else actual_period - period_ns
+    return ProbeTick(
+        index=index,
+        scheduled_monotonic_ns=scheduled_ns,
+        started_monotonic_ns=started_ns,
+        finished_monotonic_ns=finished_ns,
+        start_lateness_ns=started_ns - scheduled_ns,
+        execution_ns=finished_ns - started_ns,
+        actual_period_ns=actual_period,
+        signed_period_error_ns=signed_error,
+        absolute_period_error_ns=(None if signed_error is None else abs(signed_error)),
+        skipped_releases=skipped_releases,
+        deadline_miss=finished_ns > scheduled_ns + deadline_ns,
+    )
+
+
+class PeriodicProbe:
+    """Run a bounded callback on an interruptible absolute schedule."""
+
+    def __init__(
+        self,
+        *,
+        period_ns: int = 100_000_000,
+        deadline_ns: int | None = None,
+        work: Callable[[], None] | None = None,
+        event_sink: RuntimeEventSink | None = None,
+        clock_ns: Callable[[], int] = time.monotonic_ns,
+        thread_name: str = "phase1-periodic-probe",
+    ) -> None:
+        if (
+            isinstance(period_ns, bool)
+            or not isinstance(period_ns, int)
+            or period_ns <= 0
+        ):
+            raise ValueError("period_ns must be a positive integer")
+        resolved_deadline = period_ns if deadline_ns is None else deadline_ns
+        if (
+            isinstance(resolved_deadline, bool)
+            or not isinstance(resolved_deadline, int)
+            or resolved_deadline <= 0
+        ):
+            raise ValueError("deadline_ns must be a positive integer")
+        if work is not None and not callable(work):
+            raise TypeError("work must be callable or None")
+        if event_sink is not None and not callable(getattr(event_sink, "emit", None)):
+            raise TypeError("event_sink must provide emit(event)")
+        if not callable(clock_ns):
+            raise TypeError("clock_ns must be callable")
+        if (
+            not isinstance(thread_name, str)
+            or not 1 <= len(thread_name) <= 64
+            or thread_name != thread_name.strip()
+            or not thread_name.isprintable()
+        ):
+            raise ValueError("thread_name must be a bounded printable string")
+
+        self.period_ns = period_ns
+        self.deadline_ns = resolved_deadline
+        self._work = work or (lambda: None)
+        self._event_sink = event_sink or NullEventSink()
+        self._clock_ns = clock_ns
+        self._thread_name = thread_name
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._started = False
+        self._tick_count = 0
+        self._skipped_releases = 0
+        self._deadline_miss_count = 0
+        self._max_lateness_ns = 0
+        self._max_gap_ns = 0
+        self._error_code: str | None = None
+
+    @property
+    def is_alive(self) -> bool:
+        with self._lock:
+            return self._thread is not None and self._thread.is_alive()
+
+    def start(self) -> None:
+        with self._lock:
+            if self._started:
+                raise RuntimeError("periodic probe has already been started")
+            self._started = True
+            self._thread = threading.Thread(
+                target=self._run,
+                name=self._thread_name,
+                daemon=False,
+            )
+            self._thread.start()
+
+    def _emit(
+        self,
+        event: str,
+        status: EventStatus,
+        details: dict[str, str | int | float | bool | None],
+    ) -> None:
+        self._event_sink.emit(
+            RuntimeEvent(
+                event=event,
+                component="probe",
+                status=status,
+                details=details,
+            )
+        )
+
+    def _wait_until(self, target_ns: int) -> bool:
+        while True:
+            remaining_ns = target_ns - self._clock_ns()
+            if remaining_ns <= 0:
+                return False
+            if self._stop_event.wait(remaining_ns / 1_000_000_000):
+                return True
+
+    def _run(self) -> None:
+        origin = self._clock_ns()
+        index = 0
+        previous_started: int | None = None
+        try:
+            self._emit(
+                "probe.started",
+                EventStatus.STARTED,
+                {
+                    "origin_monotonic_ns": origin,
+                    "period_ns": self.period_ns,
+                    "deadline_ns": self.deadline_ns,
+                    "thread_name": self._thread_name,
+                },
+            )
+            while not self._stop_event.is_set():
+                scheduled = origin + index * self.period_ns
+                if self._wait_until(scheduled):
+                    break
+                observed_start = self._clock_ns()
+                selected_index, selected_release, skipped = select_release(
+                    origin,
+                    index,
+                    observed_start,
+                    self.period_ns,
+                )
+                if skipped:
+                    self._emit(
+                        "probe.skipped",
+                        EventStatus.DROPPED,
+                        {
+                            "from_index": index,
+                            "to_index": selected_index,
+                            "skipped_releases": skipped,
+                            "observed_monotonic_ns": observed_start,
+                        },
+                    )
+                index = selected_index
+                started = self._clock_ns()
+                self._work()
+                finished = self._clock_ns()
+                tick = build_probe_tick(
+                    index=index,
+                    scheduled_ns=selected_release,
+                    started_ns=started,
+                    finished_ns=finished,
+                    previous_started_ns=previous_started,
+                    period_ns=self.period_ns,
+                    deadline_ns=self.deadline_ns,
+                    skipped_releases=skipped,
+                )
+                self._emit(
+                    "probe.tick",
+                    EventStatus.TIMEOUT if tick.deadline_miss else EventStatus.OK,
+                    {
+                        "tick_index": tick.index,
+                        "scheduled_monotonic_ns": tick.scheduled_monotonic_ns,
+                        "started_monotonic_ns": tick.started_monotonic_ns,
+                        "finished_monotonic_ns": tick.finished_monotonic_ns,
+                        "start_lateness_ns": tick.start_lateness_ns,
+                        "execution_ns": tick.execution_ns,
+                        "actual_period_ns": tick.actual_period_ns,
+                        "signed_period_error_ns": tick.signed_period_error_ns,
+                        "absolute_period_error_ns": tick.absolute_period_error_ns,
+                        "skipped_releases": tick.skipped_releases,
+                        "deadline_miss": tick.deadline_miss,
+                    },
+                )
+                with self._lock:
+                    self._tick_count += 1
+                    self._skipped_releases += skipped
+                    self._deadline_miss_count += int(tick.deadline_miss)
+                    self._max_lateness_ns = max(
+                        self._max_lateness_ns, tick.start_lateness_ns
+                    )
+                    if tick.actual_period_ns is not None:
+                        self._max_gap_ns = max(self._max_gap_ns, tick.actual_period_ns)
+                previous_started = started
+                index += 1
+        except Exception as exc:
+            error_name = type(exc).__name__.lower()
+            error_code = "probe_" + "".join(
+                character if character.isalnum() else "_" for character in error_name
+            )
+            with self._lock:
+                self._error_code = error_code[:64]
+            try:
+                self._emit(
+                    "probe.failed",
+                    EventStatus.ERROR,
+                    {
+                        "error_code": self._error_code,
+                        "thread_name": self._thread_name,
+                    },
+                )
+            except Exception:
+                pass
+        finally:
+            try:
+                with self._lock:
+                    details: dict[str, str | int | float | bool | None] = {
+                        "tick_count": self._tick_count,
+                        "skipped_releases": self._skipped_releases,
+                        "deadline_miss_count": self._deadline_miss_count,
+                        "max_lateness_ns": self._max_lateness_ns,
+                        "max_gap_ns": self._max_gap_ns,
+                        "error_code": self._error_code,
+                    }
+                self._emit(
+                    "probe.stopped",
+                    EventStatus.ERROR if self._error_code else EventStatus.OK,
+                    details,
+                )
+            except Exception:
+                pass
+
+    def stop(self, *, join_timeout_s: float) -> ProbeStopReport:
+        if (
+            isinstance(join_timeout_s, bool)
+            or not isinstance(join_timeout_s, (int, float))
+            or not math.isfinite(join_timeout_s)
+            or join_timeout_s < 0
+        ):
+            raise ValueError("join_timeout_s must be a finite non-negative number")
+        with self._lock:
+            if not self._started or self._thread is None:
+                raise RuntimeError("periodic probe has not been started")
+            thread = self._thread
+        self._stop_event.set()
+        thread.join(timeout=float(join_timeout_s))
+        joined = not thread.is_alive()
+        with self._lock:
+            report = ProbeStopReport(
+                joined=joined,
+                tick_count=self._tick_count,
+                skipped_releases=self._skipped_releases,
+                deadline_miss_count=self._deadline_miss_count,
+                max_lateness_ns=self._max_lateness_ns,
+                max_gap_ns=self._max_gap_ns,
+                error_code=self._error_code,
+            )
+        self._emit(
+            "probe.joined",
+            EventStatus.OK if joined else EventStatus.TIMEOUT,
+            {
+                "joined": joined,
+                "tick_count": report.tick_count,
+                "skipped_releases": report.skipped_releases,
+                "deadline_miss_count": report.deadline_miss_count,
+                "error_code": report.error_code,
+            },
+        )
+        return report


### PR DESCRIPTION
## Summary

This pull request adds the observable host-side execution layer for Phase 1.

- Introduces a single-worker executor around the runtime broker
- Executes slow adapter calls outside the broker boundary
- Preserves mailbox capacity and result freshness validation
- Adds structured lifecycle events and JSONL trace recording
- Adds an absolute-schedule periodic probe with skipped-release accounting
- Adds independent lifecycle replay and invariant validation
- Updates the Phase 1 architecture and experiment documentation

## Runtime behavior

The executor uses one non-daemon worker and explicit result consumption. It supports cooperative and finite non-cooperative simulated adapters without involving physical hardware.

The periodic probe follows an absolute schedule. Missed releases are recorded instead of triggering catch-up bursts. Event-sink failures are surfaced as runtime failures rather than being silently ignored.

## Trace validation

The replay tool validates:

- lifecycle state transitions
- mailbox capacity
- request and result identity
- stale-result consumption
- terminal request accounting
- shutdown completion
- worker and probe failures
- periodic probe metrics

Recorded traces follow the Phase 1 `0.2.0` event schema.

Replay command:

```bash
python -m experiments.phase1.replay_lifecycle /path/to/events.jsonl
```

## Validation

- 84 repository tests passed
- Black formatting check passed
- Pyflakes static analysis passed
- Python compilation check passed
- generated events passed JSON Schema validation
- Markdown link validation passed
- Git whitespace check passed

## Scope

This change is limited to host-side runtime research. It does not introduce UART communication, STM32 integration, physical motion, or a production Jetson inference backend.