### PR TITLE
feat(experiments): add phase 1 simulation runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository began with my bachelor's thesis on speech interaction and visual perception for a wheeled robot. The thesis system runs fully local speech and vision pipelines on a Jetson Orin Nano, while an STM32F407 executes motion commands and enforces a communication watchdog. The same platform will now be used to study how long-running perception and inference can coexist with predictable control timing.
 
-> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立 host-only 有界运行时、可观测 worker 和周期探针，尚未接入 Jetson 模型或整机应用。
+> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立 host-only 有界运行时、可观测 worker、周期探针和模拟实验运行器，尚未接入 Jetson 模型或整机应用。
 
 ## Project status
 
@@ -15,7 +15,7 @@ This repository began with my bachelor's thesis on speech interaction and visual
 | Bachelor's thesis software and firmware | Complete and hardware validated |
 | Custom base-driver PCB | Published and tested on the physical robot |
 | Jetson–STM32 command link | Validated with ACK/error responses and a 1.2 s command watchdog |
-| Asynchronous inference runtime | Host-only bounded executor, periodic probe and trace replay implemented; Jetson integration pending |
+| Asynchronous inference runtime | Host-only bounded executor, periodic probe, trace replay and simulated-condition runner implemented; Jetson pilot pending |
 
 The validated Jetson–STM32 code is preserved at [`v0.1.0-thesis-baseline`](https://github.com/yuzhang-robotics/embodied-robot-heterogeneous-control/tree/v0.1.0-thesis-baseline). The current `main` branch also includes the reviewed hardware documentation and editable PCB export.
 
@@ -63,9 +63,10 @@ The current Jetson application is synchronous: wake-word detection, recording, A
 
 Phase 1 now has an immutable task/result model, bounded task ownership, scoped
 state generations, a single-worker observable executor, an absolute-schedule
-periodic probe and independent lifecycle trace replay. These components remain
-host-only and are not yet connected to the Jetson application or model
-services. The broader research stage will investigate:
+periodic probe, independent lifecycle trace replay and a reproducible
+simulated-condition runner. These components remain host-only; no Jetson pilot
+or model-service integration result is claimed yet. The broader research stage
+will investigate:
 
 - independent acquisition, inference, planning and control workers;
 - timestamped bounded queues, cancellation and stale-result rejection;
@@ -87,7 +88,7 @@ These are research objectives, not claims about the current implementation. The 
 | [`docs/hardware/`](docs/hardware/) | Physical platform, wiring, pin assignments, power and safety notes |
 | [`docs/architecture/`](docs/architecture/) | Current timing model and the boundary of the planned asynchronous architecture |
 | [`experiments/phase0/`](experiments/phase0/) | Synchronous fixed-input measurement, validation and formal analysis tools |
-| [`experiments/phase1/`](experiments/phase1/) | Host tests, Phase 1 trace schema, recorder and independent lifecycle replay |
+| [`experiments/phase1/`](experiments/phase1/) | Host tests, simulated-condition runner, Phase 1 trace schema, validation and descriptive summaries |
 
 ## Reproducing the baseline
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -100,8 +100,9 @@ The proposed task model, lifecycle invariants, queue policies, cancellation
 semantics, and Phase 1 safety Gates are specified in the
 [Phase 1 runtime contract](phase1-runtime-contract.md). That document is a
 design and correctness boundary. The host-only model, bounded broker,
-observable worker, periodic probe and lifecycle replay do not yet constitute a
-validated Jetson runtime or a performance result.
+observable worker, periodic probe, lifecycle replay and simulated-condition
+runner do not yet constitute a validated Jetson runtime or a performance
+result.
 
 ## Evaluation plan
 

--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -2,17 +2,19 @@
 
 This document defines the correctness and safety contract for the first
 asynchronous runtime used by the Octopus robot research platform. The
-host-only model, broker, observable executor, periodic probe and trace replay
-have been implemented. Jetson behavior and performance remain unvalidated.
+host-only model, broker, observable executor, periodic probes, trace replay and
+portable simulation protocol have been implemented. Jetson behavior and
+performance remain unvalidated.
 
 > 中文简介：本文冻结 Phase 1 异步运行时的任务模型、生命周期、队列、取消、结果新鲜度、
-> 快速周期代理和安全边界。host-only worker、周期探针和 trace replay 已实现；Jetson pilot、
-> 真实模型接入和正式实验仍需按 Gate 逐步完成。
+> 快速周期代理和安全边界。host-only worker、周期探针、trace replay 和模拟实验运行器已实现；
+> Jetson pilot、真实模型接入和正式实验仍需按 Gate 逐步完成。
 
 ## Status
 
-- Phase: Phase 1.2 host-only observable executor
+- Phase: Phase 1.3 portable simulation protocol
 - Contract status: frozen and implemented for the host-only boundary
+- Simulation-runner starting point: `main@4514d97`
 - Observable-executor starting point: `main@1d29b14`
 - Initial runtime-kernel starting point: `main@043e1bb`
 - Synchronous functional baseline: `61db058`
@@ -29,11 +31,13 @@ The current host implementation includes:
 - bounded pending, active, result-mailbox, state-scope and terminal ownership;
 - one non-daemon worker with cooperative cancellation and finite join reports;
 - a simulated adapter with finite service time and explicit cancellation facts;
-- an independent absolute-schedule periodic probe;
-- schema `0.2.0` JSONL recording and offline lifecycle replay.
+- inline and independent absolute-schedule periodic probes;
+- schema `0.2.0` JSONL recording and profile-aware offline lifecycle replay;
+- R0--R4 simulated-condition orchestration, atomic manifests, validation and
+  descriptive summaries.
 
-It does not include the Jetson simulation runner, real workload adapters,
-resource telemetry integration or formal performance data.
+It does not include Jetson resource telemetry, a completed Jetson simulation
+pilot, real workload adapters or formal performance data.
 
 ## Research objective
 
@@ -416,9 +420,10 @@ The experiment layer provides both:
 
 The probe is a software scheduling proxy, not a motor controller.
 
-The independent threaded probe and its pure release/tick calculations are now
-implemented. The inline condition belongs to the next simulation-runner
-milestone so that both paths can invoke the same scenario workload.
+Both probe paths and their pure release/tick calculations are implemented. The
+inline path advances on the caller thread and therefore records releases
+skipped while a direct synchronous adapter call owns that thread. The threaded
+path advances independently. Both invoke the same scenario adapter contract.
 
 ## Event and replay requirements
 
@@ -465,7 +470,16 @@ The replay implementation imports no runtime classes. It validates the
 serialized schema fields, reconstructs every task location and state
 generation, checks recorded depths against its own counts, enforces pending,
 active and result capacities, and rejects stale consumption or incomplete
-shutdown.
+shutdown. Completion uses an explicit trace profile:
+
+- `inline_probe` requires a stopped probe and forbids worker lifecycle events;
+- `threaded_probe` requires a stopped and joined probe and forbids worker
+  lifecycle events;
+- `runtime` requires a closed and joined worker, with an optional probe;
+- `runtime_threaded_probe` requires both complete lifecycles.
+
+The validator never infers a weaker completion contract from whichever events
+happen to be present.
 
 ## Experimental decomposition
 
@@ -480,18 +494,31 @@ tests, not inferential performance comparisons.
 
 ### Responsiveness
 
-The planned conditions are:
+The implemented portable conditions are:
 
 | Condition | Probe | Slow work | Runtime |
 | --- | --- | --- | --- |
-| `R0` | independent | none | none |
-| `R1` | inline | direct synchronous | none |
-| `R2` | independent | direct synchronous | none |
-| `R3` | independent | worker | bounded runtime |
-| `R4` | independent | worker plus invalidation/overflow | bounded runtime |
+| `R0_IDLE` | independent | none | none |
+| `R1_INLINE_SYNC` | inline | direct synchronous | none |
+| `R2_THREADED_SYNC` | independent | direct synchronous | none |
+| `R3_ASYNC` | independent | worker | bounded runtime |
+| `R4_STALE` | independent | non-cooperative worker plus state advance | bounded runtime |
+| `R4_OVERFLOW` | independent | worker plus excess arrivals | bounded runtime |
 
 `R2` separates the benefit of an independent fast timing domain from the
-additional semantics and overhead of the full broker.
+additional semantics and overhead of the full broker. R0--R3 form the primary
+responsiveness decomposition. Stale-result and overflow tests remain separate
+zero-tolerance correctness conditions so their different arrival and
+invalidation patterns do not confound that comparison. R4 uses a claim barrier
+to inject its state change or excess arrivals at a deterministic lifecycle
+location; timings that include this barrier are not used for the direct-versus-
+worker overhead comparison.
+
+Each run records an atomic manifest, scenario facts, an event trace and a
+descriptive summary. A manifest becomes `completed` only after explicit-profile
+replay, condition-specific Gates, artifact hashing and final directory
+validation pass. Pilot summaries are marked descriptive-only and cannot
+authorize a performance claim.
 
 ### Runtime overhead
 

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -1,14 +1,13 @@
 # Phase 1 Asynchronous Runtime Research
 
-This directory contains the host tests, trace recorder, event schema and
-independent lifecycle replay for the Phase 1 asynchronous runtime study. The
-reusable package now includes a bounded single-worker executor, simulated
-adapter and periodic probe. Jetson pilots and Phase 1 performance results have
-not been completed yet.
+This directory contains the host tests, simulated-condition runner, trace
+recorder, event schema, independent lifecycle replay, run validation and
+descriptive summaries for the Phase 1 asynchronous runtime study. Jetson
+pilots and Phase 1 performance results have not been completed yet.
 
 > 中文简介：本目录用于 Phase 1 异步运行时研究。当前已实现 host-only 有界 broker、
-> 单 worker 执行层、100 ms 周期探针和独立 trace replay；尚未开展 Jetson pilot、
-> 真实模型接入或 Phase 1 正式数据采集。
+> 单 worker 执行层、100 ms 周期探针、独立 trace replay 和模拟条件运行器；尚未开展
+> Jetson pilot、真实模型接入或 Phase 1 正式数据采集。
 
 ## Current status
 
@@ -17,8 +16,10 @@ not been completed yet.
 - Host-only task/result model and bounded broker: implemented and tested
 - Observable worker and simulated adapter: implemented and tested
 - Independent periodic probe: implemented and tested
+- Inline synchronous-path probe: implemented and tested
 - Phase 1 schema `0.2.0`, JSONL recorder and lifecycle replay: implemented
-- Jetson simulation pilot: not started
+- Reproducible R0--R4 simulated-condition runner: implemented and host-tested
+- Jetson resource telemetry and simulation pilot: not started
 - Real VLM/ASR/LLM slices: not started
 - Formal Phase 1 data: not collected
 - Physical motion and UART: excluded
@@ -29,19 +30,82 @@ The detailed contract is documented in
 Run the current host-only tests from the repository root:
 
 ```bash
-python3 -m unittest \
-  experiments.phase1.tests.test_model \
-  experiments.phase1.tests.test_broker \
-  experiments.phase1.tests.test_executor \
-  experiments.phase1.tests.test_probe \
-  experiments.phase1.tests.test_trace
+python3 -m unittest discover -s experiments/phase1/tests -p "test_*.py"
 ```
 
 Replay a completed trace without importing the runtime implementation:
 
 ```bash
-python3 -m experiments.phase1.replay_lifecycle /path/to/events.jsonl
+python3 -m experiments.phase1.replay_lifecycle \
+  /path/to/events.jsonl \
+  --profile runtime_threaded_probe
 ```
+
+## Simulated conditions
+
+The portable runner separates fast-path isolation from the additional broker
+semantics:
+
+| Condition | Probe path | Slow work | Purpose |
+| --- | --- | --- | --- |
+| `r0_idle` | independent thread | none | probe and recorder timing baseline |
+| `r1_inline_sync` | caller thread | direct adapter call | blocking synchronous reference |
+| `r2_threaded_sync` | independent thread | direct adapter call | timing-domain isolation without the broker |
+| `r3_async` | independent thread | bounded worker | nominal asynchronous runtime |
+| `r4_stale` | independent thread | worker plus state advance | old-generation result rejection |
+| `r4_overflow` | independent thread | worker plus excess arrivals | bounded overflow behavior |
+
+R0--R3 are the responsiveness decomposition. R4-stale and R4-overflow are
+separate correctness stress conditions; their probe ticks are not pooled into
+the primary responsiveness comparison. R4 uses a short claim barrier so the
+state change or excess arrivals are injected at a deterministic lifecycle
+location. Its task timings are therefore correctness evidence, not runtime-
+overhead measurements.
+
+Use one explicit session ID for conditions that will later be compared:
+
+```bash
+python3 -m experiments.phase1.run_simulation \
+  --condition r1_inline_sync \
+  --service-time-s 2 \
+  --session-id 20260827T120000Z_phase1_simulation_pilot \
+  --repetition 1
+```
+
+The default runner refuses a dirty Git tree. `--allow-dirty` is available for
+development checks only; a run created with that flag is not formal
+reproducibility evidence, and its manifest records the development override
+and formal-evidence eligibility separately. The motion setting must be unset or
+explicitly false. Enabled or unrecognized values fail before a run directory
+is created.
+
+Each run is written beneath the ignored Phase 1 root:
+
+```text
+experiments/runs/phase1-simulation/
+└── <session_id>/
+    └── <condition>/
+        └── <run_id>/
+            ├── manifest.json
+            ├── scenario.json
+            ├── events.jsonl
+            └── summary.json
+```
+
+`manifest.json` moves from `running` to `completed` only after event replay,
+condition-specific Gates, artifact hashing and final directory validation all
+pass. A failed or interrupted attempt remains marked `failed` or `running` and
+cannot be accepted by the validator.
+
+Validate a completed directory independently:
+
+```bash
+python3 -m experiments.phase1.validate_run /path/to/run_dir
+```
+
+The summary reports nearest-rank p50/p95/p99 timing statistics and lifecycle
+counts. It is explicitly marked descriptive-only and cannot be used as a
+formal improvement claim.
 
 ## Planned implementation order
 
@@ -50,11 +114,14 @@ python3 -m experiments.phase1.replay_lifecycle /path/to/events.jsonl
 2. implement and stress-test the host-only runtime kernel — complete;
 3. add the observable worker, periodic probe, Phase 1 event schema, and
    independent trace replay — complete;
-4. run safe simulated loads on the Jetson with `ROBOT_ENABLE_MOTION=0`;
-5. integrate the fixed-input VLM slice;
-6. extend the same adapter/runtime boundary to ASR and LLM;
-7. freeze formal thresholds and collect balanced synchronous/asynchronous data;
-8. add an opt-in motion-disabled application slice after the research Gates
+4. implement the portable R0--R4 simulation protocol and run artifacts —
+   complete;
+5. add Jetson resource telemetry and run the safe simulation pilot with
+   `ROBOT_ENABLE_MOTION=0`;
+6. integrate the fixed-input VLM slice;
+7. extend the same adapter/runtime boundary to ASR and LLM;
+8. freeze formal thresholds and collect balanced synchronous/asynchronous data;
+9. add an opt-in motion-disabled application slice after the research Gates
    pass.
 
 Contract changes are reviewed before implementation, and the formal protocol
@@ -83,17 +150,22 @@ The reusable, hardware-independent kernel lives under
 
 ```text
 experiments/phase1/
+├── manifest.py
+├── run_simulation.py
 ├── schemas/event.schema.json
+├── simulation.py
+├── summarize_run.py
 ├── tests/
 ├── telemetry.py
+├── validate_run.py
 ├── replay_lifecycle.py
 └── README.md
 ```
 
-Future simulation runners, workload adapters, manifests, validation,
-summaries and formal analysis remain experiment-layer work. The executor owns
-all traced broker mutations, while result consumption remains explicit so the
-result-mailbox capacity and second freshness check stay measurable.
+The experiment layer owns condition scheduling, run directories, manifests,
+validation and summaries. The executor continues to own all traced broker
+mutations, while result consumption remains explicit so result-mailbox
+capacity and the second freshness check stay measurable.
 
 The kernel package must remain import-safe on a host without Jetson models,
 camera, microphone, serial device, or NVIDIA tools. Real workload dependencies
@@ -111,6 +183,10 @@ importing runtime classes and proves:
 - no stale, cancelled, superseded, or mismatched result was consumed;
 - shutdown closed all live lifecycle locations;
 - event sequence and monotonic timestamps remained valid.
+
+Replay uses an explicit trace profile. A probe-only condition cannot pass as a
+runtime trace, an inline probe cannot claim a worker join, and a runtime-plus-
+probe condition must close both lifecycles.
 
 Pilot runs are descriptive. Numerical success thresholds, sample sizes,
 condition order, exclusions, and statistical methods are frozen before formal

--- a/experiments/phase1/manifest.py
+++ b/experiments/phase1/manifest.py
@@ -1,0 +1,140 @@
+"""Reproducibility and safety helpers for Phase 1 simulation runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+MANIFEST_SCHEMA_VERSION = "0.1.0"
+_MOTION_TRUE_VALUES = {"1", "true", "yes", "on"}
+_MOTION_FALSE_VALUES = {"", "0", "false", "no", "off"}
+
+
+class SafetyError(RuntimeError):
+    """The process environment does not prove motion is disabled."""
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def motion_environment() -> dict[str, object]:
+    raw = os.environ.get("ROBOT_ENABLE_MOTION")
+    normalized = raw.strip().lower() if raw is not None else None
+    valid = (
+        normalized is None
+        or normalized in _MOTION_TRUE_VALUES
+        or normalized in _MOTION_FALSE_VALUES
+    )
+    enabled = normalized in _MOTION_TRUE_VALUES if normalized is not None else False
+    return {
+        "robot_enable_motion_raw": raw,
+        "motion_enabled": enabled,
+        "motion_value_valid": valid,
+    }
+
+
+def require_motion_disabled() -> dict[str, object]:
+    """Return the captured setting or fail closed before creating a run."""
+
+    safety = motion_environment()
+    if safety["motion_value_valid"] is not True:
+        raise SafetyError("ROBOT_ENABLE_MOTION contains an unrecognized value")
+    if safety["motion_enabled"] is not False:
+        raise SafetyError("Phase 1 simulation refuses to run with motion enabled")
+    return safety
+
+
+def sha256_file(path: Path | str) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_json_atomic(path: Path | str, data: dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(target.name + ".tmp")
+    temporary.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, target)
+
+
+def _command_snapshot(
+    command: list[str],
+    *,
+    cwd: Path | str | None = None,
+    timeout_s: float = 5.0,
+) -> dict[str, object]:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=str(cwd) if cwd is not None else None,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "returncode": None,
+            "output": "",
+            "error_code": type(exc).__name__.lower(),
+        }
+    return {
+        "returncode": result.returncode,
+        "output": result.stdout.strip(),
+        "error_code": None,
+    }
+
+
+def git_snapshot(repo_root: Path | str) -> dict[str, object]:
+    root = Path(repo_root)
+    commit = _command_snapshot(["git", "rev-parse", "HEAD"], cwd=root)
+    branch = _command_snapshot(["git", "branch", "--show-current"], cwd=root)
+    status = _command_snapshot(["git", "status", "--porcelain"], cwd=root)
+    status_output = status["output"] if isinstance(status["output"], str) else ""
+    return {
+        "commit": commit["output"],
+        "branch": branch["output"],
+        "dirty": bool(status_output),
+        "status_porcelain": status_output.splitlines(),
+        "error_codes": [
+            value
+            for value in (
+                commit["error_code"],
+                branch["error_code"],
+                status["error_code"],
+            )
+            if value is not None
+        ],
+    }
+
+
+def collect_environment(repo_root: Path | str) -> dict[str, object]:
+    l4t_path = Path("/etc/nv_tegra_release")
+    l4t_release = ""
+    if l4t_path.is_file():
+        l4t_release = l4t_path.read_text(encoding="utf-8", errors="replace").strip()
+    return {
+        "captured_at": utc_now_iso(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "python": sys.version.split()[0],
+        "l4t_release": l4t_release,
+        "git": git_snapshot(repo_root),
+    }

--- a/experiments/phase1/replay_lifecycle.py
+++ b/experiments/phase1/replay_lifecycle.py
@@ -9,6 +9,7 @@ import re
 import sys
 from collections import Counter
 from dataclasses import asdict, dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Iterable, Mapping
 
@@ -65,6 +66,15 @@ class ReplayError(ValueError):
     """A trace cannot represent a legal bounded runtime history."""
 
 
+class TraceProfile(str, Enum):
+    """Explicit completion contract for one Phase 1 trace."""
+
+    RUNTIME = "runtime"
+    RUNTIME_THREADED_PROBE = "runtime_threaded_probe"
+    THREADED_PROBE = "threaded_probe"
+    INLINE_PROBE = "inline_probe"
+
+
 @dataclass(slots=True)
 class _ReplayTask:
     admitted: bool
@@ -84,6 +94,7 @@ class _ReplayTask:
 @dataclass(frozen=True, slots=True)
 class ReplaySummary:
     run_id: str
+    trace_profile: str
     event_count: int
     submission_attempts: int
     admitted_total: int
@@ -97,6 +108,8 @@ class ReplaySummary:
     probe_deadline_miss_count: int
     disposition_counts: tuple[tuple[str, int], ...]
     worker_joined: bool
+    probe_stopped: bool
+    probe_joined: bool
     final_broker_state: str | None
 
 
@@ -163,12 +176,15 @@ class _LifecycleReplay:
         self.broker_state = "open"
         self.worker_error = False
         self.probe_started = False
+        self.probe_stopped = False
         self.probe_joined = False
+        self.probe_join_event_seen = False
         self.probe_error = False
         self.probe_period_ns: int | None = None
         self.probe_deadline_ns: int | None = None
         self.probe_previous_started_ns: int | None = None
         self.probe_skipped_releases = 0
+        self.runtime_event_seen = False
 
     def _depths(self) -> tuple[int, int, int]:
         pending = sum(task.location == "queued" for task in self.tasks.values())
@@ -367,6 +383,11 @@ class _LifecycleReplay:
         if ("state_scope_id" in event) != ("state_generation" in event):
             raise ReplayError("state scope and generation must be recorded together")
 
+        if event_name.startswith(
+            ("task.", "result.", "state.", "shutdown.", "worker.")
+        ):
+            self.runtime_event_seen = True
+
         if event_name in {"task.enqueued", "task.rejected"}:
             task_id = _require_str(event, "task_id")
             if task_id in self.tasks:
@@ -556,14 +577,26 @@ class _LifecycleReplay:
             self.probe_skipped_releases += skipped
 
         elif event_name == "probe.stopped":
+            if not self.probe_started:
+                raise ReplayError("probe.stopped appeared before probe.started")
+            if self.probe_stopped:
+                raise ReplayError("probe.stopped appeared more than once")
             if _require_int(details, "tick_count") != self.probe_ticks:
                 raise ReplayError("probe stopped with an inconsistent tick count")
             if _require_int(details, "skipped_releases") != self.probe_skipped_releases:
                 raise ReplayError("probe stopped with an inconsistent skip count")
             if _require_int(details, "deadline_miss_count") != self.probe_misses:
                 raise ReplayError("probe stopped with an inconsistent miss count")
+            if details.get("error_code") is not None:
+                self.probe_error = True
+            self.probe_stopped = True
 
         elif event_name == "probe.joined":
+            if not self.probe_stopped:
+                raise ReplayError("probe.joined appeared before probe.stopped")
+            if self.probe_join_event_seen:
+                raise ReplayError("probe.joined appeared more than once")
+            self.probe_join_event_seen = True
             if details.get("joined") is True:
                 self.probe_joined = True
             if details.get("error_code") is not None:
@@ -652,7 +685,13 @@ class _LifecycleReplay:
 
         self._check_depths(details)
 
-    def finish(self, event_count: int, *, require_complete: bool) -> ReplaySummary:
+    def finish(
+        self,
+        event_count: int,
+        *,
+        require_complete: bool,
+        profile: TraceProfile,
+    ) -> ReplaySummary:
         terminal_admitted = sum(
             task.admitted and task.location == _TERMINAL for task in self.tasks.values()
         )
@@ -663,7 +702,16 @@ class _LifecycleReplay:
             raise ReplayError("terminal task is missing a final disposition")
         if sum(self.dispositions.values()) != len(terminal_tasks):
             raise ReplayError("final disposition accounting does not close")
-        if require_complete:
+        runtime_profile = profile in {
+            TraceProfile.RUNTIME,
+            TraceProfile.RUNTIME_THREADED_PROBE,
+        }
+        if runtime_profile and not self.runtime_event_seen:
+            raise ReplayError("runtime trace profile contains no runtime events")
+        if not runtime_profile and self.runtime_event_seen:
+            raise ReplayError("probe-only trace contains runtime lifecycle events")
+
+        if require_complete and runtime_profile:
             if not self.shutdown_seen:
                 raise ReplayError("complete trace is missing shutdown.requested")
             if not self.worker_stopped or not self.worker_joined:
@@ -679,13 +727,30 @@ class _LifecycleReplay:
                 raise ReplayError("complete trace did not close the broker")
             if self.worker_error:
                 raise ReplayError("complete trace contains a runtime worker error")
-            if self.probe_started and not self.probe_joined:
+        if require_complete:
+            probe_required = profile in {
+                TraceProfile.RUNTIME_THREADED_PROBE,
+                TraceProfile.THREADED_PROBE,
+                TraceProfile.INLINE_PROBE,
+            }
+            if probe_required and not self.probe_started:
+                raise ReplayError("trace profile requires a periodic probe")
+            if self.probe_started and not self.probe_stopped:
+                raise ReplayError("complete trace is missing probe.stopped")
+            threaded_probe_expected = profile in {
+                TraceProfile.RUNTIME_THREADED_PROBE,
+                TraceProfile.THREADED_PROBE,
+            } or (profile is TraceProfile.RUNTIME and self.probe_started)
+            if threaded_probe_expected and not self.probe_joined:
                 raise ReplayError("complete trace is missing a successful probe join")
+            if profile is TraceProfile.INLINE_PROBE and self.probe_join_event_seen:
+                raise ReplayError("inline probe trace must not contain probe.joined")
             if self.probe_error:
                 raise ReplayError("complete trace contains a periodic probe error")
         assert self.run_id is not None
         return ReplaySummary(
             run_id=self.run_id,
+            trace_profile=profile.value,
             event_count=event_count,
             submission_attempts=self.submission_attempts,
             admitted_total=self.admitted_total,
@@ -699,6 +764,8 @@ class _LifecycleReplay:
             probe_deadline_miss_count=self.probe_misses,
             disposition_counts=tuple(sorted(self.dispositions.items())),
             worker_joined=self.worker_joined,
+            probe_stopped=self.probe_stopped,
+            probe_joined=self.probe_joined,
             final_broker_state=self.final_broker_state,
         )
 
@@ -707,9 +774,12 @@ def replay_events(
     events: Iterable[Mapping[str, object]],
     *,
     require_complete: bool = True,
+    profile: TraceProfile = TraceProfile.RUNTIME,
 ) -> ReplaySummary:
     """Reconstruct one trace using only serialized public event fields."""
 
+    if not isinstance(profile, TraceProfile):
+        raise TypeError("profile must be a TraceProfile")
     replay = _LifecycleReplay()
     count = 0
     for count, event in enumerate(events, start=1):
@@ -718,15 +788,24 @@ def replay_events(
         replay.apply(event, count - 1)
     if count == 0:
         raise ReplayError("trace must contain at least one event")
-    return replay.finish(count, require_complete=require_complete)
+    return replay.finish(
+        count,
+        require_complete=require_complete,
+        profile=profile,
+    )
 
 
 def replay_file(
     path: Path | str,
     *,
     require_complete: bool = True,
+    profile: TraceProfile = TraceProfile.RUNTIME,
 ) -> ReplaySummary:
-    return replay_events(load_events(path), require_complete=require_complete)
+    return replay_events(
+        load_events(path),
+        require_complete=require_complete,
+        profile=profile,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -739,11 +818,18 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="validate the recorded prefix without requiring closed shutdown",
     )
+    parser.add_argument(
+        "--profile",
+        choices=[profile.value for profile in TraceProfile],
+        default=TraceProfile.RUNTIME.value,
+        help="explicit lifecycle contract for the recorded condition",
+    )
     args = parser.parse_args(argv)
     try:
         summary = replay_file(
             args.events,
             require_complete=not args.allow_incomplete,
+            profile=TraceProfile(args.profile),
         )
     except (OSError, ReplayError) as exc:
         print(f"INVALID: {exc}", file=sys.stderr)

--- a/experiments/phase1/run_simulation.py
+++ b/experiments/phase1/run_simulation.py
@@ -1,0 +1,265 @@
+"""Run one safe and reproducible Phase 1 simulated-load condition."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from experiments.phase1.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    collect_environment,
+    require_motion_disabled,
+    sha256_file,
+    utc_now_iso,
+    write_json_atomic,
+)
+from experiments.phase1.simulation import (
+    ScenarioSpec,
+    SimulationCondition,
+    run_simulation,
+)
+from experiments.phase1.summarize_run import build_summary
+from experiments.phase1.telemetry import EventRecorder, SCHEMA_VERSION
+from experiments.phase1.validate_run import validate_run_dir
+
+
+_SESSION_ID_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z_phase1_[a-z][a-z0-9_-]{0,47}$")
+
+
+class RunError(RuntimeError):
+    """The simulation could not produce a complete validated run."""
+
+
+def make_run_id(
+    condition: SimulationCondition,
+    repetition: int,
+    *,
+    now: datetime | None = None,
+) -> str:
+    if not isinstance(condition, SimulationCondition):
+        raise TypeError("condition must be a SimulationCondition")
+    if (
+        isinstance(repetition, bool)
+        or not isinstance(repetition, int)
+        or not 0 <= repetition <= 999
+    ):
+        raise ValueError("repetition must be an integer from 0 to 999")
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    stamp = current.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}_phase1_{condition.value}_simulated_{repetition:03d}"
+
+
+def make_session_id(now: datetime | None = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    stamp = current.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}_phase1_simulation"
+
+
+def _validate_session_id(value: str) -> str:
+    if not isinstance(value, str) or not _SESSION_ID_RE.fullmatch(value):
+        raise ValueError(
+            "session_id must use YYYYMMDDTHHMMSSZ_phase1_<lowercase-label>"
+        )
+    return value
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _validate_output_root(output_root: Path, repo_root: Path) -> Path:
+    expanded = output_root.expanduser()
+    resolved = (expanded if expanded.is_absolute() else repo_root / expanded).resolve()
+    phase0_source = (repo_root / "experiments" / "phase0").resolve()
+    if _is_relative_to(resolved, phase0_source):
+        raise RunError("Phase 1 output root must not be inside experiments/phase0")
+    return resolved
+
+
+def _artifact_identity(path: Path) -> dict[str, object]:
+    return {
+        "size_bytes": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
+
+
+def run_once(
+    args: argparse.Namespace,
+    *,
+    repo_root: Path | str | None = None,
+) -> Path:
+    root = (
+        Path(repo_root).resolve()
+        if repo_root is not None
+        else Path(__file__).resolve().parents[2]
+    )
+    condition = SimulationCondition(args.condition)
+    session_id = _validate_session_id(args.session_id or make_session_id())
+    safety = require_motion_disabled()
+    environment = collect_environment(root)
+    git = environment.get("git")
+    if not args.allow_dirty:
+        if (
+            not isinstance(git, dict)
+            or git.get("error_codes")
+            or not git.get("commit")
+            or not git.get("branch")
+        ):
+            raise RunError("a clean Git identity is required for a reproducibility run")
+        if git.get("dirty") is True:
+            raise RunError("refusing to record a reproducibility run from a dirty tree")
+    git_identity_complete = (
+        isinstance(git, dict)
+        and not git.get("error_codes")
+        and bool(git.get("commit"))
+        and bool(git.get("branch"))
+    )
+    git_clean = git_identity_complete and git.get("dirty") is False
+
+    spec = ScenarioSpec(
+        condition=condition,
+        service_time_s=args.service_time_s,
+        prelude_s=args.prelude_s,
+        postlude_s=args.postlude_s,
+        probe_period_ns=int(args.probe_period_ms * 1_000_000),
+        probe_deadline_ns=int(args.probe_deadline_ms * 1_000_000),
+        pending_capacity=args.pending_capacity,
+        result_capacity=args.result_capacity,
+        overflow_submissions=args.overflow_submissions,
+        adapter_poll_interval_s=args.adapter_poll_interval_s,
+        join_timeout_s=args.join_timeout_s,
+    )
+    run_id = make_run_id(condition, args.repetition)
+    output_root = _validate_output_root(Path(args.output_root), root)
+    run_dir = output_root / session_id / condition.value / run_id
+    if run_dir.exists():
+        raise FileExistsError(f"refusing to overwrite existing run: {run_dir}")
+    run_dir.mkdir(parents=True)
+
+    manifest_path = run_dir / "manifest.json"
+    manifest: dict[str, object] = {
+        "manifest_schema_version": MANIFEST_SCHEMA_VERSION,
+        "event_schema_version": SCHEMA_VERSION,
+        "artifact_kind": "phase1_simulation_run",
+        "run_id": run_id,
+        "session_id": session_id,
+        "condition": condition.value,
+        "trace_profile": spec.trace_profile.value,
+        "status": "running",
+        "created_at": utc_now_iso(),
+        "completed_at": None,
+        "descriptive_only": True,
+        "safety": safety,
+        "environment": environment,
+        "reproducibility": {
+            "git_identity_complete": git_identity_complete,
+            "git_clean": git_clean,
+            "development_override": args.allow_dirty,
+            "formal_evidence_eligible": (git_clean and not args.allow_dirty),
+        },
+        "spec": spec.to_dict(),
+        "artifacts": {},
+        "failure_code": None,
+    }
+    write_json_atomic(manifest_path, manifest)
+
+    recorder: EventRecorder | None = None
+    try:
+        recorder = EventRecorder(run_dir, run_id)
+        report = run_simulation(spec, recorder)
+        recorder.close()
+        recorder = None
+
+        scenario = {"spec": spec.to_dict(), "report": report.to_dict()}
+        scenario_path = run_dir / "scenario.json"
+        write_json_atomic(scenario_path, scenario)
+        summary = build_summary(
+            run_dir / "events.jsonl",
+            condition=condition,
+            profile=spec.trace_profile,
+            scenario_report=report.to_dict(),
+            spec=spec.to_dict(),
+        )
+        summary_path = run_dir / "summary.json"
+        write_json_atomic(summary_path, summary)
+        if summary.get("valid") is not True:
+            raise RunError("one or more condition Gates failed")
+
+        manifest["artifacts"] = {
+            name: _artifact_identity(run_dir / name)
+            for name in ("events.jsonl", "scenario.json", "summary.json")
+        }
+        manifest["status"] = "completed"
+        manifest["completed_at"] = utc_now_iso()
+        write_json_atomic(manifest_path, manifest)
+
+        validation_errors = validate_run_dir(run_dir)
+        if validation_errors:
+            raise RunError("final validation failed: " + "; ".join(validation_errors))
+    except Exception as exc:
+        if recorder is not None:
+            recorder.close()
+        manifest["status"] = "failed"
+        manifest["completed_at"] = utc_now_iso()
+        manifest["failure_code"] = type(exc).__name__.lower()
+        write_json_atomic(manifest_path, manifest)
+        raise
+    return run_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--condition",
+        choices=[condition.value for condition in SimulationCondition],
+        required=True,
+    )
+    parser.add_argument("--service-time-s", type=float, required=True)
+    parser.add_argument("--prelude-s", type=float, default=0.2)
+    parser.add_argument("--postlude-s", type=float, default=0.2)
+    parser.add_argument("--probe-period-ms", type=float, default=100.0)
+    parser.add_argument("--probe-deadline-ms", type=float, default=100.0)
+    parser.add_argument("--pending-capacity", type=int, default=1)
+    parser.add_argument("--result-capacity", type=int, default=1)
+    parser.add_argument("--overflow-submissions", type=int, default=2)
+    parser.add_argument("--adapter-poll-interval-s", type=float, default=0.01)
+    parser.add_argument("--join-timeout-s", type=float, default=5.0)
+    parser.add_argument("--session-id")
+    parser.add_argument("--repetition", type=int, default=1)
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("experiments/runs/phase1-simulation"),
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="permit development runs that are not formal reproducibility evidence",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        run_dir = run_once(args)
+    except Exception as exc:
+        print(f"FAILED: {exc}", file=sys.stderr)
+        return 2
+    print(run_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/phase1/simulation.py
+++ b/experiments/phase1/simulation.py
@@ -1,0 +1,810 @@
+"""Condition orchestration for the Phase 1 simulated-load protocol."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import threading
+import time
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Callable
+
+from experiments.phase1.replay_lifecycle import TraceProfile
+from jetson.phase1_runtime import (
+    BoundedTaskBroker,
+    BrokerSnapshot,
+    CancellationToken,
+    ClaimedTask,
+    EventStatus,
+    ExecutorShutdownReport,
+    LaneConfig,
+    ObservableExecutor,
+    OverflowPolicy,
+    PayloadRef,
+    PeriodicProbe,
+    ProbeStopReport,
+    ResultEnvelope,
+    RuntimeEvent,
+    RuntimeEventSink,
+    SimulatedAdapter,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+    build_probe_tick,
+    select_release,
+)
+
+
+_SIMULATED_PAYLOAD_SHA256 = hashlib.sha256(
+    b"phase1-simulated-bounded-payload-v1"
+).hexdigest()
+
+
+class SimulationCondition(str, Enum):
+    """Conditions that separate timing isolation from runtime semantics."""
+
+    R0_IDLE = "r0_idle"
+    R1_INLINE_SYNC = "r1_inline_sync"
+    R2_THREADED_SYNC = "r2_threaded_sync"
+    R3_ASYNC = "r3_async"
+    R4_STALE = "r4_stale"
+    R4_OVERFLOW = "r4_overflow"
+
+    @property
+    def trace_profile(self) -> TraceProfile:
+        if self is SimulationCondition.R1_INLINE_SYNC:
+            return TraceProfile.INLINE_PROBE
+        if self in {
+            SimulationCondition.R0_IDLE,
+            SimulationCondition.R2_THREADED_SYNC,
+        }:
+            return TraceProfile.THREADED_PROBE
+        return TraceProfile.RUNTIME_THREADED_PROBE
+
+    @property
+    def uses_runtime(self) -> bool:
+        return self in {
+            SimulationCondition.R3_ASYNC,
+            SimulationCondition.R4_STALE,
+            SimulationCondition.R4_OVERFLOW,
+        }
+
+
+def _finite_seconds(value: object, name: str, *, positive: bool = False) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+        or (positive and value == 0)
+    ):
+        qualifier = "positive" if positive else "non-negative"
+        raise ValueError(f"{name} must be a finite {qualifier} number")
+    return float(value)
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioSpec:
+    """One immutable simulated condition with an explicit timing budget."""
+
+    condition: SimulationCondition
+    service_time_s: float
+    prelude_s: float = 0.2
+    postlude_s: float = 0.2
+    probe_period_ns: int = 100_000_000
+    probe_deadline_ns: int = 100_000_000
+    pending_capacity: int = 1
+    result_capacity: int = 1
+    overflow_submissions: int = 2
+    adapter_poll_interval_s: float = 0.01
+    join_timeout_s: float = 5.0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.condition, SimulationCondition):
+            raise TypeError("condition must be a SimulationCondition")
+        service = _finite_seconds(self.service_time_s, "service_time_s")
+        prelude = _finite_seconds(self.prelude_s, "prelude_s")
+        postlude = _finite_seconds(self.postlude_s, "postlude_s")
+        poll_interval = _finite_seconds(
+            self.adapter_poll_interval_s,
+            "adapter_poll_interval_s",
+            positive=True,
+        )
+        join_timeout = _finite_seconds(
+            self.join_timeout_s, "join_timeout_s", positive=True
+        )
+        for value, name, upper in (
+            (service, "service_time_s", 3600.0),
+            (prelude, "prelude_s", 3600.0),
+            (postlude, "postlude_s", 3600.0),
+            (poll_interval, "adapter_poll_interval_s", 1.0),
+            (join_timeout, "join_timeout_s", 3600.0),
+        ):
+            if value > upper:
+                raise ValueError(f"{name} must not exceed {upper}")
+        for value, name in (
+            (self.probe_period_ns, "probe_period_ns"),
+            (self.probe_deadline_ns, "probe_deadline_ns"),
+            (self.pending_capacity, "pending_capacity"),
+            (self.result_capacity, "result_capacity"),
+            (self.overflow_submissions, "overflow_submissions"),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if (
+            self.condition
+            in {
+                SimulationCondition.R4_STALE,
+                SimulationCondition.R4_OVERFLOW,
+            }
+            and service == 0
+        ):
+            raise ValueError("R4 conditions require a positive service time")
+
+    @property
+    def trace_profile(self) -> TraceProfile:
+        return self.condition.trace_profile
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "condition": self.condition.value,
+            "trace_profile": self.trace_profile.value,
+            "service_time_s": self.service_time_s,
+            "prelude_s": self.prelude_s,
+            "postlude_s": self.postlude_s,
+            "probe_period_ns": self.probe_period_ns,
+            "probe_deadline_ns": self.probe_deadline_ns,
+            "pending_capacity": self.pending_capacity,
+            "result_capacity": self.result_capacity,
+            "overflow_submissions": self.overflow_submissions,
+            "adapter_poll_interval_s": self.adapter_poll_interval_s,
+            "join_timeout_s": self.join_timeout_s,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class InlineProbeReport:
+    tick_count: int
+    skipped_releases: int
+    deadline_miss_count: int
+    max_lateness_ns: int
+    max_gap_ns: int
+    error_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DirectWorkloadReport:
+    task_id: str
+    started_monotonic_ns: int
+    finished_monotonic_ns: int
+    execution_outcome: str
+    cancellation_requested: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationReport:
+    condition: str
+    trace_profile: str
+    started_monotonic_ns: int
+    finished_monotonic_ns: int
+    direct_workload: DirectWorkloadReport | None
+    probe: InlineProbeReport | ProbeStopReport
+    runtime: dict[str, object] | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "condition": self.condition,
+            "trace_profile": self.trace_profile,
+            "started_monotonic_ns": self.started_monotonic_ns,
+            "finished_monotonic_ns": self.finished_monotonic_ns,
+            "duration_ns": self.finished_monotonic_ns - self.started_monotonic_ns,
+            "direct_workload": (
+                None if self.direct_workload is None else asdict(self.direct_workload)
+            ),
+            "probe": asdict(self.probe),
+            "runtime": self.runtime,
+        }
+
+
+class InlineProbe:
+    """Advance an absolute probe schedule on the calling thread."""
+
+    def __init__(
+        self,
+        *,
+        period_ns: int,
+        deadline_ns: int,
+        event_sink: RuntimeEventSink,
+        work: Callable[[], None] | None = None,
+        clock_ns: Callable[[], int] = time.monotonic_ns,
+        wait: Callable[[float], None] = time.sleep,
+    ) -> None:
+        for value, name in (
+            (period_ns, "period_ns"),
+            (deadline_ns, "deadline_ns"),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if not callable(getattr(event_sink, "emit", None)):
+            raise TypeError("event_sink must provide emit(event)")
+        if not callable(clock_ns) or not callable(wait):
+            raise TypeError("clock_ns and wait must be callable")
+        self.period_ns = period_ns
+        self.deadline_ns = deadline_ns
+        self._event_sink = event_sink
+        self._work = work or (lambda: None)
+        self._clock_ns = clock_ns
+        self._wait = wait
+        self._origin_ns: int | None = None
+        self._next_index = 0
+        self._previous_started_ns: int | None = None
+        self._tick_count = 0
+        self._skipped_releases = 0
+        self._deadline_miss_count = 0
+        self._max_lateness_ns = 0
+        self._max_gap_ns = 0
+        self._stopped = False
+
+    def _emit(
+        self,
+        event: str,
+        status: EventStatus,
+        details: dict[str, str | int | float | bool | None],
+    ) -> None:
+        self._event_sink.emit(
+            RuntimeEvent(
+                event=event,
+                component="probe",
+                status=status,
+                details=details,
+            )
+        )
+
+    def start(self) -> None:
+        if self._origin_ns is not None:
+            raise RuntimeError("inline probe has already been started")
+        self._origin_ns = self._clock_ns()
+        self._emit(
+            "probe.started",
+            EventStatus.STARTED,
+            {
+                "origin_monotonic_ns": self._origin_ns,
+                "period_ns": self.period_ns,
+                "deadline_ns": self.deadline_ns,
+                "thread_name": "phase1-inline-probe",
+            },
+        )
+
+    def _wait_until(self, target_ns: int) -> None:
+        while True:
+            remaining_ns = target_ns - self._clock_ns()
+            if remaining_ns <= 0:
+                return
+            self._wait(remaining_ns / 1_000_000_000)
+
+    def run_until(self, end_monotonic_ns: int) -> None:
+        if self._origin_ns is None or self._stopped:
+            raise RuntimeError("inline probe is not running")
+        if (
+            isinstance(end_monotonic_ns, bool)
+            or not isinstance(end_monotonic_ns, int)
+            or end_monotonic_ns < self._origin_ns
+        ):
+            raise ValueError("end_monotonic_ns must not precede probe start")
+
+        while True:
+            scheduled = self._origin_ns + self._next_index * self.period_ns
+            if scheduled > end_monotonic_ns:
+                return
+            self._wait_until(scheduled)
+            observed_start = self._clock_ns()
+            selected_index, selected_release, skipped = select_release(
+                self._origin_ns,
+                self._next_index,
+                observed_start,
+                self.period_ns,
+            )
+            if selected_release > end_monotonic_ns:
+                return
+            if skipped:
+                self._emit(
+                    "probe.skipped",
+                    EventStatus.DROPPED,
+                    {
+                        "from_index": self._next_index,
+                        "to_index": selected_index,
+                        "skipped_releases": skipped,
+                        "observed_monotonic_ns": observed_start,
+                    },
+                )
+            started = self._clock_ns()
+            self._work()
+            finished = self._clock_ns()
+            tick = build_probe_tick(
+                index=selected_index,
+                scheduled_ns=selected_release,
+                started_ns=started,
+                finished_ns=finished,
+                previous_started_ns=self._previous_started_ns,
+                period_ns=self.period_ns,
+                deadline_ns=self.deadline_ns,
+                skipped_releases=skipped,
+            )
+            self._emit(
+                "probe.tick",
+                EventStatus.TIMEOUT if tick.deadline_miss else EventStatus.OK,
+                {
+                    "tick_index": tick.index,
+                    "scheduled_monotonic_ns": tick.scheduled_monotonic_ns,
+                    "started_monotonic_ns": tick.started_monotonic_ns,
+                    "finished_monotonic_ns": tick.finished_monotonic_ns,
+                    "start_lateness_ns": tick.start_lateness_ns,
+                    "execution_ns": tick.execution_ns,
+                    "actual_period_ns": tick.actual_period_ns,
+                    "signed_period_error_ns": tick.signed_period_error_ns,
+                    "absolute_period_error_ns": tick.absolute_period_error_ns,
+                    "skipped_releases": tick.skipped_releases,
+                    "deadline_miss": tick.deadline_miss,
+                },
+            )
+            self._tick_count += 1
+            self._skipped_releases += skipped
+            self._deadline_miss_count += int(tick.deadline_miss)
+            self._max_lateness_ns = max(self._max_lateness_ns, tick.start_lateness_ns)
+            if tick.actual_period_ns is not None:
+                self._max_gap_ns = max(self._max_gap_ns, tick.actual_period_ns)
+            self._previous_started_ns = started
+            self._next_index = selected_index + 1
+
+    def stop(self) -> InlineProbeReport:
+        if self._origin_ns is None or self._stopped:
+            raise RuntimeError("inline probe is not running")
+        self._stopped = True
+        report = InlineProbeReport(
+            tick_count=self._tick_count,
+            skipped_releases=self._skipped_releases,
+            deadline_miss_count=self._deadline_miss_count,
+            max_lateness_ns=self._max_lateness_ns,
+            max_gap_ns=self._max_gap_ns,
+        )
+        self._emit(
+            "probe.stopped",
+            EventStatus.OK,
+            {
+                "tick_count": report.tick_count,
+                "skipped_releases": report.skipped_releases,
+                "deadline_miss_count": report.deadline_miss_count,
+                "max_lateness_ns": report.max_lateness_ns,
+                "max_gap_ns": report.max_gap_ns,
+                "error_code": report.error_code,
+            },
+        )
+        return report
+
+
+def _make_task(
+    task_id: str,
+    *,
+    generation: int,
+    service_time_s: float,
+    postlude_s: float,
+) -> TaskEnvelope:
+    now = time.monotonic_ns()
+    validity_s = max(1.0, service_time_s * 2 + postlude_s + 1.0)
+    return TaskEnvelope(
+        task_id=task_id,
+        task_kind=TaskKind.SIMULATED,
+        source_monotonic_ns=now,
+        created_monotonic_ns=now,
+        deadline_monotonic_ns=now + int(validity_s * 1_000_000_000),
+        state_token=StateToken("simulation", generation),
+        payload=PayloadRef(
+            ref="simulation://bounded-payload-v1",
+            sha256=_SIMULATED_PAYLOAD_SHA256,
+            size_bytes=34,
+            media_type="application/octet-stream",
+        ),
+        supersession_key="simulation-latest",
+        metadata={"protocol": "phase1b1"},
+    )
+
+
+def _run_direct(
+    spec: ScenarioSpec,
+    adapter: SimulatedAdapter,
+) -> DirectWorkloadReport:
+    task = _make_task(
+        "direct-001",
+        generation=0,
+        service_time_s=spec.service_time_s,
+        postlude_s=spec.postlude_s,
+    )
+    started = time.monotonic_ns()
+    result: ResultEnvelope = adapter(
+        ClaimedTask(
+            task=task,
+            cancellation_token=CancellationToken(),
+            started_monotonic_ns=started,
+        )
+    )
+    return DirectWorkloadReport(
+        task_id=task.task_id,
+        started_monotonic_ns=result.started_monotonic_ns,
+        finished_monotonic_ns=result.finished_monotonic_ns,
+        execution_outcome=result.execution_outcome.value,
+        cancellation_requested=result.cancellation_report.requested,
+    )
+
+
+def _sleep(seconds: float) -> None:
+    if seconds > 0:
+        threading.Event().wait(seconds)
+
+
+def _wait_for(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float,
+    description: str,
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        threading.Event().wait(0.001)
+    raise TimeoutError(f"timed out waiting for {description}")
+
+
+def _snapshot_dict(snapshot: BrokerSnapshot) -> dict[str, object]:
+    return {
+        "state": snapshot.state.value,
+        "submission_attempts": snapshot.submission_attempts,
+        "admitted_total": snapshot.admitted_total,
+        "rejected_at_ingress_total": snapshot.rejected_at_ingress_total,
+        "queued": snapshot.queued,
+        "running": snapshot.running,
+        "result_pending": snapshot.result_pending,
+        "terminal_admitted_total": snapshot.terminal_admitted_total,
+        "max_pending_depth": snapshot.max_pending_depth,
+        "max_result_depth": snapshot.max_result_depth,
+        "accounting_holds": snapshot.accounting_holds,
+        "disposition_counts": {
+            disposition.value: count
+            for disposition, count in snapshot.disposition_counts
+        },
+    }
+
+
+def _shutdown_dict(report: ExecutorShutdownReport) -> dict[str, object]:
+    return {
+        "complete": report.complete,
+        "broker_state": report.broker_state.value,
+        "joined": report.joined,
+        "join_latency_ns": report.join_latency_ns,
+        "queued_ids": list(report.queued_ids),
+        "active_id": report.active_id,
+        "result_pending_ids": list(report.result_pending_ids),
+        "active_cancellation_requested": report.active_cancellation_requested,
+        "worker_error_code": report.worker_error_code,
+        "event_error_code": report.event_error_code,
+    }
+
+
+def _make_runtime(
+    spec: ScenarioSpec,
+    event_sink: RuntimeEventSink,
+    *,
+    observe_cancellation: bool,
+    overflow_policy: OverflowPolicy = OverflowPolicy.REJECT_NEW,
+    start_gate: threading.Event | None = None,
+) -> tuple[ObservableExecutor, PeriodicProbe, threading.Event]:
+    broker = BoundedTaskBroker(
+        LaneConfig(
+            task_kind=TaskKind.SIMULATED,
+            pending_capacity=spec.pending_capacity,
+            result_capacity=spec.result_capacity,
+            overflow_policy=overflow_policy,
+        )
+    )
+    adapter = SimulatedAdapter(
+        spec.service_time_s,
+        observe_cancellation=observe_cancellation,
+        poll_interval_s=spec.adapter_poll_interval_s,
+    )
+    adapter_started = threading.Event()
+
+    def observed_adapter(claimed: ClaimedTask) -> ResultEnvelope:
+        adapter_started.set()
+        if start_gate is not None and not start_gate.wait(spec.join_timeout_s):
+            raise TimeoutError("simulation start gate was not released")
+        return adapter(claimed)
+
+    executor = ObservableExecutor(broker, observed_adapter, event_sink=event_sink)
+    probe = PeriodicProbe(
+        period_ns=spec.probe_period_ns,
+        deadline_ns=spec.probe_deadline_ns,
+        event_sink=event_sink,
+    )
+    return executor, probe, adapter_started
+
+
+def _runtime_report(
+    executor: ObservableExecutor,
+    shutdown: ExecutorShutdownReport,
+) -> dict[str, object]:
+    return {
+        "shutdown": _shutdown_dict(shutdown),
+        "final_snapshot": _snapshot_dict(executor.snapshot()),
+    }
+
+
+def _run_idle(
+    spec: ScenarioSpec,
+    event_sink: RuntimeEventSink,
+) -> tuple[None, ProbeStopReport, None]:
+    probe = PeriodicProbe(
+        period_ns=spec.probe_period_ns,
+        deadline_ns=spec.probe_deadline_ns,
+        event_sink=event_sink,
+    )
+    probe.start()
+    try:
+        _sleep(spec.prelude_s + spec.service_time_s + spec.postlude_s)
+    finally:
+        report = probe.stop(join_timeout_s=spec.join_timeout_s)
+    if not report.joined:
+        raise RuntimeError("periodic probe did not join")
+    return None, report, None
+
+
+def _run_inline_sync(
+    spec: ScenarioSpec,
+    event_sink: RuntimeEventSink,
+) -> tuple[DirectWorkloadReport, InlineProbeReport, None]:
+    adapter = SimulatedAdapter(
+        spec.service_time_s,
+        poll_interval_s=spec.adapter_poll_interval_s,
+    )
+    probe = InlineProbe(
+        period_ns=spec.probe_period_ns,
+        deadline_ns=spec.probe_deadline_ns,
+        event_sink=event_sink,
+    )
+    probe.start()
+    prelude_end = time.monotonic_ns() + int(spec.prelude_s * 1_000_000_000)
+    probe.run_until(prelude_end)
+    direct = _run_direct(spec, adapter)
+    postlude_end = time.monotonic_ns() + int(spec.postlude_s * 1_000_000_000)
+    probe.run_until(postlude_end)
+    return direct, probe.stop(), None
+
+
+def _run_threaded_sync(
+    spec: ScenarioSpec,
+    event_sink: RuntimeEventSink,
+) -> tuple[DirectWorkloadReport, ProbeStopReport, None]:
+    adapter = SimulatedAdapter(
+        spec.service_time_s,
+        poll_interval_s=spec.adapter_poll_interval_s,
+    )
+    probe = PeriodicProbe(
+        period_ns=spec.probe_period_ns,
+        deadline_ns=spec.probe_deadline_ns,
+        event_sink=event_sink,
+    )
+    probe.start()
+    try:
+        _sleep(spec.prelude_s)
+        direct = _run_direct(spec, adapter)
+        _sleep(spec.postlude_s)
+    finally:
+        probe_report = probe.stop(join_timeout_s=spec.join_timeout_s)
+    if not probe_report.joined:
+        raise RuntimeError("periodic probe did not join")
+    return direct, probe_report, None
+
+
+def _run_async_nominal(
+    spec: ScenarioSpec,
+    event_sink: RuntimeEventSink,
+) -> tuple[None, ProbeStopReport, dict[str, object]]:
+    executor, probe, _ = _make_runtime(
+        spec,
+        event_sink,
+        observe_cancellation=True,
+    )
+    executor.start()
+    probe.start()
+    shutdown: ExecutorShutdownReport | None = None
+    try:
+        _sleep(spec.prelude_s)
+        executor.submit(
+            _make_task(
+                "async-001",
+                generation=0,
+                service_time_s=spec.service_time_s,
+                postlude_s=spec.postlude_s,
+            )
+        )
+        _wait_for(
+            lambda: executor.snapshot().result_pending == 1,
+            timeout_s=spec.service_time_s + spec.join_timeout_s,
+            description="the asynchronous result",
+        )
+        consumed = executor.consume_next()
+        if consumed is None or not consumed.consumed:
+            raise RuntimeError("nominal asynchronous result was not consumed")
+        _sleep(spec.postlude_s)
+        shutdown = executor.shutdown(
+            cancel_live=False,
+            join_timeout_s=spec.join_timeout_s,
+        )
+    finally:
+        if shutdown is None and executor.is_alive:
+            shutdown = executor.shutdown(
+                cancel_live=True,
+                join_timeout_s=spec.join_timeout_s,
+            )
+        probe_report = probe.stop(join_timeout_s=spec.join_timeout_s)
+    if shutdown is None or not shutdown.complete:
+        raise RuntimeError("asynchronous executor did not shut down cleanly")
+    if not probe_report.joined:
+        raise RuntimeError("periodic probe did not join")
+    return None, probe_report, _runtime_report(executor, shutdown)
+
+
+def _run_stale(
+    spec: ScenarioSpec,
+    event_sink: RuntimeEventSink,
+) -> tuple[None, ProbeStopReport, dict[str, object]]:
+    start_gate = threading.Event()
+    executor, probe, adapter_started = _make_runtime(
+        spec,
+        event_sink,
+        observe_cancellation=False,
+        start_gate=start_gate,
+    )
+    executor.start()
+    probe.start()
+    shutdown: ExecutorShutdownReport | None = None
+    try:
+        _sleep(spec.prelude_s)
+        executor.submit(
+            _make_task(
+                "stale-001",
+                generation=0,
+                service_time_s=spec.service_time_s,
+                postlude_s=spec.postlude_s,
+            )
+        )
+        if not adapter_started.wait(spec.join_timeout_s):
+            raise TimeoutError("timed out waiting for the stale scenario worker claim")
+        executor.advance_state("simulation", reason="scenario_state_change")
+        start_gate.set()
+        _wait_for(
+            lambda: executor.snapshot().terminal_admitted_total == 1,
+            timeout_s=spec.service_time_s + spec.join_timeout_s,
+            description="the invalidated result terminal",
+        )
+        if executor.consume_next() is not None:
+            raise RuntimeError("stale scenario unexpectedly exposed a result")
+        _sleep(spec.postlude_s)
+        shutdown = executor.shutdown(
+            cancel_live=False,
+            join_timeout_s=spec.join_timeout_s,
+        )
+    finally:
+        start_gate.set()
+        if shutdown is None and executor.is_alive:
+            shutdown = executor.shutdown(
+                cancel_live=True,
+                join_timeout_s=spec.join_timeout_s,
+            )
+        probe_report = probe.stop(join_timeout_s=spec.join_timeout_s)
+    if shutdown is None or not shutdown.complete:
+        raise RuntimeError("stale scenario executor did not shut down cleanly")
+    if not probe_report.joined:
+        raise RuntimeError("periodic probe did not join")
+    return None, probe_report, _runtime_report(executor, shutdown)
+
+
+def _run_overflow(
+    spec: ScenarioSpec,
+    event_sink: RuntimeEventSink,
+) -> tuple[None, ProbeStopReport, dict[str, object]]:
+    start_gate = threading.Event()
+    executor, probe, adapter_started = _make_runtime(
+        spec,
+        event_sink,
+        observe_cancellation=True,
+        overflow_policy=OverflowPolicy.DROP_OLDEST,
+        start_gate=start_gate,
+    )
+    executor.start()
+    probe.start()
+    shutdown: ExecutorShutdownReport | None = None
+    try:
+        _sleep(spec.prelude_s)
+        executor.submit(
+            _make_task(
+                "overflow-active",
+                generation=0,
+                service_time_s=spec.service_time_s,
+                postlude_s=spec.postlude_s,
+            )
+        )
+        if not adapter_started.wait(spec.join_timeout_s):
+            raise TimeoutError(
+                "timed out waiting for the overflow scenario worker claim"
+            )
+        queued_submissions = spec.pending_capacity + spec.overflow_submissions
+        for index in range(queued_submissions):
+            executor.submit(
+                _make_task(
+                    f"overflow-queued-{index:03d}",
+                    generation=0,
+                    service_time_s=spec.service_time_s,
+                    postlude_s=spec.postlude_s,
+                )
+            )
+        start_gate.set()
+        _wait_for(
+            lambda: executor.snapshot().result_pending == 1,
+            timeout_s=spec.service_time_s + spec.join_timeout_s,
+            description="the first overflow scenario result",
+        )
+        first_result = executor.consume_next()
+        if first_result is None or not first_result.consumed:
+            raise RuntimeError("overflow scenario did not consume its first result")
+        shutdown = executor.shutdown(
+            cancel_live=True,
+            join_timeout_s=spec.join_timeout_s,
+        )
+        _sleep(spec.postlude_s)
+    finally:
+        start_gate.set()
+        if shutdown is None and executor.is_alive:
+            shutdown = executor.shutdown(
+                cancel_live=True,
+                join_timeout_s=spec.join_timeout_s,
+            )
+        probe_report = probe.stop(join_timeout_s=spec.join_timeout_s)
+    if shutdown is None or not shutdown.complete:
+        raise RuntimeError("overflow scenario executor did not shut down cleanly")
+    if not probe_report.joined:
+        raise RuntimeError("periodic probe did not join")
+    return None, probe_report, _runtime_report(executor, shutdown)
+
+
+def run_simulation(
+    spec: ScenarioSpec,
+    event_sink: RuntimeEventSink,
+) -> SimulationReport:
+    """Execute one condition and return bounded manifest-ready facts."""
+
+    if not isinstance(spec, ScenarioSpec):
+        raise TypeError("spec must be a ScenarioSpec")
+    if not callable(getattr(event_sink, "emit", None)):
+        raise TypeError("event_sink must provide emit(event)")
+
+    handlers = {
+        SimulationCondition.R0_IDLE: _run_idle,
+        SimulationCondition.R1_INLINE_SYNC: _run_inline_sync,
+        SimulationCondition.R2_THREADED_SYNC: _run_threaded_sync,
+        SimulationCondition.R3_ASYNC: _run_async_nominal,
+        SimulationCondition.R4_STALE: _run_stale,
+        SimulationCondition.R4_OVERFLOW: _run_overflow,
+    }
+    started = time.monotonic_ns()
+    direct, probe, runtime = handlers[spec.condition](spec, event_sink)
+    finished = time.monotonic_ns()
+    return SimulationReport(
+        condition=spec.condition.value,
+        trace_profile=spec.trace_profile.value,
+        started_monotonic_ns=started,
+        finished_monotonic_ns=finished,
+        direct_workload=direct,
+        probe=probe,
+        runtime=runtime,
+    )

--- a/experiments/phase1/summarize_run.py
+++ b/experiments/phase1/summarize_run.py
@@ -1,0 +1,382 @@
+"""Descriptive summaries for one Phase 1 simulated-load run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from experiments.phase1.manifest import write_json_atomic
+from experiments.phase1.replay_lifecycle import (
+    TraceProfile,
+    load_events,
+    replay_events,
+)
+from experiments.phase1.simulation import SimulationCondition
+
+
+SUMMARY_SCHEMA_VERSION = "0.1.0"
+
+
+def nearest_rank(values: Iterable[int], percentile: int) -> int:
+    ordered = sorted(values)
+    if not ordered:
+        raise ValueError("nearest-rank percentile requires at least one value")
+    if isinstance(percentile, bool) or not isinstance(percentile, int):
+        raise TypeError("percentile must be an integer")
+    if not 1 <= percentile <= 100:
+        raise ValueError("percentile must be between 1 and 100")
+    rank = math.ceil(percentile / 100 * len(ordered))
+    return ordered[rank - 1]
+
+
+def _describe_ns(values: list[int]) -> dict[str, int | float] | None:
+    if not values:
+        return None
+    return {
+        "count": len(values),
+        "min_ns": min(values),
+        "mean_ns": statistics.fmean(values),
+        "median_ns": statistics.median(values),
+        "p50_ns": nearest_rank(values, 50),
+        "p95_ns": nearest_rank(values, 95),
+        "p99_ns": nearest_rank(values, 99),
+        "max_ns": max(values),
+    }
+
+
+def _require_detail_int(event: Mapping[str, object], key: str) -> int:
+    details = event.get("details")
+    if not isinstance(details, Mapping):
+        raise ValueError(f"event {event.get('seq')} has no details object")
+    value = details.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"event {event.get('seq')} has no integer {key}")
+    return value
+
+
+def _probe_summary(events: list[dict[str, object]]) -> dict[str, object]:
+    ticks = [event for event in events if event.get("event") == "probe.tick"]
+    lateness = [_require_detail_int(event, "start_lateness_ns") for event in ticks]
+    execution = [_require_detail_int(event, "execution_ns") for event in ticks]
+    gaps = [
+        value
+        for event in ticks
+        if (value := event["details"].get("actual_period_ns")) is not None
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+    ]
+    absolute_period_error = [
+        value
+        for event in ticks
+        if (value := event["details"].get("absolute_period_error_ns")) is not None
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+    ]
+    misses = sum(event["details"].get("deadline_miss") is True for event in ticks)
+    skipped = sum(
+        _require_detail_int(event, "skipped_releases")
+        for event in events
+        if event.get("event") == "probe.skipped"
+    )
+    period_ns = next(
+        (
+            _require_detail_int(event, "period_ns")
+            for event in events
+            if event.get("event") == "probe.started"
+        ),
+        None,
+    )
+    return {
+        "tick_count": len(ticks),
+        "period_ns": period_ns,
+        "skipped_releases": skipped,
+        "deadline_miss_count": misses,
+        "deadline_miss_rate": misses / len(ticks) if ticks else None,
+        "start_lateness": _describe_ns(lateness),
+        "execution": _describe_ns(execution),
+        "actual_period": _describe_ns(gaps),
+        "absolute_period_error": _describe_ns(absolute_period_error),
+        "maximum_observed_gap_ns": max(gaps) if gaps else None,
+        "percentile_method": "nearest-rank",
+    }
+
+
+def _task_timing_summary(events: list[dict[str, object]]) -> dict[str, object]:
+    created: dict[str, int] = {}
+    source: dict[str, int] = {}
+    queue_wait: list[int] = []
+    service: list[int] = []
+    terminal_age: list[int] = []
+
+    for event in events:
+        task_id = event.get("task_id")
+        if not isinstance(task_id, str):
+            continue
+        name = event.get("event")
+        if name == "task.enqueued":
+            created[task_id] = _require_detail_int(event, "created_monotonic_ns")
+            source_value = event.get("source_monotonic_ns")
+            if isinstance(source_value, int) and not isinstance(source_value, bool):
+                source[task_id] = source_value
+        elif name == "task.started" and task_id in created:
+            started = _require_detail_int(event, "started_monotonic_ns")
+            queue_wait.append(started - created[task_id])
+        elif name == "task.finished":
+            started = _require_detail_int(event, "started_monotonic_ns")
+            finished = _require_detail_int(event, "finished_monotonic_ns")
+            service.append(finished - started)
+
+        details = event.get("details")
+        if not isinstance(details, Mapping) or "disposition" not in details:
+            continue
+        transition = details.get("transition_monotonic_ns")
+        if (
+            task_id in source
+            and isinstance(transition, int)
+            and not isinstance(transition, bool)
+        ):
+            terminal_age.append(transition - source[task_id])
+
+    return {
+        "queue_wait": _describe_ns(queue_wait),
+        "service_time": _describe_ns(service),
+        "terminal_age": _describe_ns(terminal_age),
+    }
+
+
+def _gate(
+    name: str,
+    passed: bool,
+    *,
+    observed: object,
+    requirement: str,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "passed": passed,
+        "observed": observed,
+        "requirement": requirement,
+    }
+
+
+def _condition_gates(
+    condition: SimulationCondition,
+    replay: dict[str, object],
+    scenario: Mapping[str, object],
+) -> list[dict[str, object]]:
+    dispositions = dict(replay["disposition_counts"])
+    gates = [
+        _gate(
+            "probe_ticks_present",
+            replay["probe_tick_count"] > 0,
+            observed=replay["probe_tick_count"],
+            requirement="at least one recorded probe tick",
+        ),
+        _gate(
+            "stale_consumed_zero",
+            replay["stale_consumed_count"] == 0,
+            observed=replay["stale_consumed_count"],
+            requirement="zero stale results consumed",
+        ),
+    ]
+    if condition is SimulationCondition.R1_INLINE_SYNC:
+        direct = scenario.get("direct_workload")
+        outcome = (
+            direct.get("execution_outcome") if isinstance(direct, Mapping) else None
+        )
+        gates.append(
+            _gate(
+                "direct_workload_completed",
+                outcome == "ok",
+                observed=outcome,
+                requirement="direct workload outcome is ok",
+            )
+        )
+    elif condition is SimulationCondition.R2_THREADED_SYNC:
+        direct = scenario.get("direct_workload")
+        outcome = (
+            direct.get("execution_outcome") if isinstance(direct, Mapping) else None
+        )
+        gates.append(
+            _gate(
+                "direct_workload_completed",
+                outcome == "ok",
+                observed=outcome,
+                requirement="direct workload outcome is ok",
+            )
+        )
+    elif condition is SimulationCondition.R3_ASYNC:
+        gates.append(
+            _gate(
+                "nominal_result_consumed",
+                dispositions.get("consumed", 0) == 1,
+                observed=dispositions.get("consumed", 0),
+                requirement="exactly one accepted result",
+            )
+        )
+    elif condition is SimulationCondition.R4_STALE:
+        gates.append(
+            _gate(
+                "old_generation_rejected",
+                dispositions.get("rejected_state", 0) == 1
+                and replay["accepted_result_count"] == 0,
+                observed={
+                    "rejected_state": dispositions.get("rejected_state", 0),
+                    "accepted": replay["accepted_result_count"],
+                },
+                requirement="one state rejection and zero accepted results",
+            )
+        )
+    elif condition is SimulationCondition.R4_OVERFLOW:
+        runtime = scenario.get("runtime")
+        final_snapshot = (
+            runtime.get("final_snapshot") if isinstance(runtime, Mapping) else None
+        )
+        configured = scenario.get("spec")
+        expected_drops = (
+            configured.get("overflow_submissions")
+            if isinstance(configured, Mapping)
+            else None
+        )
+        max_depth = (
+            final_snapshot.get("max_pending_depth")
+            if isinstance(final_snapshot, Mapping)
+            else None
+        )
+        capacity = (
+            configured.get("pending_capacity")
+            if isinstance(configured, Mapping)
+            else None
+        )
+        gates.extend(
+            [
+                _gate(
+                    "overflow_dispositions_close",
+                    isinstance(expected_drops, int)
+                    and dispositions.get("dropped_overflow", 0) == expected_drops,
+                    observed=dispositions.get("dropped_overflow", 0),
+                    requirement="one drop for each configured overflow submission",
+                ),
+                _gate(
+                    "pending_capacity_respected",
+                    isinstance(max_depth, int)
+                    and isinstance(capacity, int)
+                    and max_depth <= capacity,
+                    observed={"max_depth": max_depth, "capacity": capacity},
+                    requirement="maximum pending depth does not exceed capacity",
+                ),
+            ]
+        )
+
+    if condition.uses_runtime:
+        runtime = scenario.get("runtime")
+        shutdown = runtime.get("shutdown") if isinstance(runtime, Mapping) else None
+        snapshot = (
+            runtime.get("final_snapshot") if isinstance(runtime, Mapping) else None
+        )
+        gates.extend(
+            [
+                _gate(
+                    "runtime_shutdown_complete",
+                    isinstance(shutdown, Mapping) and shutdown.get("complete") is True,
+                    observed=(
+                        shutdown.get("complete")
+                        if isinstance(shutdown, Mapping)
+                        else None
+                    ),
+                    requirement="worker joined with a closed and empty broker",
+                ),
+                _gate(
+                    "runtime_accounting_closed",
+                    isinstance(snapshot, Mapping)
+                    and snapshot.get("accounting_holds") is True,
+                    observed=(
+                        snapshot.get("accounting_holds")
+                        if isinstance(snapshot, Mapping)
+                        else None
+                    ),
+                    requirement="submission and terminal accounting close",
+                ),
+            ]
+        )
+    return gates
+
+
+def build_summary(
+    events_path: Path | str,
+    *,
+    condition: SimulationCondition,
+    profile: TraceProfile,
+    scenario_report: Mapping[str, object],
+    spec: Mapping[str, object],
+) -> dict[str, object]:
+    if not isinstance(condition, SimulationCondition):
+        raise TypeError("condition must be a SimulationCondition")
+    if profile is not condition.trace_profile:
+        raise ValueError("trace profile does not match the simulation condition")
+    events = load_events(events_path)
+    replay_summary = asdict(replay_events(events, profile=profile))
+    scenario = dict(scenario_report)
+    scenario["spec"] = dict(spec)
+    gates = _condition_gates(condition, replay_summary, scenario)
+    return {
+        "summary_schema_version": SUMMARY_SCHEMA_VERSION,
+        "run_id": replay_summary["run_id"],
+        "condition": condition.value,
+        "trace_profile": profile.value,
+        "descriptive_only": True,
+        "inference_claim_permitted": False,
+        "probe": _probe_summary(events),
+        "task_timing": _task_timing_summary(events),
+        "lifecycle": replay_summary,
+        "scenario": scenario_report,
+        "gates": gates,
+        "valid": all(gate["passed"] is True for gate in gates),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("events", type=Path)
+    parser.add_argument("scenario", type=Path)
+    parser.add_argument(
+        "--condition",
+        choices=[item.value for item in SimulationCondition],
+        required=True,
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        scenario = json.loads(args.scenario.read_text(encoding="utf-8"))
+        if not isinstance(scenario, dict):
+            raise ValueError("scenario file must contain an object")
+        condition = SimulationCondition(args.condition)
+        spec = scenario.get("spec")
+        report = scenario.get("report")
+        if not isinstance(spec, dict) or not isinstance(report, dict):
+            raise ValueError("scenario file must contain spec and report objects")
+        summary = build_summary(
+            args.events,
+            condition=condition,
+            profile=condition.trace_profile,
+            scenario_report=report,
+            spec=spec,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"INVALID: {exc}", file=sys.stderr)
+        return 2
+    if args.output is None:
+        print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    else:
+        write_json_atomic(args.output, summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/phase1/tests/test_simulation.py
+++ b/experiments/phase1/tests/test_simulation.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+from experiments.phase1.replay_lifecycle import (
+    ReplayError,
+    TraceProfile,
+    replay_file,
+)
+from experiments.phase1.simulation import (
+    InlineProbe,
+    ScenarioSpec,
+    SimulationCondition,
+)
+from experiments.phase1.telemetry import EventRecorder
+
+
+RUN_ID = "20260827T020000Z_phase1_r1_inline_sync_simulated_001"
+
+
+class FakeClock:
+    def __init__(self, initial_ns: int = 1_000_000) -> None:
+        self.now_ns = initial_ns
+
+    def clock_ns(self) -> int:
+        return self.now_ns
+
+    def wait(self, seconds: float) -> None:
+        self.now_ns += int(seconds * 1_000_000_000)
+
+    def advance(self, nanoseconds: int) -> None:
+        self.now_ns += nanoseconds
+
+
+class SimulationPrimitiveTests(unittest.TestCase):
+    def test_condition_profiles_are_explicit(self) -> None:
+        expected = {
+            SimulationCondition.R0_IDLE: TraceProfile.THREADED_PROBE,
+            SimulationCondition.R1_INLINE_SYNC: TraceProfile.INLINE_PROBE,
+            SimulationCondition.R2_THREADED_SYNC: TraceProfile.THREADED_PROBE,
+            SimulationCondition.R3_ASYNC: TraceProfile.RUNTIME_THREADED_PROBE,
+            SimulationCondition.R4_STALE: TraceProfile.RUNTIME_THREADED_PROBE,
+            SimulationCondition.R4_OVERFLOW: TraceProfile.RUNTIME_THREADED_PROBE,
+        }
+        self.assertEqual(
+            {condition: condition.trace_profile for condition in SimulationCondition},
+            expected,
+        )
+
+    def test_r4_requires_positive_service_time(self) -> None:
+        for condition in (
+            SimulationCondition.R4_STALE,
+            SimulationCondition.R4_OVERFLOW,
+        ):
+            with self.subTest(condition=condition):
+                with self.assertRaisesRegex(ValueError, "positive service time"):
+                    ScenarioSpec(condition=condition, service_time_s=0)
+
+    def test_inline_probe_records_blocked_releases_without_a_join_event(self) -> None:
+        clock = FakeClock()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            recorder = EventRecorder(Path(temp_dir), RUN_ID)
+            probe = InlineProbe(
+                period_ns=1_000_000,
+                deadline_ns=1_000_000,
+                event_sink=recorder,
+                clock_ns=clock.clock_ns,
+                wait=clock.wait,
+            )
+            probe.start()
+            probe.run_until(clock.clock_ns() + 2_000_000)
+            clock.advance(5_000_000)
+            probe.run_until(clock.clock_ns() + 2_000_000)
+            report = probe.stop()
+            recorder.close()
+            summary = replay_file(
+                recorder.path,
+                profile=TraceProfile.INLINE_PROBE,
+            )
+
+        self.assertEqual(report.tick_count, 6)
+        self.assertEqual(report.skipped_releases, 4)
+        self.assertEqual(summary.probe_skipped_releases, 4)
+        self.assertTrue(summary.probe_stopped)
+        self.assertFalse(summary.probe_joined)
+
+    def test_probe_only_trace_cannot_pass_as_a_runtime_trace(self) -> None:
+        clock = FakeClock()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            recorder = EventRecorder(Path(temp_dir), RUN_ID)
+            probe = InlineProbe(
+                period_ns=1_000_000,
+                deadline_ns=1_000_000,
+                event_sink=recorder,
+                clock_ns=clock.clock_ns,
+                wait=clock.wait,
+            )
+            probe.start()
+            probe.run_until(clock.clock_ns())
+            probe.stop()
+            recorder.close()
+            with self.assertRaisesRegex(ReplayError, "no runtime events"):
+                replay_file(recorder.path, profile=TraceProfile.RUNTIME)
+
+    def test_inline_probe_leaves_no_thread(self) -> None:
+        before = {thread.ident for thread in threading.enumerate()}
+        clock = FakeClock()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            recorder = EventRecorder(Path(temp_dir), RUN_ID)
+            probe = InlineProbe(
+                period_ns=1_000_000,
+                deadline_ns=1_000_000,
+                event_sink=recorder,
+                clock_ns=clock.clock_ns,
+                wait=clock.wait,
+            )
+            probe.start()
+            probe.run_until(clock.clock_ns())
+            probe.stop()
+            recorder.close()
+        after = {thread.ident for thread in threading.enumerate()}
+        self.assertEqual(after, before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_simulation_runner.py
+++ b/experiments/phase1/tests/test_simulation_runner.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from experiments.phase1.manifest import (
+    SafetyError,
+    require_motion_disabled,
+    sha256_file,
+)
+from experiments.phase1.run_simulation import (
+    RunError,
+    build_parser,
+    make_run_id,
+    run_once,
+)
+from experiments.phase1.simulation import SimulationCondition
+from experiments.phase1.validate_run import validate_run_dir
+
+
+SESSION_ID = "20260827T020000Z_phase1_simulation_test"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def build_args(
+    output_root: Path,
+    condition: SimulationCondition,
+    repetition: int,
+):
+    return build_parser().parse_args(
+        [
+            "--condition",
+            condition.value,
+            "--service-time-s",
+            "0.02",
+            "--prelude-s",
+            "0.004",
+            "--postlude-s",
+            "0.004",
+            "--probe-period-ms",
+            "1",
+            "--probe-deadline-ms",
+            "2",
+            "--adapter-poll-interval-s",
+            "0.001",
+            "--join-timeout-s",
+            "1",
+            "--session-id",
+            SESSION_ID,
+            "--repetition",
+            str(repetition),
+            "--output-root",
+            str(output_root),
+            "--allow-dirty",
+        ]
+    )
+
+
+class SimulationRunnerTests(unittest.TestCase):
+    def test_run_id_uses_condition_and_utc_timestamp(self) -> None:
+        now = datetime(2026, 8, 27, 2, 3, 4, tzinfo=timezone.utc)
+        self.assertEqual(
+            make_run_id(SimulationCondition.R3_ASYNC, 7, now=now),
+            "20260827T020304Z_phase1_r3_async_simulated_007",
+        )
+
+    def test_motion_guard_fails_closed(self) -> None:
+        for value in ("1", "true", "unexpected"):
+            with self.subTest(value=value):
+                with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": value}):
+                    with self.assertRaises(SafetyError):
+                        require_motion_disabled()
+        with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+            self.assertFalse(require_motion_disabled()["motion_enabled"])
+
+    def test_runner_refuses_a_phase0_output_root(self) -> None:
+        args = build_args(
+            REPO_ROOT / "experiments" / "phase0",
+            SimulationCondition.R0_IDLE,
+            1,
+        )
+        with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+            with self.assertRaisesRegex(RunError, "experiments/phase0"):
+                run_once(args, repo_root=REPO_ROOT)
+
+    def test_clean_run_is_marked_eligible_without_development_override(self) -> None:
+        clean_environment = {
+            "captured_at": "2026-08-27T02:00:00Z",
+            "platform": "test",
+            "machine": "test",
+            "python": "3.12",
+            "l4t_release": "",
+            "git": {
+                "commit": "a" * 40,
+                "branch": "feat/phase1-simulation-runner",
+                "dirty": False,
+                "status_porcelain": [],
+                "error_codes": [],
+            },
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = build_args(
+                Path(temp_dir),
+                SimulationCondition.R0_IDLE,
+                1,
+            )
+            args.allow_dirty = False
+            with (
+                patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}),
+                patch(
+                    "experiments.phase1.run_simulation.collect_environment",
+                    return_value=clean_environment,
+                ),
+            ):
+                run_dir = run_once(args, repo_root=REPO_ROOT)
+            manifest = json.loads(
+                (run_dir / "manifest.json").read_text(encoding="utf-8")
+            )
+
+        self.assertFalse(manifest["reproducibility"]["development_override"])
+        self.assertTrue(manifest["reproducibility"]["formal_evidence_eligible"])
+
+    def test_all_conditions_produce_valid_isolated_artifacts(self) -> None:
+        baseline_threads = {thread.name for thread in threading.enumerate()}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            run_dirs = []
+            with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+                for repetition, condition in enumerate(SimulationCondition, start=1):
+                    with self.subTest(condition=condition.value):
+                        run_dir = run_once(
+                            build_args(output_root, condition, repetition),
+                            repo_root=REPO_ROOT,
+                        )
+                        run_dirs.append(run_dir)
+                        self.assertEqual(validate_run_dir(run_dir), [])
+                        manifest = json.loads(
+                            (run_dir / "manifest.json").read_text(encoding="utf-8")
+                        )
+                        summary = json.loads(
+                            (run_dir / "summary.json").read_text(encoding="utf-8")
+                        )
+                        self.assertEqual(manifest["status"], "completed")
+                        self.assertTrue(
+                            manifest["reproducibility"]["development_override"]
+                        )
+                        self.assertFalse(
+                            manifest["reproducibility"]["formal_evidence_eligible"]
+                        )
+                        self.assertTrue(summary["valid"])
+                        self.assertTrue(summary["descriptive_only"])
+                        self.assertFalse(summary["inference_claim_permitted"])
+
+            inline_summary = json.loads(
+                (run_dirs[1] / "summary.json").read_text(encoding="utf-8")
+            )
+            self.assertGreater(inline_summary["probe"]["skipped_releases"], 0)
+            stale_summary = json.loads(
+                (run_dirs[4] / "summary.json").read_text(encoding="utf-8")
+            )
+            stale_dispositions = dict(stale_summary["lifecycle"]["disposition_counts"])
+            self.assertEqual(stale_dispositions["rejected_state"], 1)
+            self.assertEqual(stale_summary["lifecycle"]["accepted_result_count"], 0)
+
+        remaining = {thread.name for thread in threading.enumerate()}
+        self.assertEqual(remaining, baseline_threads)
+
+    def test_validator_rebuilds_summary_instead_of_trusting_its_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+                run_dir = run_once(
+                    build_args(
+                        Path(temp_dir),
+                        SimulationCondition.R3_ASYNC,
+                        1,
+                    ),
+                    repo_root=REPO_ROOT,
+                )
+            summary_path = run_dir / "summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            summary["probe"]["tick_count"] += 1
+            summary_path.write_text(
+                json.dumps(summary, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            manifest_path = run_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["artifacts"]["summary.json"] = {
+                "size_bytes": summary_path.stat().st_size,
+                "sha256": sha256_file(summary_path),
+            }
+            manifest_path.write_text(
+                json.dumps(manifest, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            errors = validate_run_dir(run_dir)
+
+        self.assertTrue(any("independently rebuilt" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_trace.py
+++ b/experiments/phase1/tests/test_trace.py
@@ -203,6 +203,15 @@ class TraceTests(unittest.TestCase):
         self.assertTrue(shutdown.complete)
         self.assertGreater(summary.probe_tick_count, 0)
         self.assertEqual(summary.accepted_result_count, 1)
+        missing_join = [
+            json.loads(json.dumps(event))
+            for event in events
+            if event["event"] != "probe.joined"
+        ]
+        for index, event in enumerate(missing_join):
+            event["seq"] = index
+        with self.assertRaisesRegex(ReplayError, "probe join"):
+            replay_events(missing_join)
         tick = next(event for event in events if event["event"] == "probe.tick")
         tick["details"]["execution_ns"] += 1
         with self.assertRaisesRegex(ReplayError, "execution duration"):

--- a/experiments/phase1/validate_run.py
+++ b/experiments/phase1/validate_run.py
@@ -1,0 +1,210 @@
+"""Validate one complete Phase 1 simulated-load run directory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from experiments.phase1.manifest import MANIFEST_SCHEMA_VERSION, sha256_file
+from experiments.phase1.replay_lifecycle import ReplayError, TraceProfile, replay_file
+from experiments.phase1.simulation import SimulationCondition
+from experiments.phase1.summarize_run import SUMMARY_SCHEMA_VERSION, build_summary
+from experiments.phase1.telemetry import SCHEMA_VERSION as EVENT_SCHEMA_VERSION
+
+
+REQUIRED_FILES = ("manifest.json", "scenario.json", "events.jsonl", "summary.json")
+
+
+def _read_object(path: Path, errors: list[str]) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        errors.append(f"{path.name}: {type(exc).__name__}: {exc}")
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"{path.name}: root must be an object")
+        return {}
+    return value
+
+
+def _json_value(value: object) -> object:
+    return json.loads(json.dumps(value, ensure_ascii=False, allow_nan=False))
+
+
+def validate_run_dir(run_dir: Path | str) -> list[str]:
+    directory = Path(run_dir)
+    errors: list[str] = []
+    for name in REQUIRED_FILES:
+        if not (directory / name).is_file():
+            errors.append(f"missing file: {name}")
+    if list(directory.glob("*.tmp")):
+        errors.append("run directory contains an unfinished temporary file")
+    if errors:
+        return errors
+
+    manifest = _read_object(directory / "manifest.json", errors)
+    scenario = _read_object(directory / "scenario.json", errors)
+    summary = _read_object(directory / "summary.json", errors)
+    if errors:
+        return errors
+
+    run_id = manifest.get("run_id")
+    if not isinstance(run_id, str) or run_id != directory.name:
+        errors.append("manifest run_id does not match the run directory")
+    if manifest.get("manifest_schema_version") != MANIFEST_SCHEMA_VERSION:
+        errors.append("unsupported manifest schema version")
+    if manifest.get("event_schema_version") != EVENT_SCHEMA_VERSION:
+        errors.append("unsupported event schema version")
+    if manifest.get("artifact_kind") != "phase1_simulation_run":
+        errors.append("manifest artifact kind is not a Phase 1 simulation run")
+    if manifest.get("status") != "completed":
+        errors.append(f"manifest status is not completed: {manifest.get('status')!r}")
+
+    safety = manifest.get("safety")
+    if not isinstance(safety, dict):
+        errors.append("manifest safety record is missing")
+    else:
+        if safety.get("motion_enabled") is not False:
+            errors.append("manifest does not prove motion was disabled")
+        if safety.get("motion_value_valid") is not True:
+            errors.append("manifest contains an unrecognized motion setting")
+
+    environment = manifest.get("environment")
+    git = environment.get("git") if isinstance(environment, dict) else None
+    reproducibility = manifest.get("reproducibility")
+    if not isinstance(reproducibility, dict):
+        errors.append("manifest reproducibility record is missing")
+    else:
+        identity_complete = (
+            isinstance(git, dict)
+            and not git.get("error_codes")
+            and bool(git.get("commit"))
+            and bool(git.get("branch"))
+        )
+        git_clean = identity_complete and git.get("dirty") is False
+        development_override = reproducibility.get("development_override")
+        expected_eligibility = git_clean and development_override is False
+        if reproducibility.get("git_identity_complete") is not identity_complete:
+            errors.append("reproducibility Git identity fact is inconsistent")
+        if reproducibility.get("git_clean") is not git_clean:
+            errors.append("reproducibility Git cleanliness fact is inconsistent")
+        if not isinstance(development_override, bool):
+            errors.append("reproducibility development override must be boolean")
+        if reproducibility.get("formal_evidence_eligible") is not expected_eligibility:
+            errors.append("formal-evidence eligibility is inconsistent")
+
+    try:
+        condition = SimulationCondition(manifest.get("condition"))
+    except ValueError:
+        errors.append("manifest condition is not supported")
+        return errors
+    if manifest.get("trace_profile") != condition.trace_profile.value:
+        errors.append("manifest trace profile does not match its condition")
+    spec = manifest.get("spec")
+    if spec != scenario.get("spec"):
+        errors.append("manifest and scenario specifications differ")
+    if not isinstance(spec, dict):
+        errors.append("manifest scenario specification is missing")
+    else:
+        if spec.get("condition") != condition.value:
+            errors.append(
+                "scenario specification condition does not match the manifest"
+            )
+        if spec.get("trace_profile") != condition.trace_profile.value:
+            errors.append(
+                "scenario specification trace profile does not match the manifest"
+            )
+    report = scenario.get("report")
+    if not isinstance(report, dict):
+        errors.append("scenario report is missing")
+    else:
+        if report.get("condition") != condition.value:
+            errors.append("scenario report condition does not match the manifest")
+        if report.get("trace_profile") != condition.trace_profile.value:
+            errors.append("scenario report trace profile does not match the manifest")
+
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        errors.append("manifest artifact identities are missing")
+    else:
+        for name in ("events.jsonl", "scenario.json", "summary.json"):
+            identity = artifacts.get(name)
+            if not isinstance(identity, dict):
+                errors.append(f"manifest identity is missing for {name}")
+                continue
+            path = directory / name
+            if identity.get("size_bytes") != path.stat().st_size:
+                errors.append(f"manifest size does not match {name}")
+            if identity.get("sha256") != sha256_file(path):
+                errors.append(f"manifest SHA-256 does not match {name}")
+
+    replay_summary = None
+    try:
+        replay_summary = replay_file(
+            directory / "events.jsonl",
+            profile=TraceProfile(manifest["trace_profile"]),
+        )
+    except (OSError, ReplayError, TypeError, ValueError) as exc:
+        errors.append(f"events.jsonl: {type(exc).__name__}: {exc}")
+
+    if summary.get("summary_schema_version") != SUMMARY_SCHEMA_VERSION:
+        errors.append("unsupported summary schema version")
+    if summary.get("run_id") != run_id:
+        errors.append("summary run_id does not match the manifest")
+    if summary.get("condition") != condition.value:
+        errors.append("summary condition does not match the manifest")
+    if summary.get("trace_profile") != condition.trace_profile.value:
+        errors.append("summary trace profile does not match the manifest")
+    if summary.get("descriptive_only") is not True:
+        errors.append("summary is not marked descriptive-only")
+    if summary.get("inference_claim_permitted") is not False:
+        errors.append("pilot summary incorrectly permits an inferential claim")
+    if summary.get("valid") is not True:
+        errors.append("summary Gates did not all pass")
+    gates = summary.get("gates")
+    if not isinstance(gates, list) or not gates:
+        errors.append("summary contains no Gates")
+    elif any(
+        not isinstance(gate, dict) or gate.get("passed") is not True for gate in gates
+    ):
+        errors.append("one or more summary Gates failed")
+    if replay_summary is not None and summary.get("lifecycle") != _json_value(
+        asdict(replay_summary)
+    ):
+        errors.append("summary lifecycle facts do not match independent replay")
+    if isinstance(spec, dict) and isinstance(report, dict):
+        try:
+            rebuilt_summary = build_summary(
+                directory / "events.jsonl",
+                condition=condition,
+                profile=condition.trace_profile,
+                scenario_report=report,
+                spec=spec,
+            )
+        except (OSError, ReplayError, TypeError, ValueError) as exc:
+            errors.append(f"summary rebuild failed: {type(exc).__name__}: {exc}")
+        else:
+            if summary != _json_value(rebuilt_summary):
+                errors.append("summary does not match independently rebuilt metrics")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir", type=Path)
+    args = parser.parse_args(argv)
+    errors = validate_run_dir(args.run_dir)
+    if errors:
+        print("INVALID")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("VALID")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -2,7 +2,7 @@
 
 The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel, which is not yet connected to the robot application or model services.
 
-The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-only task identity, bounded ownership, a single-worker observable executor and a software periodic probe. Jetson pilots and application integration remain research work.
+The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-only task identity, bounded ownership, a single-worker observable executor and a software periodic probe. A portable simulated-condition runner is available under `experiments/phase1/`, but Jetson pilots and application integration remain research work.
 
 > 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 的 host-only worker 与周期探针尚未接入真实模型或运动控制。
 


### PR DESCRIPTION
## Summary

This PR adds a host-safe simulation runner for the Phase 1 asynchronous runtime experiments.

It establishes a repeatable R0–R4 protocol for comparing idle, synchronous, threaded, and bounded asynchronous execution paths while keeping correctness experiments separate from runtime-overhead measurements.

## What changed

- Added the R0–R4 simulation protocol:
  - R0: idle baseline
  - R1: inline synchronous execution
  - R2: threaded synchronous execution
  - R3: bounded asynchronous runtime
  - R4: stale-result and overflow correctness cases
- Added explicit replay profiles for inline, threaded, runtime, and runtime-with-threaded-probe execution.
- Added a deterministic claim barrier for R4 correctness experiments.
- Added atomic run manifests and SHA-256 artifact integrity records.
- Added independent summary reconstruction and run-directory validation.
- Added command-line entry points for running, summarizing, and validating experiments.
- Extended the runtime contract and experiment documentation.
- Added tests for simulation behavior, safety guards, manifests, summaries, and validation.

## Safety and scope

- Physical motion remains disabled.
- The runner refuses to start when motion is enabled or the motion setting is invalid.
- No UART, STM32 firmware, robot application, or physical hardware path is accessed.
- Phase 0 artifact directories are protected from Phase 1 output.
- Results remain descriptive and do not make Jetson performance claims.

## Validation

- Phase 0 tests: 29 passed
- Phase 1 tests: 66 passed
- Total: 95 passed
- Formatting, static checks, compilation, JSON Schema validation, Markdown links, and whitespace checks passed