### PR TITLE
feat(experiments): add Jetson simulation pilot harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository began with my bachelor's thesis on speech interaction and visual perception for a wheeled robot. The thesis system runs fully local speech and vision pipelines on a Jetson Orin Nano, while an STM32F407 executes motion commands and enforces a communication watchdog. The same platform will now be used to study how long-running perception and inference can coexist with predictable control timing.
 
-> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立 host-only 有界运行时、可观测 worker、周期探针和模拟实验运行器，尚未接入 Jetson 模型或整机应用。
+> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立 host-only 有界运行时、可观测 worker、周期探针、模拟实验运行器和 Jetson pilot 基础设施，尚未执行 Jetson pilot 或接入整机应用。
 
 ## Project status
 
@@ -15,7 +15,7 @@ This repository began with my bachelor's thesis on speech interaction and visual
 | Bachelor's thesis software and firmware | Complete and hardware validated |
 | Custom base-driver PCB | Published and tested on the physical robot |
 | Jetson–STM32 command link | Validated with ACK/error responses and a 1.2 s command watchdog |
-| Asynchronous inference runtime | Host-only bounded executor, periodic probe, trace replay and simulated-condition runner implemented; Jetson pilot pending |
+| Asynchronous inference runtime | Bounded executor, probe, trace replay, simulation runner and host-tested Jetson pilot harness implemented; Jetson pilot pending |
 
 The validated Jetson–STM32 code is preserved at [`v0.1.0-thesis-baseline`](https://github.com/yuzhang-robotics/embodied-robot-heterogeneous-control/tree/v0.1.0-thesis-baseline). The current `main` branch also includes the reviewed hardware documentation and editable PCB export.
 
@@ -64,9 +64,10 @@ The current Jetson application is synchronous: wake-word detection, recording, A
 Phase 1 now has an immutable task/result model, bounded task ownership, scoped
 state generations, a single-worker observable executor, an absolute-schedule
 periodic probe, independent lifecycle trace replay and a reproducible
-simulated-condition runner. These components remain host-only; no Jetson pilot
-or model-service integration result is claimed yet. The broader research stage
-will investigate:
+simulated-condition runner. A fail-closed Jetson preflight, continuous
+`tegrastats` recorder and pilot-session validator are also host-tested. No
+Jetson pilot or model-service integration result is claimed yet. The broader
+research stage will investigate:
 
 - independent acquisition, inference, planning and control workers;
 - timestamped bounded queues, cancellation and stale-result rejection;
@@ -88,7 +89,7 @@ These are research objectives, not claims about the current implementation. The 
 | [`docs/hardware/`](docs/hardware/) | Physical platform, wiring, pin assignments, power and safety notes |
 | [`docs/architecture/`](docs/architecture/) | Current timing model and the boundary of the planned asynchronous architecture |
 | [`experiments/phase0/`](experiments/phase0/) | Synchronous fixed-input measurement, validation and formal analysis tools |
-| [`experiments/phase1/`](experiments/phase1/) | Host tests, simulated-condition runner, Phase 1 trace schema, validation and descriptive summaries |
+| [`experiments/phase1/`](experiments/phase1/) | Host tests, simulated-condition runner, Jetson pilot harness, Phase 1 trace schema and validation |
 
 ## Reproducing the baseline
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -101,8 +101,9 @@ semantics, and Phase 1 safety Gates are specified in the
 [Phase 1 runtime contract](phase1-runtime-contract.md). That document is a
 design and correctness boundary. The host-only model, bounded broker,
 observable worker, periodic probe, lifecycle replay and simulated-condition
-runner do not yet constitute a validated Jetson runtime or a performance
-result.
+runner are implemented. The Jetson preflight, continuous resource sampler and
+pilot-session validator are host-tested, but they do not yet constitute a
+validated Jetson runtime or a performance result.
 
 ## Evaluation plan
 

--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -12,8 +12,9 @@ performance remain unvalidated.
 
 ## Status
 
-- Phase: Phase 1.3 portable simulation protocol
-- Contract status: frozen and implemented for the host-only boundary
+- Phase: Phase 1.4 Jetson simulation-pilot protocol
+- Contract status: frozen and host-tested through the pilot infrastructure
+- Jetson-pilot starting point: `main@844b633`
 - Simulation-runner starting point: `main@4514d97`
 - Observable-executor starting point: `main@1d29b14`
 - Initial runtime-kernel starting point: `main@043e1bb`
@@ -25,7 +26,7 @@ The contract was reviewed before the host-only implementation began. Later
 implementation findings may require an explicit contract revision, but the
 contract must not be changed silently after formal data collection starts.
 
-The current host implementation includes:
+The current implementation includes:
 
 - immutable task, result, state and payload-reference contracts;
 - bounded pending, active, result-mailbox, state-scope and terminal ownership;
@@ -34,10 +35,12 @@ The current host implementation includes:
 - inline and independent absolute-schedule periodic probes;
 - schema `0.2.0` JSONL recording and profile-aware offline lifecycle replay;
 - R0--R4 simulated-condition orchestration, atomic manifests, validation and
-  descriptive summaries.
+  descriptive summaries;
+- fail-closed Jetson preflight, a continuous non-daemon `tegrastats` sampler,
+  an immutable pilot matrix and independent session reconstruction.
 
-It does not include Jetson resource telemetry, a completed Jetson simulation
-pilot, real workload adapters or formal performance data.
+It does not include a completed Jetson simulation pilot, real workload adapters
+or formal performance data.
 
 ## Research objective
 
@@ -530,6 +533,107 @@ retains module-import, Moondream, rewrite/fallback, and unload stages.
 Formal analysis treats a run or paired block as the experimental unit. Probe
 ticks within one run are temporally dependent and are not treated as hundreds
 of independent experimental samples.
+
+## Jetson simulation-pilot evidence contract
+
+The first Jetson experiment remains a simulated-load pilot. It tests whether
+the portable protocol and its evidence chain remain valid under real Jetson
+scheduling and resource behavior; it does not test a model and does not make a
+performance-improvement claim.
+
+### Preflight
+
+The pilot refuses to create a session unless it records all of the following:
+
+- Linux on ARM64 with a non-empty NVIDIA L4T identity;
+- `tegrastats` available in `PATH`;
+- a clean, named `main` branch synchronized with the recorded `origin/main`
+  commit, with zero ahead/behind counts;
+- `ROBOT_ENABLE_MOTION` unset or explicitly false;
+- `jetson.app`, `jetson.motion_planner`, and `jetson.robot_comm` absent from the
+  loaded module set.
+
+The preflight uses read-only software-identity commands. It never imports a
+robot device module, checks a serial device, or opens UART. Each individual run
+must repeat the same Git commit, branch, cleanliness and motion facts captured
+by the session preflight.
+
+### Pilot matrix
+
+The plan is written atomically before the resource sampler or first condition
+starts. For every predeclared service duration and repetition, the
+responsiveness block contains R0, R1, R2 and R3. R4-stale and R4-overflow run
+once per repetition at a separate correctness duration. Their timing remains
+excluded from the responsiveness and overhead comparison.
+
+The first descriptive pilot uses explicit simulated durations selected from
+the Phase 0 workload scale. The command records the exact values; no duration,
+condition or repetition is added after looking at the results. Formal condition
+order, thresholds and sample size remain unfrozen until this pilot is reviewed.
+
+### Continuous resource trace
+
+One non-daemon `tegrastats` reader spans the complete session. Starting and
+stopping a separate resource process for every condition would add a systematic
+boundary disturbance and break resource continuity, so the pilot does not do
+that. The reader must produce a parseable first sample before R0 begins and
+must terminate or be killed and joined within finite time after the final run.
+
+Resource schema `0.1.0` is separate from runtime-event schema `0.2.0`. Each
+JSONL sample has its own sequence, monotonic timestamp and wall timestamp.
+Required parsed observations are RAM, swap, per-core CPU state and frequency,
+GR3D usage, at least one temperature and at least one power rail. EMC and the
+`tegrastats` wall-clock prefix are recorded when available but are not assumed
+to exist on every supported format. Sensor and power-rail names are discovered
+from the line rather than fixed to one board revision. The bounded raw line is
+retained so a parser decision can be audited. Session validation reparses every
+raw line and requires the reconstructed object to match the recorded fields.
+
+Condition-level power descriptions use the instantaneous rail values. The
+second value reported by `tegrastats` is retained as
+`power_reported_average_mw` for diagnostics, but its averaging window may span
+the continuous session and is not treated as an independent per-condition
+mean.
+
+Resource samples are associated with a condition only when their monotonic
+timestamps fall within that run's recorded start and finish interval. Cross-run
+absolute monotonic values are never compared as durations. A run with no
+resource sample inside its interval fails the pilot Gate.
+
+### Session artifacts and completion
+
+One session contains:
+
+```text
+<session_id>/
+├── session_manifest.json
+├── pilot_plan.json
+├── preflight.json
+├── resources.jsonl
+├── pilot_summary.json
+└── <condition>/<run_id>/
+    ├── manifest.json
+    ├── scenario.json
+    ├── events.jsonl
+    └── summary.json
+```
+
+The session manifest advances from `running` to `completed` only after:
+
+1. every predeclared run passes the existing run-directory validator;
+2. run paths, conditions, service times and Git identities match the plan and
+   preflight;
+3. the resource sequence closes with zero unexplained parse errors;
+4. the sampler process and reader thread stop with no leak;
+5. every run has resource coverage and zero stale result consumption;
+6. top-level artifacts and every child manifest have recorded SHA-256 values;
+7. an independent validator reconstructs the complete pilot summary.
+
+A failed sampler, missing or unexpected artifact, path escape, dirty or
+different source identity, failed child Gate, uncovered run or summary mismatch
+leaves the session failed.
+The summary is permanently marked `descriptive_only=true` and
+`inference_claim_permitted=false`.
 
 ## Gates
 

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -1,13 +1,14 @@
 # Phase 1 Asynchronous Runtime Research
 
 This directory contains the host tests, simulated-condition runner, trace
-recorder, event schema, independent lifecycle replay, run validation and
-descriptive summaries for the Phase 1 asynchronous runtime study. Jetson
-pilots and Phase 1 performance results have not been completed yet.
+recorder, event schema, independent lifecycle replay, run validation, Jetson
+pilot orchestration and descriptive summaries for the Phase 1 asynchronous
+runtime study. The Jetson pilot and Phase 1 performance results have not been
+completed yet.
 
 > 中文简介：本目录用于 Phase 1 异步运行时研究。当前已实现 host-only 有界 broker、
-> 单 worker 执行层、100 ms 周期探针、独立 trace replay 和模拟条件运行器；尚未开展
-> Jetson pilot、真实模型接入或 Phase 1 正式数据采集。
+> 单 worker 执行层、100 ms 周期探针、独立 trace replay、模拟条件运行器和 Jetson
+> pilot 基础设施；尚未执行真实 Jetson pilot、接入真实模型或采集 Phase 1 正式数据。
 
 ## Current status
 
@@ -19,7 +20,8 @@ pilots and Phase 1 performance results have not been completed yet.
 - Inline synchronous-path probe: implemented and tested
 - Phase 1 schema `0.2.0`, JSONL recorder and lifecycle replay: implemented
 - Reproducible R0--R4 simulated-condition runner: implemented and host-tested
-- Jetson resource telemetry and simulation pilot: not started
+- Jetson preflight, continuous resource telemetry and pilot runner: host-tested
+- Jetson simulation pilot: not run
 - Real VLM/ASR/LLM slices: not started
 - Formal Phase 1 data: not collected
 - Physical motion and UART: excluded
@@ -107,6 +109,70 @@ The summary reports nearest-rank p50/p95/p99 timing statistics and lifecycle
 counts. It is explicitly marked descriptive-only and cannot be used as a
 formal improvement claim.
 
+## Jetson simulation pilot
+
+The Jetson pilot reuses the validated single-run protocol. One non-daemon
+`tegrastats` reader remains active across the complete session, avoiding a
+resource-sampler restart between conditions. Samples are assigned to each run
+using the run's monotonic start and finish timestamps.
+
+The preflight refuses to create a session unless all of the following hold:
+
+- the process runs on Linux ARM64 with an L4T release identity;
+- `tegrastats` is available;
+- the source tree is clean, on `main`, synchronized with `origin/main`, and has
+  a complete Git identity;
+- motion is unset or explicitly disabled;
+- robot application, motion-planner and UART modules are not loaded.
+
+After this implementation is merged to `main`, run the descriptive pilot on
+the Jetson with explicit simulated service durations:
+
+```bash
+export ROBOT_ENABLE_MOTION=0
+python3 -m experiments.phase1.run_jetson_pilot \
+  --service-times-s 2 5 70 \
+  --correctness-service-time-s 2 \
+  --repetitions 1
+```
+
+The responsiveness matrix runs R0--R3 at each service duration. R4-stale and
+R4-overflow run once per repetition at the separate correctness duration. The
+order, durations, capacities, probe settings and 200 ms resource interval are
+frozen in `pilot_plan.json` before the first condition starts. Resource rows use
+the separate [`0.1.0` JSON Schema](schemas/resource.schema.json).
+
+The ignored session directory contains:
+
+```text
+experiments/runs/phase1-jetson-pilot/
+└── <session_id>/
+    ├── session_manifest.json
+    ├── pilot_plan.json
+    ├── preflight.json
+    ├── resources.jsonl
+    ├── pilot_summary.json
+    └── <condition>/<run_id>/
+        ├── manifest.json
+        ├── scenario.json
+        ├── events.jsonl
+        └── summary.json
+```
+
+The session manifest becomes `completed` only after every single-run validator,
+the continuous resource trace, per-run resource coverage, sampler shutdown,
+artifact hashes and an independent pilot-summary rebuild pass. Validate it
+again with:
+
+```bash
+python3 -m experiments.phase1.validate_jetson_pilot /path/to/session_dir
+```
+
+The pilot is descriptive evidence used to design the later formal protocol. It
+does not authorize an asynchronous-performance or hard-real-time claim.
+Condition-level power summaries use instantaneous rail samples; the
+`tegrastats`-reported average is retained only as a session-window diagnostic.
+
 ## Planned implementation order
 
 1. freeze the task, result, lifecycle, queue, cancellation, and freshness
@@ -116,12 +182,13 @@ formal improvement claim.
    independent trace replay — complete;
 4. implement the portable R0--R4 simulation protocol and run artifacts —
    complete;
-5. add Jetson resource telemetry and run the safe simulation pilot with
-   `ROBOT_ENABLE_MOTION=0`;
-6. integrate the fixed-input VLM slice;
-7. extend the same adapter/runtime boundary to ASR and LLM;
-8. freeze formal thresholds and collect balanced synchronous/asynchronous data;
-9. add an opt-in motion-disabled application slice after the research Gates
+5. implement and host-test Jetson preflight, continuous resource telemetry and
+   pilot session validation — complete;
+6. run the safe Jetson simulation pilot with `ROBOT_ENABLE_MOTION=0`;
+7. integrate the fixed-input VLM slice;
+8. extend the same adapter/runtime boundary to ASR and LLM;
+9. freeze formal thresholds and collect balanced synchronous/asynchronous data;
+10. add an opt-in motion-disabled application slice after the research Gates
    pass.
 
 Contract changes are reviewed before implementation, and the formal protocol
@@ -150,13 +217,20 @@ The reusable, hardware-independent kernel lives under
 
 ```text
 experiments/phase1/
+├── jetson_preflight.py
+├── jetson_telemetry.py
 ├── manifest.py
+├── pilot.py
+├── run_jetson_pilot.py
 ├── run_simulation.py
-├── schemas/event.schema.json
+├── schemas/
+│   ├── event.schema.json
+│   └── resource.schema.json
 ├── simulation.py
 ├── summarize_run.py
 ├── tests/
 ├── telemetry.py
+├── validate_jetson_pilot.py
 ├── validate_run.py
 ├── replay_lifecycle.py
 └── README.md

--- a/experiments/phase1/jetson_preflight.py
+++ b/experiments/phase1/jetson_preflight.py
@@ -1,0 +1,269 @@
+"""Fail-closed environment checks for the Phase 1 Jetson simulation pilot."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from experiments.phase1.manifest import (
+    collect_environment,
+    command_snapshot,
+    motion_environment,
+    utc_now_iso,
+)
+
+
+PREFLIGHT_SCHEMA_VERSION = "0.1.0"
+FORBIDDEN_MODULES = (
+    "jetson.app",
+    "jetson.motion_planner",
+    "jetson.robot_comm",
+)
+_REQUIRED_CHECKS = {
+    "motion_disabled",
+    "linux_platform",
+    "arm64_machine",
+    "l4t_release_present",
+    "tegrastats_available",
+    "git_identity_complete",
+    "git_tree_clean",
+    "expected_branch",
+    "git_upstream_synchronized",
+    "forbidden_modules_absent",
+}
+
+
+def collect_jetson_environment(repo_root: Path | str) -> dict[str, object]:
+    """Collect read-only platform facts without importing device modules."""
+
+    environment = collect_environment(repo_root)
+    environment["jetpack_packages"] = command_snapshot(
+        [
+            "dpkg-query",
+            "-W",
+            "-f=${Package}\\t${Version}\\n",
+            "nvidia-jetpack",
+            "nvidia-l4t-core",
+        ]
+    )
+    environment["nvpmodel"] = command_snapshot(["nvpmodel", "-q"])
+    environment["jetson_clocks"] = command_snapshot(["jetson_clocks", "--show"])
+    return environment
+
+
+def _check(
+    name: str,
+    passed: bool,
+    *,
+    observed: object,
+    requirement: str,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "required": True,
+        "passed": passed,
+        "observed": observed,
+        "requirement": requirement,
+    }
+
+
+def build_jetson_preflight(
+    repo_root: Path | str,
+    *,
+    expected_branch: str = "main",
+    environment: Mapping[str, object] | None = None,
+    tegrastats_available: bool | None = None,
+    loaded_modules: Iterable[str] | None = None,
+) -> dict[str, object]:
+    """Build one serializable pilot preflight record."""
+
+    if not isinstance(expected_branch, str) or not expected_branch:
+        raise ValueError("expected_branch must be a non-empty string")
+    captured_environment = dict(
+        environment
+        if environment is not None
+        else collect_jetson_environment(repo_root)
+    )
+    safety = motion_environment()
+    git = captured_environment.get("git")
+    git_record = git if isinstance(git, Mapping) else {}
+    machine = str(captured_environment.get("machine", "")).lower()
+    platform_name = str(captured_environment.get("platform", ""))
+    l4t_release = str(captured_environment.get("l4t_release", ""))
+    available = (
+        bool(shutil.which("tegrastats"))
+        if tegrastats_available is None
+        else tegrastats_available
+    )
+    if not isinstance(available, bool):
+        raise TypeError("tegrastats_available must be boolean")
+    module_names = set(loaded_modules if loaded_modules is not None else sys.modules)
+    forbidden_loaded = sorted(
+        module
+        for module in module_names
+        if module in FORBIDDEN_MODULES
+        or any(module.startswith(name + ".") for name in FORBIDDEN_MODULES)
+    )
+    git_identity_complete = (
+        not git_record.get("error_codes")
+        and bool(git_record.get("commit"))
+        and bool(git_record.get("branch"))
+    )
+
+    checks = [
+        _check(
+            "motion_disabled",
+            safety.get("motion_enabled") is False
+            and safety.get("motion_value_valid") is True,
+            observed=safety,
+            requirement="ROBOT_ENABLE_MOTION is unset or explicitly false",
+        ),
+        _check(
+            "linux_platform",
+            platform_name.lower().startswith("linux"),
+            observed=platform_name,
+            requirement="the pilot runs on Linux",
+        ),
+        _check(
+            "arm64_machine",
+            machine in {"aarch64", "arm64"},
+            observed=machine,
+            requirement="the pilot runs on an ARM64 Jetson host",
+        ),
+        _check(
+            "l4t_release_present",
+            bool(l4t_release),
+            observed=bool(l4t_release),
+            requirement="the NVIDIA L4T release file is present",
+        ),
+        _check(
+            "tegrastats_available",
+            available,
+            observed=available,
+            requirement="tegrastats is available in PATH",
+        ),
+        _check(
+            "git_identity_complete",
+            git_identity_complete,
+            observed={
+                "commit_present": bool(git_record.get("commit")),
+                "branch": git_record.get("branch"),
+                "error_codes": git_record.get("error_codes"),
+            },
+            requirement="a commit and named branch identify the source tree",
+        ),
+        _check(
+            "git_tree_clean",
+            git_identity_complete and git_record.get("dirty") is False,
+            observed=git_record.get("dirty"),
+            requirement="the Git tree is clean before pilot artifacts are created",
+        ),
+        _check(
+            "expected_branch",
+            git_record.get("branch") == expected_branch,
+            observed=git_record.get("branch"),
+            requirement=f"the pilot runs from the reviewed {expected_branch} branch",
+        ),
+        _check(
+            "git_upstream_synchronized",
+            git_record.get("upstream") == f"origin/{expected_branch}"
+            and git_record.get("upstream_commit") == git_record.get("commit")
+            and str(git_record.get("ahead_behind", "")).split() == ["0", "0"],
+            observed={
+                "upstream": git_record.get("upstream"),
+                "same_commit": git_record.get("upstream_commit")
+                == git_record.get("commit"),
+                "ahead_behind": git_record.get("ahead_behind"),
+            },
+            requirement=f"local {expected_branch} matches origin/{expected_branch}",
+        ),
+        _check(
+            "forbidden_modules_absent",
+            not forbidden_loaded,
+            observed=forbidden_loaded,
+            requirement="robot application, motion planner and UART modules are not loaded",
+        ),
+    ]
+    return {
+        "preflight_schema_version": PREFLIGHT_SCHEMA_VERSION,
+        "captured_at": utc_now_iso(),
+        "expected_branch": expected_branch,
+        "safety": safety,
+        "environment": captured_environment,
+        "checks": checks,
+        "eligible": all(check["passed"] is True for check in checks),
+    }
+
+
+def preflight_errors(preflight: Mapping[str, object]) -> list[str]:
+    errors: list[str] = []
+    if preflight.get("preflight_schema_version") != PREFLIGHT_SCHEMA_VERSION:
+        errors.append("unsupported preflight schema version")
+    checks = preflight.get("checks")
+    if not isinstance(checks, list) or not checks:
+        errors.append("preflight contains no checks")
+        return errors
+    check_by_name: dict[str, Mapping[str, object]] = {}
+    for item in checks:
+        if not isinstance(item, Mapping):
+            errors.append("preflight check is not an object")
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or name in check_by_name:
+            errors.append(f"preflight check name is invalid or duplicated: {name!r}")
+            continue
+        check_by_name[name] = item
+        if item.get("required") is not True or item.get("passed") is not True:
+            errors.append(f"preflight check failed: {name}")
+    if set(check_by_name) != _REQUIRED_CHECKS:
+        errors.append("preflight check set is incomplete or unsupported")
+
+    safety = preflight.get("safety")
+    environment = preflight.get("environment")
+    git = environment.get("git") if isinstance(environment, Mapping) else None
+    expected_branch = preflight.get("expected_branch")
+    if not isinstance(safety, Mapping):
+        errors.append("preflight safety record is missing")
+    elif (
+        safety.get("motion_enabled") is not False
+        or safety.get("motion_value_valid") is not True
+    ):
+        errors.append("preflight safety record does not prove motion is disabled")
+    if not isinstance(environment, Mapping):
+        errors.append("preflight environment record is missing")
+    else:
+        if not str(environment.get("platform", "")).lower().startswith("linux"):
+            errors.append("preflight environment is not Linux")
+        if str(environment.get("machine", "")).lower() not in {"aarch64", "arm64"}:
+            errors.append("preflight environment is not ARM64")
+        if not environment.get("l4t_release"):
+            errors.append("preflight environment has no L4T release")
+    if not isinstance(git, Mapping):
+        errors.append("preflight Git record is missing")
+    else:
+        if git.get("error_codes") or not git.get("commit") or not git.get("branch"):
+            errors.append("preflight Git identity is incomplete")
+        if git.get("dirty") is not False:
+            errors.append("preflight Git tree is not clean")
+        if not isinstance(expected_branch, str) or git.get("branch") != expected_branch:
+            errors.append("preflight Git branch does not match the expected branch")
+        if (
+            not isinstance(expected_branch, str)
+            or git.get("upstream") != f"origin/{expected_branch}"
+            or git.get("upstream_commit") != git.get("commit")
+            or str(git.get("ahead_behind", "")).split() != ["0", "0"]
+        ):
+            errors.append("preflight Git branch is not synchronized with its upstream")
+    forbidden_check = check_by_name.get("forbidden_modules_absent")
+    if forbidden_check is None or forbidden_check.get("observed") != []:
+        errors.append("preflight does not prove forbidden modules were absent")
+    tegrastats_check = check_by_name.get("tegrastats_available")
+    if tegrastats_check is None or tegrastats_check.get("observed") is not True:
+        errors.append("preflight does not prove tegrastats was available")
+
+    expected_eligibility = not errors
+    if preflight.get("eligible") is not expected_eligibility:
+        errors.append("preflight eligibility is inconsistent")
+    return errors

--- a/experiments/phase1/jetson_telemetry.py
+++ b/experiments/phase1/jetson_telemetry.py
@@ -1,0 +1,808 @@
+"""Bounded tegrastats recording for the Phase 1 Jetson pilot."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import shutil
+import statistics
+import subprocess
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence, TextIO
+
+
+RESOURCE_SCHEMA_VERSION = "0.1.0"
+_MAX_LINE_LENGTH = 8192
+
+_TEGRA_TIME_RE = re.compile(
+    r"^(?P<date>[0-9]{2}-[0-9]{2}-[0-9]{4})\s+" r"(?P<time>[0-9]{2}:[0-9]{2}:[0-9]{2})"
+)
+_RAM_RE = re.compile(
+    r"\bRAM\s+(?P<used>\d+)/(?P<total>\d+)MB\s+"
+    r"\(lfb\s+(?P<count>\d+)x(?P<size>\d+)(?P<unit>MB|kB)\)"
+)
+_SWAP_RE = re.compile(
+    r"\bSWAP\s+(?P<used>\d+)/(?P<total>\d+)MB\s+" r"\(cached\s+(?P<cached>\d+)MB\)"
+)
+_CPU_RE = re.compile(r"\bCPU\s+\[(?P<cores>[^\]]+)\]")
+_CORE_RE = re.compile(r"^(?P<usage>\d+)%@(?P<freq>\d+)$")
+_EMC_RE = re.compile(r"\bEMC_FREQ\s+(?P<usage>\d+)%" r"(?:@(?P<freq>\d+))?")
+_GR3D_RE = re.compile(
+    r"\bGR3D_FREQ\s+(?P<usage>\d+)%" r"(?:@(?P<freq>\[[0-9, ]+\]|\d+))?"
+)
+_TEMP_RE = re.compile(
+    r"\b(?P<name>[A-Za-z][A-Za-z0-9_]*)@(?P<value>[0-9]+(?:\.[0-9]+)?)C"
+)
+_POWER_RE = re.compile(
+    r"\b(?P<name>VDD_[A-Z0-9_]+)\s+" r"(?P<instant>\d+)mW/(?P<average>\d+)mW"
+)
+_SAMPLE_KEYS = {
+    "resource_schema_version",
+    "seq",
+    "sample_monotonic_ns",
+    "sample_wall_time_ns",
+    "tegrastats_time",
+    "ram",
+    "swap",
+    "cpu",
+    "emc",
+    "gr3d",
+    "temperatures_c",
+    "power",
+    "parse_errors",
+    "parse_warnings",
+    "raw_line",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TegrastatsStopReport:
+    """Finite process and reader-thread shutdown evidence."""
+
+    sample_count: int
+    parse_error_count: int
+    first_sample_monotonic_ns: int | None
+    last_sample_monotonic_ns: int | None
+    process_returncode: int | None
+    stop_method: str
+    reader_joined: bool
+    reader_error_code: str | None
+
+    @property
+    def successful(self) -> bool:
+        return (
+            self.sample_count > 0
+            and self.parse_error_count == 0
+            and self.stop_method in {"terminated", "killed"}
+            and self.reader_joined
+            and self.reader_error_code is None
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        value = asdict(self)
+        value["successful"] = self.successful
+        return value
+
+
+def _percentage(value: str, field: str, errors: list[str]) -> int:
+    parsed = int(value)
+    if not 0 <= parsed <= 100:
+        errors.append(f"{field}_range")
+    return parsed
+
+
+def _gr3d_frequencies(value: str | None) -> list[int]:
+    if value is None:
+        return []
+    return [int(item) for item in re.findall(r"\d+", value)]
+
+
+def parse_tegrastats_line(
+    line: str,
+    *,
+    sequence: int,
+    sample_monotonic_ns: int,
+    sample_wall_time_ns: int,
+) -> dict[str, Any]:
+    """Parse one bounded JetPack tegrastats line without fixed sensor names."""
+
+    for value, name in (
+        (sequence, "sequence"),
+        (sample_monotonic_ns, "sample_monotonic_ns"),
+        (sample_wall_time_ns, "sample_wall_time_ns"),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{name} must be a non-negative integer")
+    if not isinstance(line, str):
+        raise TypeError("line must be a string")
+
+    raw_line = line.rstrip("\r\n")
+    errors: list[str] = []
+    warnings: list[str] = []
+    if len(raw_line) > _MAX_LINE_LENGTH:
+        raw_line = raw_line[:_MAX_LINE_LENGTH]
+        errors.append("line_too_long")
+
+    timestamp_match = _TEGRA_TIME_RE.search(raw_line)
+    timestamp = (
+        f"{timestamp_match.group('date')} {timestamp_match.group('time')}"
+        if timestamp_match is not None
+        else None
+    )
+    if timestamp is None:
+        warnings.append("tegrastats_timestamp_missing")
+
+    ram: dict[str, int | float] | None = None
+    ram_match = _RAM_RE.search(raw_line)
+    if ram_match is None:
+        errors.append("ram_missing")
+    else:
+        lfb_size_mb = int(ram_match.group("size"))
+        if ram_match.group("unit") == "kB":
+            lfb_size_mb /= 1024
+        ram = {
+            "used_mb": int(ram_match.group("used")),
+            "total_mb": int(ram_match.group("total")),
+            "lfb_count": int(ram_match.group("count")),
+            "lfb_size_mb": lfb_size_mb,
+        }
+
+    swap: dict[str, int] | None = None
+    swap_match = _SWAP_RE.search(raw_line)
+    if swap_match is None:
+        errors.append("swap_missing")
+    else:
+        swap = {
+            "used_mb": int(swap_match.group("used")),
+            "total_mb": int(swap_match.group("total")),
+            "cached_mb": int(swap_match.group("cached")),
+        }
+
+    cpu: list[dict[str, int | bool | None]] = []
+    cpu_match = _CPU_RE.search(raw_line)
+    if cpu_match is None:
+        errors.append("cpu_missing")
+    else:
+        tokens = [item.strip() for item in cpu_match.group("cores").split(",")]
+        if not tokens or len(tokens) > 32:
+            errors.append("cpu_count_invalid")
+        for index, token in enumerate(tokens[:32]):
+            if token.lower() == "off":
+                cpu.append(
+                    {
+                        "index": index,
+                        "online": False,
+                        "usage_pct": None,
+                        "frequency_mhz": None,
+                    }
+                )
+                continue
+            core_match = _CORE_RE.fullmatch(token)
+            if core_match is None:
+                errors.append(f"cpu{index}_invalid")
+                cpu.append(
+                    {
+                        "index": index,
+                        "online": True,
+                        "usage_pct": None,
+                        "frequency_mhz": None,
+                    }
+                )
+                continue
+            cpu.append(
+                {
+                    "index": index,
+                    "online": True,
+                    "usage_pct": _percentage(
+                        core_match.group("usage"), f"cpu{index}_usage", errors
+                    ),
+                    "frequency_mhz": int(core_match.group("freq")),
+                }
+            )
+
+    emc: dict[str, int | None] | None = None
+    emc_match = _EMC_RE.search(raw_line)
+    if emc_match is not None:
+        emc = {
+            "usage_pct": _percentage(emc_match.group("usage"), "emc_usage", errors),
+            "frequency_mhz": (
+                int(emc_match.group("freq"))
+                if emc_match.group("freq") is not None
+                else None
+            ),
+        }
+    else:
+        warnings.append("emc_missing")
+
+    gr3d: dict[str, object] | None = None
+    gr3d_match = _GR3D_RE.search(raw_line)
+    if gr3d_match is None:
+        errors.append("gr3d_missing")
+    else:
+        gr3d = {
+            "usage_pct": _percentage(gr3d_match.group("usage"), "gr3d_usage", errors),
+            "frequencies_mhz": _gr3d_frequencies(gr3d_match.group("freq")),
+        }
+
+    temperatures: dict[str, float] = {}
+    for match in _TEMP_RE.finditer(raw_line):
+        if len(temperatures) >= 64:
+            errors.append("temperature_count_invalid")
+            break
+        temperatures[match.group("name").lower()] = float(match.group("value"))
+    if not temperatures:
+        errors.append("temperature_missing")
+
+    power: dict[str, dict[str, int]] = {}
+    for match in _POWER_RE.finditer(raw_line):
+        if len(power) >= 64:
+            errors.append("power_count_invalid")
+            break
+        power[match.group("name")] = {
+            "instant_mw": int(match.group("instant")),
+            "average_mw": int(match.group("average")),
+        }
+    if not power:
+        errors.append("power_missing")
+
+    return {
+        "resource_schema_version": RESOURCE_SCHEMA_VERSION,
+        "seq": sequence,
+        "sample_monotonic_ns": sample_monotonic_ns,
+        "sample_wall_time_ns": sample_wall_time_ns,
+        "tegrastats_time": timestamp,
+        "ram": ram,
+        "swap": swap,
+        "cpu": cpu,
+        "emc": emc,
+        "gr3d": gr3d,
+        "temperatures_c": temperatures,
+        "power": power,
+        "parse_errors": errors,
+        "parse_warnings": warnings,
+        "raw_line": raw_line,
+    }
+
+
+def load_resource_samples(path: Path | str) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    with Path(path).open("r", encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, start=1):
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"resources.jsonl line {line_number}: invalid JSON: {exc}"
+                ) from exc
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"resources.jsonl line {line_number}: root must be an object"
+                )
+            samples.append(item)
+    return samples
+
+
+def _nonnegative_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _finite_nonnegative_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= 0
+    )
+
+
+def _bounded_messages(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and len(value) <= 32
+        and all(isinstance(item, str) and 1 <= len(item) <= 128 for item in value)
+    )
+
+
+def validate_resource_samples(samples: Sequence[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    if not samples:
+        return ["resources.jsonl contains no samples"]
+    previous_monotonic_ns = -1
+    for expected_seq, sample in enumerate(samples):
+        prefix = f"resources.jsonl line {expected_seq + 1}"
+        if set(sample) != _SAMPLE_KEYS:
+            errors.append(f"{prefix}: sample fields do not match the resource schema")
+        if sample.get("resource_schema_version") != RESOURCE_SCHEMA_VERSION:
+            errors.append(f"{prefix}: unsupported resource schema version")
+        if sample.get("seq") != expected_seq:
+            errors.append(f"{prefix}: sequence is not contiguous")
+
+        monotonic_ns = sample.get("sample_monotonic_ns")
+        if not _nonnegative_int(monotonic_ns) or monotonic_ns < previous_monotonic_ns:
+            errors.append(f"{prefix}: monotonic timestamp moved backwards")
+        if _nonnegative_int(monotonic_ns):
+            previous_monotonic_ns = max(previous_monotonic_ns, monotonic_ns)
+        wall_time_ns = sample.get("sample_wall_time_ns")
+        if not _nonnegative_int(wall_time_ns) or wall_time_ns == 0:
+            errors.append(f"{prefix}: invalid wall timestamp")
+        tegrastats_time = sample.get("tegrastats_time")
+        if tegrastats_time is not None and (
+            not isinstance(tegrastats_time, str)
+            or _TEGRA_TIME_RE.fullmatch(tegrastats_time) is None
+        ):
+            errors.append(f"{prefix}: invalid tegrastats timestamp")
+
+        ram = sample.get("ram")
+        if not isinstance(ram, dict) or set(ram) != {
+            "used_mb",
+            "total_mb",
+            "lfb_count",
+            "lfb_size_mb",
+        }:
+            errors.append(f"{prefix}: ram observation is invalid")
+        elif (
+            not _nonnegative_int(ram.get("used_mb"))
+            or not _nonnegative_int(ram.get("total_mb"))
+            or ram["used_mb"] > ram["total_mb"]
+            or not _nonnegative_int(ram.get("lfb_count"))
+            or not _finite_nonnegative_number(ram.get("lfb_size_mb"))
+        ):
+            errors.append(f"{prefix}: ram values are invalid")
+
+        swap = sample.get("swap")
+        if not isinstance(swap, dict) or set(swap) != {
+            "used_mb",
+            "total_mb",
+            "cached_mb",
+        }:
+            errors.append(f"{prefix}: swap observation is invalid")
+        elif (
+            not _nonnegative_int(swap.get("used_mb"))
+            or not _nonnegative_int(swap.get("total_mb"))
+            or swap["used_mb"] > swap["total_mb"]
+            or not _nonnegative_int(swap.get("cached_mb"))
+        ):
+            errors.append(f"{prefix}: swap values are invalid")
+
+        parse_errors = sample.get("parse_errors")
+        if not _bounded_messages(parse_errors):
+            errors.append(f"{prefix}: parse_errors must be a bounded array")
+        elif parse_errors:
+            errors.append(f"{prefix}: unexplained parse errors: {parse_errors}")
+        if not _bounded_messages(sample.get("parse_warnings")):
+            errors.append(f"{prefix}: parse_warnings must be a bounded array")
+
+        cpu = sample.get("cpu")
+        if not isinstance(cpu, list) or not 1 <= len(cpu) <= 32:
+            errors.append(f"{prefix}: CPU observations are missing")
+        else:
+            for index, core in enumerate(cpu):
+                if not isinstance(core, dict) or set(core) != {
+                    "index",
+                    "online",
+                    "usage_pct",
+                    "frequency_mhz",
+                }:
+                    errors.append(f"{prefix}: CPU core {index} is invalid")
+                    continue
+                online = core.get("online")
+                usage = core.get("usage_pct")
+                frequency = core.get("frequency_mhz")
+                if core.get("index") != index or not isinstance(online, bool):
+                    errors.append(f"{prefix}: CPU core {index} identity is invalid")
+                if online:
+                    if (
+                        not _nonnegative_int(usage)
+                        or usage > 100
+                        or not _nonnegative_int(frequency)
+                    ):
+                        errors.append(f"{prefix}: CPU core {index} values are invalid")
+                elif usage is not None or frequency is not None:
+                    errors.append(f"{prefix}: offline CPU core {index} has values")
+
+        emc = sample.get("emc")
+        if emc is not None:
+            if not isinstance(emc, dict) or set(emc) != {
+                "usage_pct",
+                "frequency_mhz",
+            }:
+                errors.append(f"{prefix}: EMC observation is invalid")
+            else:
+                usage = emc.get("usage_pct")
+                frequency = emc.get("frequency_mhz")
+                if not _nonnegative_int(usage) or usage > 100:
+                    errors.append(f"{prefix}: EMC usage is invalid")
+                if frequency is not None and not _nonnegative_int(frequency):
+                    errors.append(f"{prefix}: EMC frequency is invalid")
+
+        gr3d = sample.get("gr3d")
+        if not isinstance(gr3d, dict) or set(gr3d) != {
+            "usage_pct",
+            "frequencies_mhz",
+        }:
+            errors.append(f"{prefix}: GR3D observation is invalid")
+        else:
+            frequencies = gr3d.get("frequencies_mhz")
+            if not _nonnegative_int(gr3d.get("usage_pct")) or gr3d["usage_pct"] > 100:
+                errors.append(f"{prefix}: GR3D usage is invalid")
+            if (
+                not isinstance(frequencies, list)
+                or len(frequencies) > 16
+                or any(not _nonnegative_int(value) for value in frequencies)
+            ):
+                errors.append(f"{prefix}: GR3D frequencies are invalid")
+
+        temperatures = sample.get("temperatures_c")
+        if not isinstance(temperatures, dict) or not 1 <= len(temperatures) <= 64:
+            errors.append(f"{prefix}: temperature observations are missing")
+        elif any(
+            re.fullmatch(r"[a-z][a-z0-9_]*", str(name)) is None
+            or not _finite_nonnegative_number(value)
+            for name, value in temperatures.items()
+        ):
+            errors.append(f"{prefix}: temperature observations are invalid")
+
+        power = sample.get("power")
+        if not isinstance(power, dict) or not 1 <= len(power) <= 64:
+            errors.append(f"{prefix}: power observations are missing")
+        else:
+            for name, values in power.items():
+                if re.fullmatch(r"VDD_[A-Z0-9_]+", str(name)) is None:
+                    errors.append(f"{prefix}: power rail name is invalid")
+                if not isinstance(values, dict) or set(values) != {
+                    "instant_mw",
+                    "average_mw",
+                }:
+                    errors.append(f"{prefix}: power rail {name} is invalid")
+                elif not _nonnegative_int(
+                    values.get("instant_mw")
+                ) or not _nonnegative_int(values.get("average_mw")):
+                    errors.append(f"{prefix}: power rail {name} values are invalid")
+
+        raw_line = sample.get("raw_line")
+        if (
+            not isinstance(raw_line, str)
+            or not raw_line
+            or len(raw_line) > _MAX_LINE_LENGTH
+        ):
+            errors.append(f"{prefix}: raw_line is invalid")
+        elif (
+            _nonnegative_int(sample.get("seq"))
+            and _nonnegative_int(monotonic_ns)
+            and _nonnegative_int(wall_time_ns)
+        ):
+            rebuilt = parse_tegrastats_line(
+                raw_line,
+                sequence=sample["seq"],
+                sample_monotonic_ns=monotonic_ns,
+                sample_wall_time_ns=wall_time_ns,
+            )
+            if sample != rebuilt:
+                errors.append(f"{prefix}: parsed fields do not match raw_line")
+    return errors
+
+
+def _nearest_rank(values: Sequence[float], percentile: int) -> float:
+    ordered = sorted(values)
+    rank = math.ceil(percentile / 100 * len(ordered))
+    return ordered[rank - 1]
+
+
+def _describe(values: Iterable[int | float]) -> dict[str, int | float] | None:
+    items = [float(value) for value in values]
+    if not items:
+        return None
+    return {
+        "count": len(items),
+        "min": min(items),
+        "mean": statistics.fmean(items),
+        "median": statistics.median(items),
+        "p50": _nearest_rank(items, 50),
+        "p95": _nearest_rank(items, 95),
+        "p99": _nearest_rank(items, 99),
+        "max": max(items),
+    }
+
+
+def summarize_resource_samples(
+    samples: Sequence[dict[str, Any]],
+) -> dict[str, object]:
+    monotonic = [int(sample["sample_monotonic_ns"]) for sample in samples]
+    intervals = [
+        current - previous for previous, current in zip(monotonic, monotonic[1:])
+    ]
+    cpu_usage: dict[str, list[int]] = {}
+    cpu_frequency: dict[str, list[int]] = {}
+    temperatures: dict[str, list[float]] = {}
+    power_instant: dict[str, list[int]] = {}
+    power_average: dict[str, list[int]] = {}
+
+    for sample in samples:
+        for core in sample.get("cpu", []):
+            if not isinstance(core, dict):
+                continue
+            key = str(core.get("index"))
+            usage = core.get("usage_pct")
+            frequency = core.get("frequency_mhz")
+            if isinstance(usage, int) and not isinstance(usage, bool):
+                cpu_usage.setdefault(key, []).append(usage)
+            if isinstance(frequency, int) and not isinstance(frequency, bool):
+                cpu_frequency.setdefault(key, []).append(frequency)
+        for name, value in sample.get("temperatures_c", {}).items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                temperatures.setdefault(str(name), []).append(float(value))
+        for name, value in sample.get("power", {}).items():
+            if not isinstance(value, dict):
+                continue
+            instant = value.get("instant_mw")
+            average = value.get("average_mw")
+            if isinstance(instant, int) and not isinstance(instant, bool):
+                power_instant.setdefault(str(name), []).append(instant)
+            if isinstance(average, int) and not isinstance(average, bool):
+                power_average.setdefault(str(name), []).append(average)
+
+    ram_used = [sample["ram"]["used_mb"] for sample in samples]
+    swap_used = [sample["swap"]["used_mb"] for sample in samples]
+    gr3d_usage = [sample["gr3d"]["usage_pct"] for sample in samples]
+    emc_usage = [
+        sample["emc"]["usage_pct"]
+        for sample in samples
+        if isinstance(sample.get("emc"), dict)
+    ]
+    return {
+        "resource_schema_version": RESOURCE_SCHEMA_VERSION,
+        "sample_count": len(samples),
+        "parse_error_count": sum(
+            bool(sample.get("parse_errors")) for sample in samples
+        ),
+        "parse_warning_count": sum(
+            bool(sample.get("parse_warnings")) for sample in samples
+        ),
+        "first_sample_monotonic_ns": monotonic[0] if monotonic else None,
+        "last_sample_monotonic_ns": monotonic[-1] if monotonic else None,
+        "sample_span_ns": monotonic[-1] - monotonic[0] if len(monotonic) > 1 else 0,
+        "sample_interval_ns": _describe(intervals),
+        "ram_used_mb": _describe(ram_used),
+        "swap_used_mb": _describe(swap_used),
+        "cpu_usage_pct": {
+            key: _describe(values) for key, values in sorted(cpu_usage.items())
+        },
+        "cpu_frequency_mhz": {
+            key: _describe(values) for key, values in sorted(cpu_frequency.items())
+        },
+        "gr3d_usage_pct": _describe(gr3d_usage),
+        "emc_usage_pct": _describe(emc_usage),
+        "temperatures_c": {
+            key: _describe(values) for key, values in sorted(temperatures.items())
+        },
+        "power_instant_mw": {
+            key: _describe(values) for key, values in sorted(power_instant.items())
+        },
+        "power_reported_average_mw": {
+            key: _describe(values) for key, values in sorted(power_average.items())
+        },
+    }
+
+
+class TegrastatsSampler:
+    """Run one non-daemon tegrastats reader for an entire pilot session."""
+
+    def __init__(
+        self,
+        session_dir: Path | str,
+        interval_ms: int = 200,
+        *,
+        command: Sequence[str] | None = None,
+    ) -> None:
+        if isinstance(interval_ms, bool) or not isinstance(interval_ms, int):
+            raise TypeError("interval_ms must be an integer")
+        if interval_ms < 50 or interval_ms > 10_000:
+            raise ValueError("interval_ms must be between 50 and 10000")
+        if command is not None and (
+            isinstance(command, (str, bytes))
+            or not command
+            or any(not isinstance(item, str) or not item for item in command)
+        ):
+            raise ValueError("command must be a non-empty sequence of strings")
+        self.session_dir = Path(session_dir)
+        self.interval_ms = interval_ms
+        self.path = self.session_dir / "resources.jsonl"
+        self._configured_command = tuple(command) if command is not None else None
+        self._process: subprocess.Popen[str] | None = None
+        self._thread: threading.Thread | None = None
+        self._stream: TextIO | None = None
+        self._ready = threading.Event()
+        self._sample_count = 0
+        self._parse_error_count = 0
+        self._first_sample_ns: int | None = None
+        self._last_sample_ns: int | None = None
+        self._reader_error_code: str | None = None
+        self._stop_report: TegrastatsStopReport | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._process is not None and self._stop_report is None
+
+    @property
+    def stop_report(self) -> TegrastatsStopReport | None:
+        return self._stop_report
+
+    def _command(self) -> list[str]:
+        if self._configured_command is not None:
+            return list(self._configured_command)
+        binary = shutil.which("tegrastats")
+        if binary is None:
+            raise RuntimeError("tegrastats was not found in PATH")
+        return [binary, "--interval", str(self.interval_ms)]
+
+    def start(self, *, first_sample_timeout_s: float = 3.0) -> None:
+        if self._process is not None or self._stop_report is not None:
+            raise RuntimeError("tegrastats sampler has already been started")
+        if (
+            isinstance(first_sample_timeout_s, bool)
+            or not isinstance(first_sample_timeout_s, (int, float))
+            or not math.isfinite(first_sample_timeout_s)
+            or first_sample_timeout_s <= 0
+        ):
+            raise ValueError("first_sample_timeout_s must be positive and finite")
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            raise FileExistsError(f"refusing to overwrite telemetry: {self.path}")
+        self._stream = self.path.open(
+            "w", encoding="utf-8", buffering=64 * 1024, newline="\n"
+        )
+        try:
+            self._process = subprocess.Popen(
+                self._command(),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+        except Exception:
+            self._stream.close()
+            self._stream = None
+            raise
+        self._thread = threading.Thread(
+            target=self._reader_loop,
+            name="phase1-tegrastats-reader",
+            daemon=False,
+        )
+        try:
+            self._thread.start()
+        except Exception:
+            if self._process.poll() is None:
+                self._process.terminate()
+                try:
+                    self._process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self._process.kill()
+                    self._process.wait(timeout=2)
+            if self._process.stdout is not None:
+                self._process.stdout.close()
+            self._stream.close()
+            self._process = None
+            self._thread = None
+            self._stream = None
+            raise
+        if not self._ready.wait(float(first_sample_timeout_s)):
+            self.stop()
+            raise TimeoutError("tegrastats did not produce a sample before the timeout")
+        if self._sample_count == 0:
+            error_code = self._reader_error_code or "tegrastats_exited_without_sample"
+            self.stop()
+            raise RuntimeError(f"tegrastats startup failed: {error_code}")
+        if self._parse_error_count:
+            self.stop()
+            raise RuntimeError(
+                "the first tegrastats sample did not satisfy the parser contract"
+            )
+
+    def _reader_loop(self) -> None:
+        assert self._process is not None
+        assert self._process.stdout is not None
+        assert self._stream is not None
+        try:
+            for line in self._process.stdout:
+                if not line.strip():
+                    continue
+                monotonic_ns = time.monotonic_ns()
+                sample = parse_tegrastats_line(
+                    line,
+                    sequence=self._sample_count,
+                    sample_monotonic_ns=monotonic_ns,
+                    sample_wall_time_ns=time.time_ns(),
+                )
+                self._stream.write(
+                    json.dumps(
+                        sample,
+                        ensure_ascii=False,
+                        allow_nan=False,
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                self._stream.flush()
+                self._sample_count += 1
+                self._parse_error_count += int(bool(sample["parse_errors"]))
+                if self._first_sample_ns is None:
+                    self._first_sample_ns = monotonic_ns
+                self._last_sample_ns = monotonic_ns
+                self._ready.set()
+        except Exception as exc:
+            self._reader_error_code = type(exc).__name__.lower()
+        finally:
+            self._ready.set()
+
+    def stop(
+        self,
+        *,
+        terminate_timeout_s: float = 2.0,
+        join_timeout_s: float = 2.0,
+    ) -> TegrastatsStopReport:
+        if self._stop_report is not None:
+            return self._stop_report
+        for value, name in (
+            (terminate_timeout_s, "terminate_timeout_s"),
+            (join_timeout_s, "join_timeout_s"),
+        ):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                or value <= 0
+            ):
+                raise ValueError(f"{name} must be positive and finite")
+        process = self._process
+        if process is None:
+            raise RuntimeError("tegrastats sampler has not been started")
+        stop_method = "exited"
+        if process.poll() is None:
+            stop_method = "terminated"
+            process.terminate()
+            try:
+                process.wait(timeout=terminate_timeout_s)
+            except subprocess.TimeoutExpired:
+                stop_method = "killed"
+                process.kill()
+                process.wait(timeout=terminate_timeout_s)
+
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=join_timeout_s)
+        reader_joined = thread is None or not thread.is_alive()
+        if not reader_joined and process.stdout is not None:
+            process.stdout.close()
+            thread.join(timeout=join_timeout_s)
+            reader_joined = not thread.is_alive()
+        if not reader_joined and self._reader_error_code is None:
+            self._reader_error_code = "reader_join_timeout"
+        if process.stdout is not None and not process.stdout.closed:
+            process.stdout.close()
+        if self._stream is not None:
+            self._stream.flush()
+            self._stream.close()
+
+        self._stop_report = TegrastatsStopReport(
+            sample_count=self._sample_count,
+            parse_error_count=self._parse_error_count,
+            first_sample_monotonic_ns=self._first_sample_ns,
+            last_sample_monotonic_ns=self._last_sample_ns,
+            process_returncode=process.returncode,
+            stop_method=stop_method,
+            reader_joined=reader_joined,
+            reader_error_code=self._reader_error_code,
+        )
+        return self._stop_report
+
+    def __enter__(self) -> "TegrastatsSampler":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.stop()

--- a/experiments/phase1/manifest.py
+++ b/experiments/phase1/manifest.py
@@ -72,7 +72,7 @@ def write_json_atomic(path: Path | str, data: dict[str, Any]) -> None:
     os.replace(temporary, target)
 
 
-def _command_snapshot(
+def command_snapshot(
     command: list[str],
     *,
     cwd: Path | str | None = None,
@@ -104,15 +104,31 @@ def _command_snapshot(
 
 def git_snapshot(repo_root: Path | str) -> dict[str, object]:
     root = Path(repo_root)
-    commit = _command_snapshot(["git", "rev-parse", "HEAD"], cwd=root)
-    branch = _command_snapshot(["git", "branch", "--show-current"], cwd=root)
-    status = _command_snapshot(["git", "status", "--porcelain"], cwd=root)
+    commit = command_snapshot(["git", "rev-parse", "HEAD"], cwd=root)
+    branch = command_snapshot(["git", "branch", "--show-current"], cwd=root)
+    status = command_snapshot(["git", "status", "--porcelain"], cwd=root)
+    upstream = command_snapshot(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        cwd=root,
+    )
+    upstream_commit = command_snapshot(["git", "rev-parse", "@{upstream}"], cwd=root)
+    ahead_behind = command_snapshot(
+        ["git", "rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
+        cwd=root,
+    )
     status_output = status["output"] if isinstance(status["output"], str) else ""
     return {
         "commit": commit["output"],
         "branch": branch["output"],
         "dirty": bool(status_output),
         "status_porcelain": status_output.splitlines(),
+        "upstream": upstream["output"] if upstream["returncode"] == 0 else "",
+        "upstream_commit": (
+            upstream_commit["output"] if upstream_commit["returncode"] == 0 else ""
+        ),
+        "ahead_behind": (
+            ahead_behind["output"] if ahead_behind["returncode"] == 0 else ""
+        ),
         "error_codes": [
             value
             for value in (

--- a/experiments/phase1/pilot.py
+++ b/experiments/phase1/pilot.py
@@ -1,0 +1,732 @@
+"""Plan, summarize and validate the Phase 1 Jetson simulation pilot."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from experiments.phase1.jetson_preflight import (
+    PREFLIGHT_SCHEMA_VERSION,
+    preflight_errors,
+)
+from experiments.phase1.jetson_telemetry import (
+    RESOURCE_SCHEMA_VERSION,
+    load_resource_samples,
+    summarize_resource_samples,
+    validate_resource_samples,
+)
+from experiments.phase1.manifest import sha256_file
+from experiments.phase1.simulation import SimulationCondition
+from experiments.phase1.validate_run import (
+    REQUIRED_FILES as RUN_REQUIRED_FILES,
+    validate_run_dir,
+)
+
+
+PILOT_MANIFEST_SCHEMA_VERSION = "0.1.0"
+PILOT_PLAN_SCHEMA_VERSION = "0.1.0"
+PILOT_SUMMARY_SCHEMA_VERSION = "0.1.0"
+PILOT_REQUIRED_FILES = (
+    "session_manifest.json",
+    "pilot_plan.json",
+    "preflight.json",
+    "resources.jsonl",
+    "pilot_summary.json",
+)
+_SESSION_ID_RE = re.compile(
+    r"^[0-9]{8}T[0-9]{6}Z_phase1_jetson_pilot(?:_[a-z][a-z0-9_-]{0,31})?$"
+)
+_RESPONSIVENESS_CONDITIONS = (
+    SimulationCondition.R0_IDLE,
+    SimulationCondition.R1_INLINE_SYNC,
+    SimulationCondition.R2_THREADED_SYNC,
+    SimulationCondition.R3_ASYNC,
+)
+_CORRECTNESS_CONDITIONS = (
+    SimulationCondition.R4_STALE,
+    SimulationCondition.R4_OVERFLOW,
+)
+
+
+class PilotError(RuntimeError):
+    """The Jetson pilot contract could not be satisfied."""
+
+
+def make_pilot_session_id(
+    now: datetime | None = None,
+    *,
+    label: str | None = None,
+) -> str:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    suffix = ""
+    if label is not None:
+        if not re.fullmatch(r"[a-z][a-z0-9_-]{0,31}", label):
+            raise ValueError("label must be a bounded lowercase identifier")
+        suffix = "_" + label
+    stamp = current.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}_phase1_jetson_pilot{suffix}"
+
+
+def validate_pilot_session_id(value: str) -> str:
+    if not isinstance(value, str) or not _SESSION_ID_RE.fullmatch(value):
+        raise ValueError(
+            "session_id must use YYYYMMDDTHHMMSSZ_phase1_jetson_pilot[_label]"
+        )
+    return value
+
+
+def _finite_seconds(value: object, name: str, *, positive: bool = False) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+        or (positive and value == 0)
+        or value > 3600
+    ):
+        qualifier = "positive" if positive else "non-negative"
+        raise ValueError(f"{name} must be a finite {qualifier} value up to 3600")
+    return float(value)
+
+
+def build_pilot_plan(
+    *,
+    session_id: str,
+    service_times_s: Sequence[float],
+    repetitions: int = 1,
+    correctness_service_time_s: float | None = None,
+    prelude_s: float = 1.0,
+    postlude_s: float = 1.0,
+    probe_period_ms: float = 100.0,
+    probe_deadline_ms: float = 100.0,
+    pending_capacity: int = 1,
+    result_capacity: int = 1,
+    overflow_submissions: int = 2,
+    adapter_poll_interval_s: float = 0.01,
+    join_timeout_s: float = 5.0,
+    resource_interval_ms: int = 200,
+    resource_tail_s: float = 0.4,
+) -> dict[str, object]:
+    """Freeze one deterministic descriptive pilot matrix before execution."""
+
+    validate_pilot_session_id(session_id)
+    if isinstance(service_times_s, (str, bytes)) or not service_times_s:
+        raise ValueError("service_times_s must contain at least one duration")
+    durations = [
+        _finite_seconds(value, "service_times_s", positive=True)
+        for value in service_times_s
+    ]
+    if len(set(durations)) != len(durations):
+        raise ValueError("service_times_s must not contain duplicates")
+    if isinstance(repetitions, bool) or not isinstance(repetitions, int):
+        raise TypeError("repetitions must be an integer")
+    if repetitions < 1 or repetitions > 30:
+        raise ValueError("repetitions must be between 1 and 30")
+    correctness_duration = _finite_seconds(
+        (
+            correctness_service_time_s
+            if correctness_service_time_s is not None
+            else min(durations)
+        ),
+        "correctness_service_time_s",
+        positive=True,
+    )
+    prelude = _finite_seconds(prelude_s, "prelude_s")
+    postlude = _finite_seconds(postlude_s, "postlude_s")
+    poll = _finite_seconds(
+        adapter_poll_interval_s, "adapter_poll_interval_s", positive=True
+    )
+    join = _finite_seconds(join_timeout_s, "join_timeout_s", positive=True)
+    tail = _finite_seconds(resource_tail_s, "resource_tail_s")
+    for value, name in (
+        (probe_period_ms, "probe_period_ms"),
+        (probe_deadline_ms, "probe_deadline_ms"),
+    ):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{name} must be numeric")
+    probe_period = (
+        _finite_seconds(probe_period_ms / 1000, "probe_period_ms", positive=True) * 1000
+    )
+    probe_deadline = (
+        _finite_seconds(probe_deadline_ms / 1000, "probe_deadline_ms", positive=True)
+        * 1000
+    )
+    for value, name in (
+        (pending_capacity, "pending_capacity"),
+        (result_capacity, "result_capacity"),
+        (overflow_submissions, "overflow_submissions"),
+        (resource_interval_ms, "resource_interval_ms"),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+    if resource_interval_ms < 50 or resource_interval_ms > 10_000:
+        raise ValueError("resource_interval_ms must be between 50 and 10000")
+
+    runs: list[dict[str, object]] = []
+    sequence = 0
+    for repetition in range(1, repetitions + 1):
+        for duration in durations:
+            for condition in _RESPONSIVENESS_CONDITIONS:
+                sequence += 1
+                runs.append(
+                    {
+                        "sequence": sequence,
+                        "block_repetition": repetition,
+                        "condition": condition.value,
+                        "service_time_s": duration,
+                        "role": "responsiveness",
+                    }
+                )
+        for condition in _CORRECTNESS_CONDITIONS:
+            sequence += 1
+            runs.append(
+                {
+                    "sequence": sequence,
+                    "block_repetition": repetition,
+                    "condition": condition.value,
+                    "service_time_s": correctness_duration,
+                    "role": "correctness",
+                }
+            )
+    if len(runs) > 999:
+        raise ValueError("pilot plan must not exceed 999 runs")
+
+    return {
+        "pilot_plan_schema_version": PILOT_PLAN_SCHEMA_VERSION,
+        "session_id": session_id,
+        "design_role": "descriptive_pilot",
+        "descriptive_only": True,
+        "inference_claim_permitted": False,
+        "service_times_s": durations,
+        "correctness_service_time_s": correctness_duration,
+        "repetitions": repetitions,
+        "condition_order": [
+            condition.value
+            for condition in _RESPONSIVENESS_CONDITIONS + _CORRECTNESS_CONDITIONS
+        ],
+        "scenario": {
+            "prelude_s": prelude,
+            "postlude_s": postlude,
+            "probe_period_ms": probe_period,
+            "probe_deadline_ms": probe_deadline,
+            "pending_capacity": pending_capacity,
+            "result_capacity": result_capacity,
+            "overflow_submissions": overflow_submissions,
+            "adapter_poll_interval_s": poll,
+            "join_timeout_s": join,
+        },
+        "resource_telemetry": {
+            "backend": "tegrastats",
+            "resource_schema_version": RESOURCE_SCHEMA_VERSION,
+            "interval_ms": resource_interval_ms,
+            "tail_s": tail,
+            "scope": "continuous_session",
+        },
+        "runs": runs,
+    }
+
+
+def _read_object(path: Path, errors: list[str]) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        errors.append(f"{path.name}: {type(exc).__name__}: {exc}")
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"{path.name}: root must be an object")
+        return {}
+    return value
+
+
+def _gate(
+    name: str,
+    passed: bool,
+    *,
+    observed: object,
+    requirement: str,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "passed": passed,
+        "observed": observed,
+        "requirement": requirement,
+    }
+
+
+def _samples_for_interval(
+    samples: Sequence[dict[str, Any]],
+    started_monotonic_ns: int,
+    finished_monotonic_ns: int,
+) -> list[dict[str, Any]]:
+    return [
+        sample
+        for sample in samples
+        if started_monotonic_ns
+        <= sample["sample_monotonic_ns"]
+        <= finished_monotonic_ns
+    ]
+
+
+def build_pilot_summary(
+    session_dir: Path | str,
+    *,
+    plan: Mapping[str, object],
+    preflight: Mapping[str, object],
+    run_records: Sequence[Mapping[str, object]],
+    sampler_report: Mapping[str, object],
+    samples: Sequence[dict[str, Any]],
+) -> dict[str, object]:
+    """Reconstruct descriptive run and resource facts from session artifacts."""
+
+    directory = Path(session_dir)
+    per_run: list[dict[str, object]] = []
+    invalid_run_count = 0
+    uncovered_run_count = 0
+    stale_consumed_count = 0
+
+    for record in run_records:
+        relative_path = record.get("relative_path")
+        if not isinstance(relative_path, str):
+            raise ValueError("run record has no relative_path")
+        run_dir = directory / relative_path
+        scenario = json.loads((run_dir / "scenario.json").read_text(encoding="utf-8"))
+        run_summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+        if not isinstance(scenario, dict) or not isinstance(run_summary, dict):
+            raise ValueError("run artifacts must contain JSON objects")
+        report = scenario.get("report")
+        if not isinstance(report, dict):
+            raise ValueError("scenario report is missing")
+        started = report.get("started_monotonic_ns")
+        finished = report.get("finished_monotonic_ns")
+        if (
+            isinstance(started, bool)
+            or not isinstance(started, int)
+            or isinstance(finished, bool)
+            or not isinstance(finished, int)
+            or finished < started
+        ):
+            raise ValueError("scenario report contains an invalid monotonic interval")
+        selected = _samples_for_interval(samples, started, finished)
+        uncovered_run_count += int(not selected)
+        invalid_run_count += int(run_summary.get("valid") is not True)
+        lifecycle = run_summary.get("lifecycle")
+        if isinstance(lifecycle, dict):
+            count = lifecycle.get("stale_consumed_count")
+            if isinstance(count, int) and not isinstance(count, bool):
+                stale_consumed_count += count
+        per_run.append(
+            {
+                "sequence": record.get("sequence"),
+                "block_repetition": record.get("block_repetition"),
+                "condition": record.get("condition"),
+                "service_time_s": record.get("service_time_s"),
+                "role": record.get("role"),
+                "run_id": record.get("run_id"),
+                "relative_path": relative_path,
+                "started_monotonic_ns": started,
+                "finished_monotonic_ns": finished,
+                "probe": run_summary.get("probe"),
+                "task_timing": run_summary.get("task_timing"),
+                "lifecycle": lifecycle,
+                "resources": summarize_resource_samples(selected),
+                "run_valid": run_summary.get("valid") is True,
+            }
+        )
+
+    resource_errors = validate_resource_samples(samples)
+    gates = [
+        _gate(
+            "preflight_passed",
+            preflight.get("eligible") is True and not preflight_errors(preflight),
+            observed=preflight.get("eligible"),
+            requirement="all Jetson, source-identity and motion-safety checks pass",
+        ),
+        _gate(
+            "run_matrix_complete",
+            len(run_records) == len(plan.get("runs", [])),
+            observed={
+                "completed": len(run_records),
+                "planned": len(plan.get("runs", [])),
+            },
+            requirement="every predeclared pilot run completes",
+        ),
+        _gate(
+            "all_run_gates_passed",
+            invalid_run_count == 0,
+            observed=invalid_run_count,
+            requirement="every individual R0--R4 summary is valid",
+        ),
+        _gate(
+            "resource_stream_valid",
+            not resource_errors,
+            observed=resource_errors,
+            requirement="resource samples are contiguous and have zero parse errors",
+        ),
+        _gate(
+            "resource_sampler_stopped",
+            sampler_report.get("successful") is True,
+            observed=dict(sampler_report),
+            requirement="tegrastats and its non-daemon reader stop cleanly",
+        ),
+        _gate(
+            "every_run_has_resource_coverage",
+            uncovered_run_count == 0,
+            observed=uncovered_run_count,
+            requirement="at least one resource sample falls inside every run interval",
+        ),
+        _gate(
+            "stale_consumed_zero",
+            stale_consumed_count == 0,
+            observed=stale_consumed_count,
+            requirement="no stale result is consumed in any pilot condition",
+        ),
+    ]
+    return {
+        "pilot_summary_schema_version": PILOT_SUMMARY_SCHEMA_VERSION,
+        "session_id": plan.get("session_id"),
+        "design_role": "descriptive_pilot",
+        "descriptive_only": True,
+        "inference_claim_permitted": False,
+        "run_count": len(per_run),
+        "resources": summarize_resource_samples(samples),
+        "runs": per_run,
+        "gates": gates,
+        "valid": all(gate["passed"] is True for gate in gates),
+    }
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _json_value(value: object) -> object:
+    return json.loads(json.dumps(value, ensure_ascii=False, allow_nan=False))
+
+
+def validate_pilot_dir(session_dir: Path | str) -> list[str]:
+    """Independently validate one completed Jetson pilot session directory."""
+
+    directory = Path(session_dir)
+    errors: list[str] = []
+    for name in PILOT_REQUIRED_FILES:
+        if not (directory / name).is_file():
+            errors.append(f"missing file: {name}")
+    if list(directory.rglob("*.tmp")):
+        errors.append("pilot directory contains an unfinished temporary file")
+    if errors:
+        return errors
+
+    manifest = _read_object(directory / "session_manifest.json", errors)
+    plan = _read_object(directory / "pilot_plan.json", errors)
+    preflight = _read_object(directory / "preflight.json", errors)
+    summary = _read_object(directory / "pilot_summary.json", errors)
+    if errors:
+        return errors
+
+    session_id = manifest.get("session_id")
+    if not isinstance(session_id, str) or session_id != directory.name:
+        errors.append("manifest session_id does not match the directory")
+    else:
+        try:
+            validate_pilot_session_id(session_id)
+        except ValueError as exc:
+            errors.append(str(exc))
+    if manifest.get("pilot_manifest_schema_version") != PILOT_MANIFEST_SCHEMA_VERSION:
+        errors.append("unsupported pilot manifest schema version")
+    if manifest.get("artifact_kind") != "phase1_jetson_simulation_pilot":
+        errors.append("manifest artifact kind is not a Jetson simulation pilot")
+    if manifest.get("status") != "completed":
+        errors.append(
+            f"pilot manifest status is not completed: {manifest.get('status')!r}"
+        )
+    if manifest.get("failure_code") is not None:
+        errors.append("completed pilot manifest contains a failure code")
+    if manifest.get("cleanup_error_code") is not None:
+        errors.append("completed pilot manifest contains a cleanup error code")
+    if manifest.get("descriptive_only") is not True:
+        errors.append("pilot manifest is not marked descriptive-only")
+    if manifest.get("inference_claim_permitted") is not False:
+        errors.append("pilot manifest incorrectly permits an inferential claim")
+
+    if plan.get("pilot_plan_schema_version") != PILOT_PLAN_SCHEMA_VERSION:
+        errors.append("unsupported pilot plan schema version")
+    if plan.get("session_id") != session_id:
+        errors.append("pilot plan session_id does not match the manifest")
+    if (
+        plan.get("descriptive_only") is not True
+        or plan.get("inference_claim_permitted") is not False
+    ):
+        errors.append("pilot plan claim boundary is invalid")
+    scenario_config = plan.get("scenario")
+    resource_config = plan.get("resource_telemetry")
+    if isinstance(scenario_config, dict) and isinstance(resource_config, dict):
+        try:
+            rebuilt_plan = build_pilot_plan(
+                session_id=str(plan.get("session_id")),
+                service_times_s=plan.get("service_times_s", []),
+                repetitions=plan.get("repetitions"),
+                correctness_service_time_s=plan.get("correctness_service_time_s"),
+                prelude_s=scenario_config.get("prelude_s"),
+                postlude_s=scenario_config.get("postlude_s"),
+                probe_period_ms=scenario_config.get("probe_period_ms"),
+                probe_deadline_ms=scenario_config.get("probe_deadline_ms"),
+                pending_capacity=scenario_config.get("pending_capacity"),
+                result_capacity=scenario_config.get("result_capacity"),
+                overflow_submissions=scenario_config.get("overflow_submissions"),
+                adapter_poll_interval_s=scenario_config.get("adapter_poll_interval_s"),
+                join_timeout_s=scenario_config.get("join_timeout_s"),
+                resource_interval_ms=resource_config.get("interval_ms"),
+                resource_tail_s=resource_config.get("tail_s"),
+            )
+        except (TypeError, ValueError) as exc:
+            errors.append(f"pilot plan reconstruction failed: {exc}")
+        else:
+            if plan != _json_value(rebuilt_plan):
+                errors.append("pilot plan does not match its declared matrix")
+    else:
+        errors.append("pilot plan scenario or resource configuration is missing")
+    if preflight.get("preflight_schema_version") != PREFLIGHT_SCHEMA_VERSION:
+        errors.append("unsupported preflight schema version")
+    errors.extend(preflight_errors(preflight))
+
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        errors.append("pilot artifact identities are missing")
+    else:
+        for name in (
+            "pilot_plan.json",
+            "preflight.json",
+            "resources.jsonl",
+            "pilot_summary.json",
+        ):
+            identity = artifacts.get(name)
+            path = directory / name
+            if not isinstance(identity, dict):
+                errors.append(f"pilot identity is missing for {name}")
+                continue
+            if identity.get("size_bytes") != path.stat().st_size:
+                errors.append(f"pilot size does not match {name}")
+            if identity.get("sha256") != sha256_file(path):
+                errors.append(f"pilot SHA-256 does not match {name}")
+
+    planned_runs = plan.get("runs")
+    run_records = manifest.get("runs")
+    if not isinstance(planned_runs, list) or not planned_runs:
+        errors.append("pilot plan contains no runs")
+        return errors
+    if not isinstance(run_records, list):
+        errors.append("pilot manifest run records are missing")
+        return errors
+    if len(run_records) != len(planned_runs):
+        errors.append("pilot manifest does not contain every planned run")
+
+    allowed_top_level = set(PILOT_REQUIRED_FILES) | {
+        str(item.get("condition")) for item in planned_runs if isinstance(item, dict)
+    }
+    for child in directory.iterdir():
+        if child.name not in allowed_top_level:
+            errors.append(f"unexpected pilot artifact: {child.name}")
+
+    for index, record in enumerate(run_records):
+        if not isinstance(record, dict):
+            errors.append(f"run record {index + 1} is not an object")
+            continue
+        planned = planned_runs[index] if index < len(planned_runs) else None
+        if not isinstance(planned, dict):
+            errors.append(f"planned run {index + 1} is not an object")
+            continue
+        for field in (
+            "sequence",
+            "block_repetition",
+            "condition",
+            "service_time_s",
+            "role",
+        ):
+            if record.get(field) != planned.get(field):
+                errors.append(f"run record {index + 1} differs from the plan: {field}")
+        relative_path = record.get("relative_path")
+        if not isinstance(relative_path, str):
+            errors.append(f"run record {index + 1} has no relative path")
+            continue
+        if Path(relative_path).is_absolute():
+            errors.append(f"run record {index + 1} path is not relative")
+            continue
+        run_dir = (directory / relative_path).resolve()
+        if not _is_relative_to(run_dir, directory.resolve()):
+            errors.append(f"run record {index + 1} escapes the session directory")
+            continue
+        expected_parent = (directory / str(record.get("condition"))).resolve()
+        if run_dir.parent != expected_parent or run_dir.name != record.get("run_id"):
+            errors.append(f"run record {index + 1} path does not match its identity")
+        if run_dir.is_dir():
+            unexpected_run_files = {child.name for child in run_dir.iterdir()} - set(
+                RUN_REQUIRED_FILES
+            )
+            if unexpected_run_files:
+                errors.append(
+                    f"run record {index + 1} contains unexpected artifacts: "
+                    + ", ".join(sorted(unexpected_run_files))
+                )
+        run_errors = validate_run_dir(run_dir)
+        errors.extend(f"run {index + 1}: {error}" for error in run_errors)
+        run_manifest = _read_object(run_dir / "manifest.json", errors)
+        if run_manifest:
+            if run_manifest.get("run_id") != record.get("run_id"):
+                errors.append(f"run record {index + 1} has a mismatched run_id")
+            if run_manifest.get("session_id") != session_id:
+                errors.append(f"run record {index + 1} has a mismatched session_id")
+            if run_manifest.get("condition") != record.get("condition"):
+                errors.append(f"run record {index + 1} has a mismatched condition")
+            preflight_environment = preflight.get("environment")
+            preflight_git = (
+                preflight_environment.get("git")
+                if isinstance(preflight_environment, dict)
+                else None
+            )
+            run_environment = run_manifest.get("environment")
+            run_git = (
+                run_environment.get("git")
+                if isinstance(run_environment, dict)
+                else None
+            )
+            if not isinstance(preflight_git, dict) or not isinstance(run_git, dict):
+                errors.append(f"run record {index + 1} has no comparable Git identity")
+            else:
+                for field in (
+                    "commit",
+                    "branch",
+                    "dirty",
+                    "upstream",
+                    "upstream_commit",
+                    "ahead_behind",
+                ):
+                    if run_git.get(field) != preflight_git.get(field):
+                        errors.append(
+                            f"run record {index + 1} Git identity differs: {field}"
+                        )
+            reproducibility = run_manifest.get("reproducibility")
+            if (
+                not isinstance(reproducibility, dict)
+                or reproducibility.get("formal_evidence_eligible") is not True
+            ):
+                errors.append(
+                    f"run record {index + 1} is not clean reproducibility evidence"
+                )
+            spec = run_manifest.get("spec")
+            if not isinstance(spec, dict) or spec.get("service_time_s") != record.get(
+                "service_time_s"
+            ):
+                errors.append(f"run record {index + 1} has a mismatched service time")
+        identity = record.get("manifest_identity")
+        manifest_path = run_dir / "manifest.json"
+        if not isinstance(identity, dict):
+            errors.append(f"run record {index + 1} has no manifest identity")
+        elif manifest_path.is_file():
+            if identity.get("size_bytes") != manifest_path.stat().st_size:
+                errors.append(f"run record {index + 1} manifest size differs")
+            if identity.get("sha256") != sha256_file(manifest_path):
+                errors.append(f"run record {index + 1} manifest hash differs")
+
+    expected_run_dirs = {
+        (directory / record["relative_path"]).resolve()
+        for record in run_records
+        if isinstance(record, dict) and isinstance(record.get("relative_path"), str)
+    }
+    condition_names = {
+        str(item.get("condition")) for item in planned_runs if isinstance(item, dict)
+    }
+    for condition_name in condition_names:
+        condition_dir = directory / condition_name
+        if not condition_dir.is_dir():
+            continue
+        for child in condition_dir.iterdir():
+            if child.resolve() not in expected_run_dirs:
+                errors.append(
+                    f"unexpected run directory in {condition_name}: {child.name}"
+                )
+
+    try:
+        samples = load_resource_samples(directory / "resources.jsonl")
+    except (OSError, UnicodeError, ValueError) as exc:
+        errors.append(f"resources.jsonl: {type(exc).__name__}: {exc}")
+        samples = []
+    resource_errors = validate_resource_samples(samples)
+    errors.extend(resource_errors)
+    sampler_report = manifest.get("resource_sampler_report")
+    if not isinstance(sampler_report, dict):
+        errors.append("resource sampler report is missing")
+    else:
+        if sampler_report.get("sample_count") != len(samples):
+            errors.append("resource sampler sample count differs from resources.jsonl")
+        parse_error_count = sum(bool(sample.get("parse_errors")) for sample in samples)
+        if sampler_report.get("parse_error_count") != parse_error_count:
+            errors.append(
+                "resource sampler parse-error count differs from resources.jsonl"
+            )
+        first_sample_ns = samples[0].get("sample_monotonic_ns") if samples else None
+        last_sample_ns = samples[-1].get("sample_monotonic_ns") if samples else None
+        if sampler_report.get("first_sample_monotonic_ns") != first_sample_ns:
+            errors.append(
+                "resource sampler first timestamp differs from resources.jsonl"
+            )
+        if sampler_report.get("last_sample_monotonic_ns") != last_sample_ns:
+            errors.append(
+                "resource sampler last timestamp differs from resources.jsonl"
+            )
+        expected_sampler_success = (
+            len(samples) > 0
+            and parse_error_count == 0
+            and sampler_report.get("stop_method") in {"terminated", "killed"}
+            and sampler_report.get("reader_joined") is True
+            and sampler_report.get("reader_error_code") is None
+        )
+        if sampler_report.get("successful") is not expected_sampler_success:
+            errors.append("resource sampler success fact is inconsistent")
+        if sampler_report.get("successful") is not True:
+            errors.append("resource sampler did not stop successfully")
+
+    if summary.get("pilot_summary_schema_version") != PILOT_SUMMARY_SCHEMA_VERSION:
+        errors.append("unsupported pilot summary schema version")
+    if summary.get("session_id") != session_id:
+        errors.append("pilot summary session_id does not match the manifest")
+    if summary.get("descriptive_only") is not True:
+        errors.append("pilot summary is not marked descriptive-only")
+    if summary.get("inference_claim_permitted") is not False:
+        errors.append("pilot summary incorrectly permits an inferential claim")
+    if summary.get("valid") is not True:
+        errors.append("pilot summary Gates did not all pass")
+    if isinstance(sampler_report, dict) and samples and not resource_errors:
+        try:
+            rebuilt = build_pilot_summary(
+                directory,
+                plan=plan,
+                preflight=preflight,
+                run_records=run_records,
+                sampler_report=sampler_report,
+                samples=samples,
+            )
+        except (
+            OSError,
+            UnicodeError,
+            ValueError,
+            TypeError,
+            KeyError,
+            json.JSONDecodeError,
+        ) as exc:
+            errors.append(f"pilot summary rebuild failed: {type(exc).__name__}: {exc}")
+        else:
+            if summary != _json_value(rebuilt):
+                errors.append(
+                    "pilot summary does not match independently rebuilt metrics"
+                )
+    return errors

--- a/experiments/phase1/run_jetson_pilot.py
+++ b/experiments/phase1/run_jetson_pilot.py
@@ -1,0 +1,292 @@
+"""Run one motion-disabled Phase 1 simulated-load pilot on Jetson."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import threading
+from pathlib import Path
+from typing import Callable
+
+from experiments.phase1.jetson_preflight import (
+    build_jetson_preflight,
+    preflight_errors,
+)
+from experiments.phase1.jetson_telemetry import (
+    TegrastatsSampler,
+    load_resource_samples,
+)
+from experiments.phase1.manifest import (
+    sha256_file,
+    utc_now_iso,
+    write_json_atomic,
+)
+from experiments.phase1.pilot import (
+    PILOT_MANIFEST_SCHEMA_VERSION,
+    PilotError,
+    build_pilot_plan,
+    build_pilot_summary,
+    make_pilot_session_id,
+    validate_pilot_dir,
+    validate_pilot_session_id,
+)
+from experiments.phase1.run_simulation import run_once
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_output_root(output_root: Path, repo_root: Path) -> Path:
+    expanded = output_root.expanduser()
+    resolved = (expanded if expanded.is_absolute() else repo_root / expanded).resolve()
+    phase0_source = (repo_root / "experiments" / "phase0").resolve()
+    if _is_relative_to(resolved, phase0_source):
+        raise PilotError("Phase 1 pilot output must not be inside experiments/phase0")
+    if _is_relative_to(resolved, repo_root):
+        ignored_root = (repo_root / "experiments" / "runs").resolve()
+        if not _is_relative_to(resolved, ignored_root):
+            raise PilotError(
+                "repository-local pilot output must be inside experiments/runs"
+            )
+    return resolved
+
+
+def _artifact_identity(path: Path) -> dict[str, object]:
+    return {
+        "size_bytes": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
+
+
+def _run_args(
+    entry: dict[str, object],
+    *,
+    plan: dict[str, object],
+    output_root: Path,
+) -> argparse.Namespace:
+    scenario = plan["scenario"]
+    if not isinstance(scenario, dict):
+        raise PilotError("pilot scenario configuration is missing")
+    return argparse.Namespace(
+        condition=entry["condition"],
+        service_time_s=entry["service_time_s"],
+        prelude_s=scenario["prelude_s"],
+        postlude_s=scenario["postlude_s"],
+        probe_period_ms=scenario["probe_period_ms"],
+        probe_deadline_ms=scenario["probe_deadline_ms"],
+        pending_capacity=scenario["pending_capacity"],
+        result_capacity=scenario["result_capacity"],
+        overflow_submissions=scenario["overflow_submissions"],
+        adapter_poll_interval_s=scenario["adapter_poll_interval_s"],
+        join_timeout_s=scenario["join_timeout_s"],
+        session_id=plan["session_id"],
+        repetition=entry["sequence"],
+        output_root=output_root,
+        allow_dirty=False,
+    )
+
+
+def run_pilot_session(
+    args: argparse.Namespace,
+    *,
+    repo_root: Path | str | None = None,
+    preflight_builder: Callable[..., dict[str, object]] = build_jetson_preflight,
+    sampler_factory: Callable[..., TegrastatsSampler] = TegrastatsSampler,
+) -> Path:
+    """Execute one predeclared pilot and preserve atomic session evidence."""
+
+    root = (
+        Path(repo_root).resolve()
+        if repo_root is not None
+        else Path(__file__).resolve().parents[2]
+    )
+    session_id = validate_pilot_session_id(args.session_id or make_pilot_session_id())
+    plan = build_pilot_plan(
+        session_id=session_id,
+        service_times_s=args.service_times_s,
+        repetitions=args.repetitions,
+        correctness_service_time_s=args.correctness_service_time_s,
+        prelude_s=args.prelude_s,
+        postlude_s=args.postlude_s,
+        probe_period_ms=args.probe_period_ms,
+        probe_deadline_ms=args.probe_deadline_ms,
+        pending_capacity=args.pending_capacity,
+        result_capacity=args.result_capacity,
+        overflow_submissions=args.overflow_submissions,
+        adapter_poll_interval_s=args.adapter_poll_interval_s,
+        join_timeout_s=args.join_timeout_s,
+        resource_interval_ms=args.resource_interval_ms,
+        resource_tail_s=args.resource_tail_s,
+    )
+    preflight = preflight_builder(root, expected_branch="main")
+    failed_checks = preflight_errors(preflight)
+    if failed_checks:
+        raise PilotError("Jetson preflight failed: " + "; ".join(failed_checks))
+
+    output_root = _resolve_output_root(Path(args.output_root), root)
+    session_dir = output_root / session_id
+    if session_dir.exists():
+        raise FileExistsError(f"refusing to overwrite pilot session: {session_dir}")
+    session_dir.mkdir(parents=True)
+    plan_path = session_dir / "pilot_plan.json"
+    preflight_path = session_dir / "preflight.json"
+    manifest_path = session_dir / "session_manifest.json"
+    write_json_atomic(plan_path, plan)
+    write_json_atomic(preflight_path, preflight)
+
+    manifest: dict[str, object] = {
+        "pilot_manifest_schema_version": PILOT_MANIFEST_SCHEMA_VERSION,
+        "artifact_kind": "phase1_jetson_simulation_pilot",
+        "session_id": session_id,
+        "status": "running",
+        "created_at": utc_now_iso(),
+        "completed_at": None,
+        "descriptive_only": True,
+        "inference_claim_permitted": False,
+        "runs": [],
+        "resource_sampler_report": None,
+        "artifacts": {},
+        "failure_code": None,
+        "cleanup_error_code": None,
+    }
+    write_json_atomic(manifest_path, manifest)
+
+    sampler: TegrastatsSampler | None = None
+    run_records: list[dict[str, object]] = []
+    try:
+        resource_config = plan["resource_telemetry"]
+        if not isinstance(resource_config, dict):
+            raise PilotError("pilot resource configuration is missing")
+        sampler = sampler_factory(
+            session_dir,
+            int(resource_config["interval_ms"]),
+        )
+        sampler.start(first_sample_timeout_s=args.resource_first_sample_timeout_s)
+        planned_runs = plan["runs"]
+        if not isinstance(planned_runs, list):
+            raise PilotError("pilot plan contains no run matrix")
+        for entry in planned_runs:
+            if not isinstance(entry, dict):
+                raise PilotError("pilot plan run is not an object")
+            run_dir = run_once(
+                _run_args(entry, plan=plan, output_root=output_root),
+                repo_root=root,
+            )
+            run_manifest_path = run_dir / "manifest.json"
+            record = dict(entry)
+            record.update(
+                {
+                    "run_id": run_dir.name,
+                    "relative_path": run_dir.relative_to(session_dir).as_posix(),
+                    "manifest_identity": _artifact_identity(run_manifest_path),
+                }
+            )
+            run_records.append(record)
+            manifest["runs"] = run_records
+            write_json_atomic(manifest_path, manifest)
+
+        tail_s = float(resource_config["tail_s"])
+        if tail_s > 0:
+            threading.Event().wait(tail_s)
+        sampler_report = sampler.stop()
+        manifest["resource_sampler_report"] = sampler_report.to_dict()
+        if not sampler_report.successful:
+            raise PilotError("tegrastats did not produce a valid closed resource trace")
+
+        samples = load_resource_samples(session_dir / "resources.jsonl")
+        summary = build_pilot_summary(
+            session_dir,
+            plan=plan,
+            preflight=preflight,
+            run_records=run_records,
+            sampler_report=sampler_report.to_dict(),
+            samples=samples,
+        )
+        summary_path = session_dir / "pilot_summary.json"
+        write_json_atomic(summary_path, summary)
+        if summary.get("valid") is not True:
+            raise PilotError("one or more Jetson pilot Gates failed")
+
+        manifest["artifacts"] = {
+            name: _artifact_identity(session_dir / name)
+            for name in (
+                "pilot_plan.json",
+                "preflight.json",
+                "resources.jsonl",
+                "pilot_summary.json",
+            )
+        }
+        manifest["status"] = "completed"
+        manifest["completed_at"] = utc_now_iso()
+        write_json_atomic(manifest_path, manifest)
+        validation_errors = validate_pilot_dir(session_dir)
+        if validation_errors:
+            raise PilotError(
+                "final pilot validation failed: " + "; ".join(validation_errors)
+            )
+    except Exception as exc:
+        if sampler is not None and sampler.is_running:
+            try:
+                sampler.stop()
+            except Exception as cleanup_exc:
+                manifest["cleanup_error_code"] = type(cleanup_exc).__name__.lower()
+        if sampler is not None and sampler.stop_report is not None:
+            manifest["resource_sampler_report"] = sampler.stop_report.to_dict()
+        manifest["status"] = "failed"
+        manifest["completed_at"] = utc_now_iso()
+        manifest["failure_code"] = type(exc).__name__.lower()
+        write_json_atomic(manifest_path, manifest)
+        raise
+    return session_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--service-times-s",
+        type=float,
+        nargs="+",
+        required=True,
+        help="predeclared simulated service durations for the R0--R3 blocks",
+    )
+    parser.add_argument("--correctness-service-time-s", type=float)
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument("--prelude-s", type=float, default=1.0)
+    parser.add_argument("--postlude-s", type=float, default=1.0)
+    parser.add_argument("--probe-period-ms", type=float, default=100.0)
+    parser.add_argument("--probe-deadline-ms", type=float, default=100.0)
+    parser.add_argument("--pending-capacity", type=int, default=1)
+    parser.add_argument("--result-capacity", type=int, default=1)
+    parser.add_argument("--overflow-submissions", type=int, default=2)
+    parser.add_argument("--adapter-poll-interval-s", type=float, default=0.01)
+    parser.add_argument("--join-timeout-s", type=float, default=5.0)
+    parser.add_argument("--resource-interval-ms", type=int, default=200)
+    parser.add_argument("--resource-tail-s", type=float, default=0.4)
+    parser.add_argument("--resource-first-sample-timeout-s", type=float, default=3.0)
+    parser.add_argument("--session-id")
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("experiments/runs/phase1-jetson-pilot"),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        session_dir = run_pilot_session(args)
+    except Exception as exc:
+        print(f"FAILED: {exc}", file=sys.stderr)
+        return 2
+    print(session_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/phase1/schemas/resource.schema.json
+++ b/experiments/phase1/schemas/resource.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/embodied-robot/phase1-resource.schema.json",
+  "title": "Phase 1 Jetson Resource Sample",
+  "description": "One bounded tegrastats observation in the session-level UTF-8 JSONL resource trace.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "resource_schema_version",
+    "seq",
+    "sample_monotonic_ns",
+    "sample_wall_time_ns",
+    "tegrastats_time",
+    "ram",
+    "swap",
+    "cpu",
+    "emc",
+    "gr3d",
+    "temperatures_c",
+    "power",
+    "parse_errors",
+    "parse_warnings",
+    "raw_line"
+  ],
+  "properties": {
+    "resource_schema_version": {
+      "const": "0.1.0"
+    },
+    "seq": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "sample_monotonic_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "sample_wall_time_ns": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "tegrastats_time": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9]{2}-[0-9]{2}-[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}$"
+    },
+    "ram": {
+      "$ref": "#/$defs/memory"
+    },
+    "swap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["used_mb", "total_mb", "cached_mb"],
+      "properties": {
+        "used_mb": {"type": "integer", "minimum": 0},
+        "total_mb": {"type": "integer", "minimum": 0},
+        "cached_mb": {"type": "integer", "minimum": 0}
+      }
+    },
+    "cpu": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["index", "online", "usage_pct", "frequency_mhz"],
+        "properties": {
+          "index": {"type": "integer", "minimum": 0, "maximum": 31},
+          "online": {"type": "boolean"},
+          "usage_pct": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 100
+          },
+          "frequency_mhz": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "emc": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["usage_pct", "frequency_mhz"],
+          "properties": {
+            "usage_pct": {"type": "integer", "minimum": 0, "maximum": 100},
+            "frequency_mhz": {"type": ["integer", "null"], "minimum": 0}
+          }
+        }
+      ]
+    },
+    "gr3d": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["usage_pct", "frequencies_mhz"],
+      "properties": {
+        "usage_pct": {"type": "integer", "minimum": 0, "maximum": 100},
+        "frequencies_mhz": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "temperatures_c": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 64,
+      "propertyNames": {"pattern": "^[a-z][a-z0-9_]*$"},
+      "additionalProperties": {"type": "number"}
+    },
+    "power": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 64,
+      "propertyNames": {"pattern": "^VDD_[A-Z0-9_]+$"},
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["instant_mw", "average_mw"],
+        "properties": {
+          "instant_mw": {"type": "integer", "minimum": 0},
+          "average_mw": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "parse_errors": {
+      "type": "array",
+      "maxItems": 32,
+      "items": {"type": "string", "minLength": 1, "maxLength": 128}
+    },
+    "parse_warnings": {
+      "type": "array",
+      "maxItems": 32,
+      "items": {"type": "string", "minLength": 1, "maxLength": 128}
+    },
+    "raw_line": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 8192
+    }
+  },
+  "$defs": {
+    "memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["used_mb", "total_mb", "lfb_count", "lfb_size_mb"],
+      "properties": {
+        "used_mb": {"type": "integer", "minimum": 0},
+        "total_mb": {"type": "integer", "minimum": 0},
+        "lfb_count": {"type": "integer", "minimum": 0},
+        "lfb_size_mb": {"type": "number", "minimum": 0}
+      }
+    }
+  }
+}

--- a/experiments/phase1/tests/test_jetson_pilot.py
+++ b/experiments/phase1/tests/test_jetson_pilot.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from experiments.phase1.jetson_preflight import build_jetson_preflight
+from experiments.phase1.jetson_telemetry import TegrastatsSampler
+from experiments.phase1.manifest import sha256_file
+from experiments.phase1.pilot import (
+    PilotError,
+    build_pilot_plan,
+    make_pilot_session_id,
+    validate_pilot_dir,
+)
+from experiments.phase1.run_jetson_pilot import (
+    build_parser,
+    run_pilot_session,
+)
+from experiments.phase1.tests.test_jetson_telemetry import sampler_command
+
+
+SESSION_ID = "20260827T120000Z_phase1_jetson_pilot_test"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def clean_environment() -> dict[str, object]:
+    return {
+        "captured_at": "2026-08-27T12:00:00Z",
+        "platform": "Linux-5.15.0-tegra-aarch64-with-glibc2.35",
+        "machine": "aarch64",
+        "python": "3.10.12",
+        "l4t_release": "# R36 (release), REVISION: 4.7",
+        "git": {
+            "commit": "a" * 40,
+            "branch": "main",
+            "dirty": False,
+            "status_porcelain": [],
+            "upstream": "origin/main",
+            "upstream_commit": "a" * 40,
+            "ahead_behind": "0\t0",
+            "error_codes": [],
+        },
+        "jetpack_packages": {"returncode": 0, "output": "", "error_code": None},
+        "nvpmodel": {"returncode": 0, "output": "MAXN", "error_code": None},
+        "jetson_clocks": {"returncode": 0, "output": "", "error_code": None},
+    }
+
+
+def passing_preflight() -> dict[str, object]:
+    with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+        return build_jetson_preflight(
+            REPO_ROOT,
+            environment=clean_environment(),
+            tegrastats_available=True,
+            loaded_modules={"experiments.phase1.run_jetson_pilot"},
+        )
+
+
+def pilot_args(output_root: Path):
+    return build_parser().parse_args(
+        [
+            "--service-times-s",
+            "0.02",
+            "--correctness-service-time-s",
+            "0.02",
+            "--prelude-s",
+            "0.02",
+            "--postlude-s",
+            "0.02",
+            "--probe-period-ms",
+            "5",
+            "--probe-deadline-ms",
+            "10",
+            "--adapter-poll-interval-s",
+            "0.001",
+            "--join-timeout-s",
+            "1",
+            "--resource-interval-ms",
+            "50",
+            "--resource-tail-s",
+            "0.02",
+            "--resource-first-sample-timeout-s",
+            "2",
+            "--session-id",
+            SESSION_ID,
+            "--output-root",
+            str(output_root),
+        ]
+    )
+
+
+class JetsonPilotTests(unittest.TestCase):
+    def test_preflight_requires_jetson_clean_main_and_safe_imports(self) -> None:
+        preflight = passing_preflight()
+        self.assertTrue(preflight["eligible"])
+
+        environment = clean_environment()
+        environment["machine"] = "x86_64"
+        environment["git"] = dict(environment["git"], dirty=True)
+        with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+            failed = build_jetson_preflight(
+                REPO_ROOT,
+                environment=environment,
+                tegrastats_available=True,
+                loaded_modules={"jetson.robot_comm"},
+            )
+        failed_names = {
+            check["name"] for check in failed["checks"] if check["passed"] is False
+        }
+        self.assertEqual(
+            failed_names,
+            {"arm64_machine", "git_tree_clean", "forbidden_modules_absent"},
+        )
+
+    def test_preflight_fails_closed_on_motion_and_upstream_mismatch(self) -> None:
+        environment = clean_environment()
+        environment["git"] = dict(
+            environment["git"],
+            upstream_commit="b" * 40,
+            ahead_behind="1\t0",
+        )
+        for motion_value in ("1", "unexpected"):
+            with self.subTest(motion_value=motion_value):
+                with patch.dict(
+                    os.environ, {"ROBOT_ENABLE_MOTION": motion_value}, clear=False
+                ):
+                    preflight = build_jetson_preflight(
+                        REPO_ROOT,
+                        environment=environment,
+                        tegrastats_available=True,
+                        loaded_modules=set(),
+                    )
+                failed_names = {
+                    check["name"]
+                    for check in preflight["checks"]
+                    if check["passed"] is False
+                }
+                self.assertEqual(
+                    failed_names,
+                    {"motion_disabled", "git_upstream_synchronized"},
+                )
+                self.assertFalse(preflight["eligible"])
+
+    def test_plan_freezes_responsiveness_and_correctness_roles(self) -> None:
+        plan = build_pilot_plan(
+            session_id=SESSION_ID,
+            service_times_s=[2.0, 5.0],
+            repetitions=2,
+            correctness_service_time_s=2.0,
+        )
+
+        self.assertEqual(len(plan["runs"]), 20)
+        self.assertEqual(
+            [entry["condition"] for entry in plan["runs"][:6]],
+            [
+                "r0_idle",
+                "r1_inline_sync",
+                "r2_threaded_sync",
+                "r3_async",
+                "r0_idle",
+                "r1_inline_sync",
+            ],
+        )
+        self.assertEqual(plan["runs"][8]["role"], "correctness")
+        self.assertFalse(plan["inference_claim_permitted"])
+
+        with self.assertRaisesRegex(TypeError, "probe_period_ms"):
+            build_pilot_plan(
+                session_id=SESSION_ID,
+                service_times_s=[2.0],
+                probe_period_ms=True,
+            )
+
+    def test_session_id_uses_utc_and_optional_label(self) -> None:
+        now = datetime(2026, 8, 27, 12, 3, 4, tzinfo=timezone.utc)
+        self.assertEqual(
+            make_pilot_session_id(now, label="smoke"),
+            "20260827T120304Z_phase1_jetson_pilot_smoke",
+        )
+
+    def test_preflight_failure_creates_no_session_directory(self) -> None:
+        failed_preflight = passing_preflight()
+        failed_preflight["checks"][0]["passed"] = False
+        failed_preflight["eligible"] = False
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            with self.assertRaisesRegex(PilotError, "preflight failed"):
+                run_pilot_session(
+                    pilot_args(output_root),
+                    repo_root=REPO_ROOT,
+                    preflight_builder=lambda *args, **kwargs: failed_preflight,
+                )
+            self.assertEqual(list(output_root.iterdir()), [])
+
+    def test_pilot_refuses_the_phase0_source_as_output(self) -> None:
+        with self.assertRaisesRegex(PilotError, "experiments/phase0"):
+            run_pilot_session(
+                pilot_args(REPO_ROOT / "experiments" / "phase0"),
+                repo_root=REPO_ROOT,
+                preflight_builder=lambda *args, **kwargs: passing_preflight(),
+            )
+
+    def test_sampler_construction_failure_marks_the_session_failed(self) -> None:
+        def failing_sampler_factory(*args, **kwargs):
+            raise RuntimeError("sampler unavailable")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            with self.assertRaisesRegex(RuntimeError, "sampler unavailable"):
+                run_pilot_session(
+                    pilot_args(output_root),
+                    repo_root=REPO_ROOT,
+                    preflight_builder=lambda *args, **kwargs: passing_preflight(),
+                    sampler_factory=failing_sampler_factory,
+                )
+            manifest = json.loads(
+                (output_root / SESSION_ID / "session_manifest.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        self.assertEqual(manifest["status"], "failed")
+        self.assertEqual(manifest["failure_code"], "runtimeerror")
+
+    def test_complete_session_is_reconstructable_and_leak_free(self) -> None:
+        baseline_threads = {thread.name for thread in threading.enumerate()}
+        preflight = passing_preflight()
+
+        def sampler_factory(session_dir: Path, interval_ms: int):
+            return TegrastatsSampler(
+                session_dir,
+                interval_ms,
+                command=sampler_command(),
+            )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch(
+                "experiments.phase1.run_simulation.collect_environment",
+                return_value=clean_environment(),
+            ):
+                session_dir = run_pilot_session(
+                    pilot_args(Path(temp_dir)),
+                    repo_root=REPO_ROOT,
+                    preflight_builder=lambda *args, **kwargs: preflight,
+                    sampler_factory=sampler_factory,
+                )
+            self.assertEqual(validate_pilot_dir(session_dir), [])
+            summary = json.loads(
+                (session_dir / "pilot_summary.json").read_text(encoding="utf-8")
+            )
+            manifest = json.loads(
+                (session_dir / "session_manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(summary["valid"])
+            self.assertEqual(summary["run_count"], 6)
+            self.assertTrue(manifest["resource_sampler_report"]["successful"])
+            self.assertTrue(
+                all(run["resources"]["sample_count"] > 0 for run in summary["runs"])
+            )
+
+            summary["run_count"] += 1
+            summary_path = session_dir / "pilot_summary.json"
+            summary_path.write_text(
+                json.dumps(summary, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            manifest["artifacts"]["pilot_summary.json"] = {
+                "size_bytes": summary_path.stat().st_size,
+                "sha256": sha256_file(summary_path),
+            }
+            (session_dir / "session_manifest.json").write_text(
+                json.dumps(manifest, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            summary_errors = validate_pilot_dir(session_dir)
+
+            summary["run_count"] -= 1
+            summary_path.write_text(
+                json.dumps(summary, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            manifest["artifacts"]["pilot_summary.json"] = {
+                "size_bytes": summary_path.stat().st_size,
+                "sha256": sha256_file(summary_path),
+            }
+            resources_path = session_dir / "resources.jsonl"
+            resource_rows = [
+                json.loads(line)
+                for line in resources_path.read_text(encoding="utf-8").splitlines()
+            ]
+            resource_rows[0]["gr3d"]["usage_pct"] = 101
+            resources_path.write_text(
+                "".join(
+                    json.dumps(row, ensure_ascii=False) + "\n" for row in resource_rows
+                ),
+                encoding="utf-8",
+            )
+            manifest["artifacts"]["resources.jsonl"] = {
+                "size_bytes": resources_path.stat().st_size,
+                "sha256": sha256_file(resources_path),
+            }
+            (session_dir / "session_manifest.json").write_text(
+                json.dumps(manifest, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            (session_dir / "unexpected.txt").write_text(
+                "unexpected\n", encoding="utf-8"
+            )
+            resource_errors = validate_pilot_dir(session_dir)
+
+        self.assertTrue(
+            any("independently rebuilt" in error for error in summary_errors)
+        )
+        self.assertTrue(any("GR3D usage" in error for error in resource_errors))
+        self.assertTrue(
+            any("unexpected pilot artifact" in error for error in resource_errors)
+        )
+        remaining_threads = {thread.name for thread in threading.enumerate()}
+        self.assertEqual(remaining_threads, baseline_threads)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_jetson_telemetry.py
+++ b/experiments/phase1/tests/test_jetson_telemetry.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import copy
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+from experiments.phase1.jetson_telemetry import (
+    TegrastatsSampler,
+    load_resource_samples,
+    parse_tegrastats_line,
+    summarize_resource_samples,
+    validate_resource_samples,
+)
+
+
+TEGRASTATS_SAMPLE = (
+    "08-23-2026 13:57:46 RAM 3595/7607MB (lfb 1x1MB) "
+    "SWAP 11/3804MB (cached 0MB) CPU [1%@729,off,3%@729,4%@729,5%@729,6%@729] "
+    "EMC_FREQ 2%@2133 GR3D_FREQ 7%@[306] cpu@51C soc2@50.562C "
+    "soc0@51.031C gpu@50.5C tj@51C soc1@50C "
+    "VDD_IN 5832mW/5852mW VDD_CPU_GPU_CV 1307mW/1327mW "
+    "VDD_SOC 1468mW/1468mW"
+)
+
+
+def sampler_command(line: str = TEGRASTATS_SAMPLE) -> list[str]:
+    code = (
+        "import time\n"
+        f"line = {line!r}\n"
+        "while True:\n"
+        "    print(line, flush=True)\n"
+        "    time.sleep(0.005)\n"
+    )
+    return [sys.executable, "-u", "-c", code]
+
+
+class JetsonTelemetryTests(unittest.TestCase):
+    def test_parser_supports_dynamic_sensors_and_offline_cores(self) -> None:
+        sample = parse_tegrastats_line(
+            TEGRASTATS_SAMPLE,
+            sequence=0,
+            sample_monotonic_ns=100,
+            sample_wall_time_ns=200,
+        )
+
+        self.assertEqual(sample["parse_errors"], [])
+        self.assertEqual(sample["tegrastats_time"], "08-23-2026 13:57:46")
+        self.assertEqual(sample["ram"]["used_mb"], 3595)
+        self.assertFalse(sample["cpu"][1]["online"])
+        self.assertEqual(sample["gr3d"]["frequencies_mhz"], [306])
+        self.assertEqual(sample["temperatures_c"]["soc2"], 50.562)
+        self.assertEqual(sample["power"]["VDD_IN"]["instant_mw"], 5832)
+
+    def test_missing_optional_timestamp_is_a_warning(self) -> None:
+        sample = parse_tegrastats_line(
+            "RAM " + TEGRASTATS_SAMPLE.split(" RAM ", 1)[1],
+            sequence=0,
+            sample_monotonic_ns=100,
+            sample_wall_time_ns=200,
+        )
+
+        self.assertEqual(sample["parse_errors"], [])
+        self.assertIn("tegrastats_timestamp_missing", sample["parse_warnings"])
+
+    def test_validator_rejects_tampered_structure_and_ranges(self) -> None:
+        sample = parse_tegrastats_line(
+            TEGRASTATS_SAMPLE,
+            sequence=0,
+            sample_monotonic_ns=100,
+            sample_wall_time_ns=200,
+        )
+        tampered_range = copy.deepcopy(sample)
+        tampered_range["gr3d"]["usage_pct"] = 101
+        tampered_shape = copy.deepcopy(sample)
+        tampered_shape["unexpected"] = True
+
+        self.assertTrue(
+            any(
+                "GR3D usage" in error
+                for error in validate_resource_samples([tampered_range])
+            )
+        )
+        self.assertTrue(
+            any(
+                "fields do not match" in error
+                for error in validate_resource_samples([tampered_shape])
+            )
+        )
+
+    def test_sampler_stops_process_and_non_daemon_reader(self) -> None:
+        baseline_threads = {thread.name for thread in threading.enumerate()}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sampler = TegrastatsSampler(
+                Path(temp_dir),
+                50,
+                command=sampler_command(),
+            )
+            sampler.start(first_sample_timeout_s=2)
+            time.sleep(0.04)
+            report = sampler.stop()
+            samples = load_resource_samples(Path(temp_dir) / "resources.jsonl")
+
+        self.assertTrue(report.successful)
+        self.assertTrue(report.reader_joined)
+        self.assertGreaterEqual(report.sample_count, 2)
+        self.assertEqual(validate_resource_samples(samples), [])
+        resource_summary = summarize_resource_samples(samples)
+        self.assertEqual(resource_summary["sample_count"], len(samples))
+        remaining_threads = {thread.name for thread in threading.enumerate()}
+        self.assertEqual(remaining_threads, baseline_threads)
+
+    def test_sampler_rejects_an_unparseable_first_sample(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sampler = TegrastatsSampler(
+                Path(temp_dir),
+                50,
+                command=sampler_command("unexpected output"),
+            )
+            with self.assertRaisesRegex(RuntimeError, "parser contract"):
+                sampler.start(first_sample_timeout_s=2)
+
+        self.assertIsNotNone(sampler.stop_report)
+        self.assertFalse(sampler.stop_report.successful)
+        self.assertGreater(sampler.stop_report.parse_error_count, 0)
+
+    def test_sampler_rejects_an_early_process_exit(self) -> None:
+        code = f"print({TEGRASTATS_SAMPLE!r}, flush=True)"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sampler = TegrastatsSampler(
+                Path(temp_dir),
+                50,
+                command=[sys.executable, "-u", "-c", code],
+            )
+            sampler.start(first_sample_timeout_s=2)
+            time.sleep(0.05)
+            report = sampler.stop()
+
+        self.assertEqual(report.stop_method, "exited")
+        self.assertFalse(report.successful)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/validate_jetson_pilot.py
+++ b/experiments/phase1/validate_jetson_pilot.py
@@ -1,0 +1,26 @@
+"""Validate one completed Phase 1 Jetson simulation pilot session."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from experiments.phase1.pilot import validate_pilot_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("session_dir", type=Path)
+    args = parser.parse_args(argv)
+    errors = validate_pilot_dir(args.session_dir)
+    if errors:
+        print("INVALID")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("VALID")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -2,7 +2,7 @@
 
 The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel, which is not yet connected to the robot application or model services.
 
-The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-only task identity, bounded ownership, a single-worker observable executor and a software periodic probe. A portable simulated-condition runner is available under `experiments/phase1/`, but Jetson pilots and application integration remain research work.
+The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. A portable simulated-condition runner and host-tested Jetson pilot harness are available under `experiments/phase1/`, but the Jetson pilot and application integration remain research work.
 
 > 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 的 host-only worker 与周期探针尚未接入真实模型或运动控制。
 


### PR DESCRIPTION
## Summary

This PR adds the Jetson-side simulation pilot harness for Phase 1.

- add a fail-closed preflight that verifies the Jetson platform, L4T environment, Git state, telemetry availability, and motion-disabled operating boundary
- define an immutable R0-R4 pilot matrix before execution
- collect continuous `tegrastats` telemetry across the complete pilot session
- parse CPU, GPU, memory, swap, temperature, EMC, and power measurements into a versioned resource schema
- associate resource samples with individual runs using monotonic execution intervals
- record atomic manifests and SHA-256 identities for session artifacts
- independently reconstruct and validate pilot summaries from raw events and resource samples
- reject unexpected artifacts, path escapes, repository drift, sampler failures, and execution leaks
- document the Jetson pilot workflow and its current evidence boundary

## Validation

- Phase 0 test suite: 29 tests passed
- Phase 1 test suite: 80 tests passed
- Total: 109 tests passed
- formatting, static analysis, compilation, schema validation, Markdown links, and repository hygiene checks passed

## Scope

This milestone remains simulation-only. Physical motion is disabled, and no UART, serial, STM32, application-layer, or real-model integration is introduced.

The actual Jetson pilot will be executed only after this PR is merged and the device is synchronized with a clean `main` branch. This PR therefore makes no Jetson performance claim.