### PR TITLE
feat(phase1): analyze Jetson pilot and add VLM slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository began with my bachelor's thesis on speech interaction and visual perception for a wheeled robot. The thesis system runs fully local speech and vision pipelines on a Jetson Orin Nano, while an STM32F407 executes motion commands and enforces a communication watchdog. The same platform will now be used to study how long-running perception and inference can coexist with predictable control timing.
 
-> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立 host-only 有界运行时、可观测 worker、周期探针、模拟实验运行器和 Jetson pilot 基础设施，尚未执行 Jetson pilot 或接入整机应用。
+> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立有界运行时、可观测 worker、周期探针和模拟实验运行器，完成首次 Jetson simulation pilot 及独立验证，并通过固定输入 VLM 接入的主机测试；真实模型实机采集和整机应用适配尚未开始。
 
 ## Project status
 
@@ -15,7 +15,7 @@ This repository began with my bachelor's thesis on speech interaction and visual
 | Bachelor's thesis software and firmware | Complete and hardware validated |
 | Custom base-driver PCB | Published and tested on the physical robot |
 | Jetson–STM32 command link | Validated with ACK/error responses and a 1.2 s command watchdog |
-| Asynchronous inference runtime | Bounded executor, probe, trace replay, simulation runner and host-tested Jetson pilot harness implemented; Jetson pilot pending |
+| Asynchronous inference runtime | Bounded executor, probe and replay validated by a Jetson simulation pilot; fixed-input VLM runner host-tested, with Jetson execution pending |
 
 The validated Jetson–STM32 code is preserved at [`v0.1.0-thesis-baseline`](https://github.com/yuzhang-robotics/embodied-robot-heterogeneous-control/tree/v0.1.0-thesis-baseline). The current `main` branch also includes the reviewed hardware documentation and editable PCB export.
 
@@ -65,9 +65,14 @@ Phase 1 now has an immutable task/result model, bounded task ownership, scoped
 state generations, a single-worker observable executor, an absolute-schedule
 periodic probe, independent lifecycle trace replay and a reproducible
 simulated-condition runner. A fail-closed Jetson preflight, continuous
-`tegrastats` recorder and pilot-session validator are also host-tested. No
-Jetson pilot or model-service integration result is claimed yet. The broader
-research stage will investigate:
+`tegrastats` recorder and pilot-session validator are also implemented. A
+motion-disabled Jetson simulation pilot completed all session Gates; its
+[descriptive report](experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/)
+separates timing-domain isolation from the additional bounded-runtime
+semantics. A fixed-input Moondream/Qwen adapter, single-request nominal/stale
+runner and independent validator are now host-tested, but have not yet been
+executed on the Jetson. Neither milestone authorizes a performance-superiority
+claim. The broader research stage will investigate:
 
 - independent acquisition, inference, planning and control workers;
 - timestamped bounded queues, cancellation and stale-result rejection;
@@ -89,7 +94,7 @@ These are research objectives, not claims about the current implementation. The 
 | [`docs/hardware/`](docs/hardware/) | Physical platform, wiring, pin assignments, power and safety notes |
 | [`docs/architecture/`](docs/architecture/) | Current timing model and the boundary of the planned asynchronous architecture |
 | [`experiments/phase0/`](experiments/phase0/) | Synchronous fixed-input measurement, validation and formal analysis tools |
-| [`experiments/phase1/`](experiments/phase1/) | Host tests, simulated-condition runner, Jetson pilot harness, Phase 1 trace schema and validation |
+| [`experiments/phase1/`](experiments/phase1/) | Host tests, simulation and fixed-input VLM runners, Jetson pilot, deterministic analysis, trace schemas and validation |
 
 ## Reproducing the baseline
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -102,8 +102,13 @@ semantics, and Phase 1 safety Gates are specified in the
 design and correctness boundary. The host-only model, bounded broker,
 observable worker, periodic probe, lifecycle replay and simulated-condition
 runner are implemented. The Jetson preflight, continuous resource sampler and
-pilot-session validator are host-tested, but they do not yet constitute a
-validated Jetson runtime or a performance result.
+pilot-session validator have also completed one motion-disabled simulation
+pilot on the Jetson. The independently reconstructed
+[descriptive result](../../experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/)
+validates the evidence chain and runtime semantics, but it is not a real-model
+or formal performance result. The fixed-input VLM adapter and its nominal/stale
+single-request evidence path are host-tested; Jetson execution is the next
+Gate.
 
 ## Evaluation plan
 

--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -3,18 +3,23 @@
 This document defines the correctness and safety contract for the first
 asynchronous runtime used by the Octopus robot research platform. The
 host-only model, broker, observable executor, periodic probes, trace replay and
-portable simulation protocol have been implemented. Jetson behavior and
-performance remain unvalidated.
+portable simulation protocol have been implemented. One motion-disabled Jetson
+simulation pilot has validated the protocol and runtime semantics. The first
+fixed-input VLM adapter and runner are host-tested; real-model Jetson execution
+and formal performance behavior remain unvalidated.
 
 > 中文简介：本文冻结 Phase 1 异步运行时的任务模型、生命周期、队列、取消、结果新鲜度、
 > 快速周期代理和安全边界。host-only worker、周期探针、trace replay 和模拟实验运行器已实现；
-> Jetson pilot、真实模型接入和正式实验仍需按 Gate 逐步完成。
+> Jetson simulation pilot 已完成并通过独立验证；固定输入 VLM 接入已通过主机测试，
+> 真实模型实机运行和正式实验仍需按 Gate 逐步完成。
 
 ## Status
 
-- Phase: Phase 1.4 Jetson simulation-pilot protocol
-- Contract status: frozen and host-tested through the pilot infrastructure
-- Jetson-pilot starting point: `main@844b633`
+- Phase: Phase 1C fixed-input VLM implementation; Jetson execution pending
+- Contract status: frozen through one independently validated Jetson simulation
+  pilot
+- Jetson-pilot result: `main@77138f2`, session `20260828T121142Z_phase1_jetson_pilot`
+- Jetson-pilot harness starting point: `main@844b633`
 - Simulation-runner starting point: `main@4514d97`
 - Observable-executor starting point: `main@1d29b14`
 - Initial runtime-kernel starting point: `main@043e1bb`
@@ -37,10 +42,14 @@ The current implementation includes:
 - R0--R4 simulated-condition orchestration, atomic manifests, validation and
   descriptive summaries;
 - fail-closed Jetson preflight, a continuous non-daemon `tegrastats` sampler,
-  an immutable pilot matrix and independent session reconstruction.
+  an immutable pilot matrix and independent session reconstruction;
+- a lazy fixed-input VLM adapter, nominal/stale single-request orchestration,
+  model-service preflight, resource trace and independent run validation.
 
-It does not include a completed Jetson simulation pilot, real workload adapters
-or formal performance data.
+The VLM implementation has not yet run on the Jetson and it does not include
+formal performance data. The completed simulation pilot remains descriptive
+protocol evidence and does not authorize an asynchronous-performance,
+hard-real-time or heterogeneous-inference claim.
 
 ## Research objective
 
@@ -275,9 +284,13 @@ The kernel provides policies; workload adapters select them explicitly.
 
 ### VLM
 
-- pending capacity: 1;
-- coalesce related pending tasks by `supersession_key`;
-- replacement emits a dropped disposition for the replaced pending task;
+- the fixed-input Phase 1C slice admits exactly one task with pending and
+  result capacities of one and `reject_new` overflow;
+- later live acquisition may coalesce related pending tasks by
+  `supersession_key`, but that policy is not inferred from the single-request
+  slice;
+- any later replacement must emit a dropped disposition for the replaced
+  pending task;
 - a new image does not silently claim to stop an active backend request;
 - active result invalidation requires an explicit cancel or state-generation
   change.
@@ -528,7 +541,7 @@ authorize a performance claim.
 A queue-empty, single-task direct condition is compared with a queue-empty,
 single-task worker condition. Both invoke the same workload adapter. ASR is the
 sensitive low-variance control; LLM retains token-normalized metrics; VLM
-retains module-import, Moondream, rewrite/fallback, and unload stages.
+retains module-import, Moondream, rewrite/fallback, and unload-request stages.
 
 Formal analysis treats a run or paired block as the experimental unit. Probe
 ticks within one run are temporally dependent and are not treated as hundreds
@@ -635,6 +648,69 @@ leaves the session failed.
 The summary is permanently marked `descriptive_only=true` and
 `inference_claim_permitted=false`.
 
+### First pilot outcome
+
+Session `20260828T121142Z_phase1_jetson_pilot` completed the 14-run matrix on
+`main@77138f2` with all seven session Gates passing. The inline condition
+produced service-time-scale probe gaps and skipped releases, while the threaded
+direct and bounded-runtime conditions recorded no skipped releases. R4 rejected
+one old-state result, bounded pending and result depth at one, and consumed zero
+stale results.
+
+The public
+[derived report](../../experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/)
+also records the limits discovered by the pilot. It contains one fixed-order
+repetition, all resource rows report `emc_missing`, the unprivileged
+`jetson_clocks --show` snapshot is unavailable, and sustained unattributed CPU
+activity crosses condition boundaries. No resource difference is therefore
+assigned causally to R0--R4, and no sample is excluded post hoc.
+
+## Fixed-input VLM evidence contract
+
+Phase 1C reuses the exact Phase 0 C100 JPEG identity (320 × 193, 9009 bytes,
+SHA-256 `607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7`).
+The adapter invokes the existing Moondream description, Qwen rewrite with
+Argos fallback, speech-oriented normalization and per-request Moondream unload
+functions. Those dependencies are imported only inside the explicit worker
+call; importing the Phase 1 runtime or experiment modules must not start a
+model, service request, camera or device.
+
+The first real-workload protocol contains one request per run:
+
+| Condition | Injection | Required terminal result |
+| --- | --- | --- |
+| `vlm_async` | no state change | `consumed` once |
+| `vlm_stale` | generation advances after Moondream starts | `rejected_state` once |
+
+Both conditions use pending and result capacities of one, an independent
+100 ms probe, finite service and join budgets, and a continuous 200 ms
+`tegrastats` trace. The stale condition intentionally does not attempt to
+interrupt the Ollama request. It records whether the worker later observes the
+cancellation token while leaving `backend_stop_confirmed` unknown. State
+invalidation and backend preemption remain separate facts.
+
+The input is hashed before admission, rechecked immediately before model work
+and rechecked again after the pipeline finishes. A size or hash change makes
+the result an execution error. Public scenario and summary artifacts contain
+the input identity, output SHA-256 and character count, translation route,
+stage durations, cancellation facts and lifecycle decisions. They do not
+contain the file path, prompt, English description, Chinese output or captured
+stdout/stderr.
+
+Before creating a run directory, preflight requires the existing Jetson safety
+and synchronized-`main` checks plus the fixed input, local-only Ollama and
+llama.cpp endpoints, installed Moondream and Qwen model identities, and the
+Ollama CLI plus OpenCV/Argos dependencies. A completed manifest additionally
+requires resource coverage during the adapter interval, valid replay, exactly one terminal
+disposition, zero stale consumption, a returned model-unload request,
+worker/probe/sampler joins,
+artifact hashes and an independently rebuilt summary.
+
+The host implementation and fault-injection tests do not count as a real-model
+result. The first Jetson runs remain descriptive correctness evidence. They do
+not measure visual accuracy, compare synchronous and asynchronous performance,
+prove GPU preemption or authorize a heterogeneous-compute performance claim.
+
 ## Gates
 
 The following correctness thresholds are fixed before the pilot:
@@ -648,10 +724,21 @@ The following correctness thresholds are fixed before the pilot:
 - zero unexplained telemetry parse errors;
 - zero Phase 0 artifact modifications.
 
-Numerical jitter and non-inferiority thresholds are frozen after an independent
-pilot and before formal data. The current 300 ms unchanged-command refresh
-target is a Phase 2 readiness reference; the STM32 1.2 s watchdog is a last
-defense and must not be used as the Jetson scheduling success target.
+The fixed-input VLM slice adds these zero-tolerance Gates:
+
+- the C100 identity matches before and after the request;
+- Moondream, one translation route, normalization and the unload call close;
+- the artifact records an unload request without claiming confirmed eviction;
+- raw model text and the private input path are absent from public artifacts;
+- `vlm_async` consumes exactly one result;
+- `vlm_stale` records exactly one `rejected_state` and zero accepted results;
+- cancellation evidence does not claim backend stop without confirmation;
+- at least one valid resource sample falls inside the adapter interval.
+
+Numerical jitter and non-inferiority thresholds will be frozen during the next
+protocol review and before formal data. The current 300 ms unchanged-command
+refresh target is a Phase 2 readiness reference; the STM32 1.2 s watchdog is a
+last defense and must not be used as the Jetson scheduling success target.
 
 ## Phase 1 completion boundary
 

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -2,13 +2,15 @@
 
 This directory contains the host tests, simulated-condition runner, trace
 recorder, event schema, independent lifecycle replay, run validation, Jetson
-pilot orchestration and descriptive summaries for the Phase 1 asynchronous
-runtime study. The Jetson pilot and Phase 1 performance results have not been
-completed yet.
+pilot orchestration, deterministic analysis, fixed-input VLM integration and
+descriptive summaries for the Phase 1 asynchronous runtime study. The first
+Jetson simulation pilot is complete. The VLM slice is implemented and
+host-tested, but its Jetson runs and all formal Phase 1 data remain uncollected.
 
 > 中文简介：本目录用于 Phase 1 异步运行时研究。当前已实现 host-only 有界 broker、
 > 单 worker 执行层、100 ms 周期探针、独立 trace replay、模拟条件运行器和 Jetson
-> pilot 基础设施；尚未执行真实 Jetson pilot、接入真实模型或采集 Phase 1 正式数据。
+> pilot 证据链，并完成首次 Jetson simulation pilot 及确定性分析；固定输入 VLM
+> 适配器和证据链已通过主机测试，Jetson 实机运行与 Phase 1 正式数据尚未采集。
 
 ## Current status
 
@@ -20,9 +22,12 @@ completed yet.
 - Inline synchronous-path probe: implemented and tested
 - Phase 1 schema `0.2.0`, JSONL recorder and lifecycle replay: implemented
 - Reproducible R0--R4 simulated-condition runner: implemented and host-tested
-- Jetson preflight, continuous resource telemetry and pilot runner: host-tested
-- Jetson simulation pilot: not run
-- Real VLM/ASR/LLM slices: not started
+- Jetson preflight, continuous resource telemetry and pilot runner: implemented
+- Jetson simulation pilot: completed and independently validated
+- Deterministic pilot analysis and public descriptive report: implemented
+- Fixed-input VLM adapter, single-request runner and validator: host-tested;
+  Jetson execution pending
+- Real ASR/LLM slices: not started
 - Formal Phase 1 data: not collected
 - Physical motion and UART: excluded
 
@@ -125,8 +130,8 @@ The preflight refuses to create a session unless all of the following hold:
 - motion is unset or explicitly disabled;
 - robot application, motion-planner and UART modules are not loaded.
 
-After this implementation is merged to `main`, run the descriptive pilot on
-the Jetson with explicit simulated service durations:
+Run the descriptive pilot on a clean, synchronized Jetson `main` branch with
+explicit simulated service durations:
 
 ```bash
 export ROBOT_ENABLE_MOTION=0
@@ -168,10 +173,84 @@ again with:
 python3 -m experiments.phase1.validate_jetson_pilot /path/to/session_dir
 ```
 
+Build deterministic JSON and Markdown derivatives outside the ignored session
+directory:
+
+```bash
+python3 -m experiments.phase1.analyze_jetson_pilot /path/to/session_dir \
+  --source-archive-sha256 <sha256> \
+  --json-output /path/to/analysis.json \
+  --markdown-output /path/to/report.md
+```
+
+The analyzer reruns the independent session validator before reading results.
+It preserves the non-inferential claim boundary, reports missing resource
+capabilities rather than converting them to zero, and applies a declared CPU
+activity screen without excluding samples. It refuses to write into the source
+session because an extra file would invalidate the evidence directory.
+
+The first public derived result is the
+[`20260828T121142Z` Jetson simulation pilot](results/20260828T121142Z_phase1_jetson_pilot/).
+It contains one fixed-order repetition and a simulated workload. The report is
+therefore descriptive evidence for protocol and runtime behavior, not a causal
+resource comparison or heterogeneous-inference result.
+
 The pilot is descriptive evidence used to design the later formal protocol. It
 does not authorize an asynchronous-performance or hard-real-time claim.
 Condition-level power summaries use instantaneous rail samples; the
 `tegrastats`-reported average is retained only as a session-window diagnostic.
+
+## Fixed-input VLM slice
+
+The first real-workload integration reuses the exact Phase 0 C100 JPEG, the
+Moondream request path, Qwen rewrite with Argos fallback, output normalization
+and the per-request unload policy. `vlm_adapter.py` imports the model-facing
+module only inside the worker call. Importing the experiment package on a host
+does not load OpenCV, Argos, a camera or either model service.
+
+The initial protocol has two separate single-request correctness conditions:
+
+| Condition | State action | Required disposition |
+| --- | --- | --- |
+| `vlm_async` | none | one result consumed |
+| `vlm_stale` | advance generation after Moondream starts | one `rejected_state`, zero consumed |
+
+State invalidation does not claim that Ollama stopped GPU inference. The
+adapter allows the backend path to finish, records
+`backend_stop_confirmed=null`, and relies on the broker's generation check to
+reject the completed result. Public artifacts retain only input identity,
+output hash and length, translation route, stage durations and lifecycle
+facts. Model text, prompts and the private input path are not serialized.
+
+After this implementation is merged, run each condition from a clean,
+synchronized Jetson `main` branch:
+
+```bash
+export ROBOT_ENABLE_MOTION=0
+python3 -m experiments.phase1.run_vlm_slice \
+  --condition vlm_async \
+  --session-id 20260829T000000Z_phase1_vlm_pilot \
+  --repetition 1
+
+python3 -m experiments.phase1.run_vlm_slice \
+  --condition vlm_stale \
+  --session-id 20260829T000000Z_phase1_vlm_pilot \
+  --repetition 1
+```
+
+The runner refuses to create a directory unless platform, Git, motion, module,
+fixed-input, dependency, Ollama CLI, Moondream and Qwen checks all pass. Each
+run contains `preflight.json`, the event and resource JSONL traces, `scenario.json`,
+`summary.json` and an atomic manifest. Validate either directory again with:
+
+```bash
+python3 -m experiments.phase1.validate_vlm_slice /path/to/run_dir
+```
+
+These two runs establish integration and stale-result correctness only. They
+do not form a balanced synchronous/asynchronous comparison, prove backend
+preemption, measure visual accuracy or authorize a heterogeneous-performance
+claim.
 
 ## Planned implementation order
 
@@ -184,8 +263,10 @@ Condition-level power summaries use instantaneous rail samples; the
    complete;
 5. implement and host-test Jetson preflight, continuous resource telemetry and
    pilot session validation — complete;
-6. run the safe Jetson simulation pilot with `ROBOT_ENABLE_MOTION=0`;
-7. integrate the fixed-input VLM slice;
+6. run and independently analyze the safe Jetson simulation pilot with
+   `ROBOT_ENABLE_MOTION=0` — complete;
+7. implement and host-test the fixed-input VLM slice — complete; Jetson
+   execution pending;
 8. extend the same adapter/runtime boundary to ASR and LLM;
 9. freeze formal thresholds and collect balanced synchronous/asynchronous data;
 10. add an opt-in motion-disabled application slice after the research Gates
@@ -223,18 +304,28 @@ experiments/phase1/
 ├── pilot.py
 ├── run_jetson_pilot.py
 ├── run_simulation.py
+├── run_vlm_slice.py
 ├── schemas/
 │   ├── event.schema.json
 │   └── resource.schema.json
 ├── simulation.py
 ├── summarize_run.py
+├── summarize_vlm_slice.py
 ├── tests/
 ├── telemetry.py
 ├── validate_jetson_pilot.py
 ├── validate_run.py
+├── validate_vlm_slice.py
+├── vlm_adapter.py
+├── vlm_preflight.py
+├── vlm_slice.py
 ├── replay_lifecycle.py
 └── README.md
 ```
+
+`analyze_jetson_pilot.py` validates an ignored raw session and produces the
+tracked, deterministic derivatives under `results/`. The raw session remains
+outside Git.
 
 The experiment layer owns condition scheduling, run directories, manifests,
 validation and summaries. The executor continues to own all traced broker

--- a/experiments/phase1/analyze_jetson_pilot.py
+++ b/experiments/phase1/analyze_jetson_pilot.py
@@ -1,0 +1,964 @@
+"""Build a deterministic descriptive report from one validated Jetson pilot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from experiments.phase1.jetson_telemetry import load_resource_samples
+from experiments.phase1.pilot import validate_pilot_dir
+
+
+ANALYSIS_SCHEMA_VERSION = "0.1.0"
+DEFAULT_CPU_ACTIVITY_THRESHOLD_PCT = 80.0
+DEFAULT_CPU_ACTIVITY_MIN_SAMPLES = 5
+DEFAULT_CPU_ACTIVITY_MERGE_GAP_MS = 500.0
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.name} must contain a JSON object")
+    return value
+
+
+def _finite_positive(value: object, name: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError(f"{name} must be positive and finite")
+    return float(value)
+
+
+def _positive_integer(value: object, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _milliseconds(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("nanosecond metric must be numeric or null")
+    return round(float(value) / 1_000_000.0, 6)
+
+
+def _metric_value(
+    description: object,
+    field: str,
+    *,
+    divisor: float = 1.0,
+) -> float | None:
+    if description is None:
+        return None
+    if not isinstance(description, Mapping):
+        raise ValueError("descriptive metric must be an object or null")
+    value = description.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"descriptive metric {field} must be numeric")
+    return round(float(value) / divisor, 6)
+
+
+def _snapshot_status(value: object) -> dict[str, object]:
+    snapshot = value if isinstance(value, Mapping) else {}
+    return {
+        "available": snapshot.get("returncode") == 0
+        and snapshot.get("error_code") is None,
+        "returncode": snapshot.get("returncode"),
+        "error_code": snapshot.get("error_code"),
+        "output": snapshot.get("output", ""),
+    }
+
+
+def _condition_rows(summary: Mapping[str, object]) -> list[dict[str, object]]:
+    runs = summary.get("runs")
+    if not isinstance(runs, list):
+        raise ValueError("pilot summary has no run list")
+    rows: list[dict[str, object]] = []
+    for run in runs:
+        if not isinstance(run, Mapping):
+            raise ValueError("pilot summary run is not an object")
+        probe = run.get("probe")
+        if not isinstance(probe, Mapping):
+            raise ValueError("pilot summary run has no probe object")
+        rows.append(
+            {
+                "sequence": run.get("sequence"),
+                "condition": run.get("condition"),
+                "role": run.get("role"),
+                "service_time_s": run.get("service_time_s"),
+                "tick_count": probe.get("tick_count"),
+                "skipped_releases": probe.get("skipped_releases"),
+                "deadline_miss_count": probe.get("deadline_miss_count"),
+                "deadline_miss_rate": probe.get("deadline_miss_rate"),
+                "start_lateness_p95_ms": _milliseconds(
+                    _mapping_value(probe.get("start_lateness"), "p95_ns")
+                ),
+                "start_lateness_p99_ms": _milliseconds(
+                    _mapping_value(probe.get("start_lateness"), "p99_ns")
+                ),
+                "start_lateness_max_ms": _milliseconds(
+                    _mapping_value(probe.get("start_lateness"), "max_ns")
+                ),
+                "actual_period_p99_ms": _milliseconds(
+                    _mapping_value(probe.get("actual_period"), "p99_ns")
+                ),
+                "maximum_observed_gap_ms": _milliseconds(
+                    probe.get("maximum_observed_gap_ns")
+                ),
+                "run_valid": run.get("run_valid") is True,
+            }
+        )
+    return rows
+
+
+def _mapping_value(value: object, key: str) -> object:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError(f"metric containing {key} must be an object")
+    return value.get(key)
+
+
+def _runtime_rows(summary: Mapping[str, object]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for run in _run_objects(summary):
+        if run.get("condition") != "r3_async":
+            continue
+        timing = run.get("task_timing")
+        if not isinstance(timing, Mapping):
+            raise ValueError("R3 run has no task timing object")
+        service_time_s = run.get("service_time_s")
+        if isinstance(service_time_s, bool) or not isinstance(
+            service_time_s, (int, float)
+        ):
+            raise ValueError("R3 service time is not numeric")
+        terminal_age_ms = _milliseconds(
+            _mapping_value(timing.get("terminal_age"), "mean_ns")
+        )
+        configured_ms = round(float(service_time_s) * 1000.0, 6)
+        rows.append(
+            {
+                "sequence": run.get("sequence"),
+                "service_time_s": float(service_time_s),
+                "queue_wait_ms": _milliseconds(
+                    _mapping_value(timing.get("queue_wait"), "mean_ns")
+                ),
+                "measured_service_time_ms": _milliseconds(
+                    _mapping_value(timing.get("service_time"), "mean_ns")
+                ),
+                "terminal_age_ms": terminal_age_ms,
+                "terminal_age_excess_over_configured_ms": (
+                    round(terminal_age_ms - configured_ms, 6)
+                    if terminal_age_ms is not None
+                    else None
+                ),
+            }
+        )
+    return rows
+
+
+def _run_objects(summary: Mapping[str, object]) -> list[Mapping[str, object]]:
+    runs = summary.get("runs")
+    if not isinstance(runs, list):
+        raise ValueError("pilot summary has no run list")
+    if not all(isinstance(run, Mapping) for run in runs):
+        raise ValueError("pilot summary run is not an object")
+    return runs
+
+
+def _lifecycle_rows(summary: Mapping[str, object]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for run in _run_objects(summary):
+        if run.get("condition") not in {
+            "r3_async",
+            "r4_stale",
+            "r4_overflow",
+        }:
+            continue
+        lifecycle = run.get("lifecycle")
+        if not isinstance(lifecycle, Mapping):
+            raise ValueError("runtime run has no lifecycle object")
+        disposition_items = lifecycle.get("disposition_counts")
+        if not isinstance(disposition_items, list):
+            raise ValueError("runtime run has no disposition counts")
+        dispositions: dict[str, int] = {}
+        for item in disposition_items:
+            if (
+                not isinstance(item, list)
+                or len(item) != 2
+                or not isinstance(item[0], str)
+                or isinstance(item[1], bool)
+                or not isinstance(item[1], int)
+            ):
+                raise ValueError("runtime disposition count is invalid")
+            dispositions[item[0]] = item[1]
+        rows.append(
+            {
+                "sequence": run.get("sequence"),
+                "condition": run.get("condition"),
+                "service_time_s": run.get("service_time_s"),
+                "submission_attempts": lifecycle.get("submission_attempts"),
+                "admitted_total": lifecycle.get("admitted_total"),
+                "accepted_result_count": lifecycle.get("accepted_result_count"),
+                "stale_consumed_count": lifecycle.get("stale_consumed_count"),
+                "max_pending_depth": lifecycle.get("max_pending_depth"),
+                "max_result_depth": lifecycle.get("max_result_depth"),
+                "worker_joined": lifecycle.get("worker_joined"),
+                "probe_joined": lifecycle.get("probe_joined"),
+                "disposition_counts": dispositions,
+            }
+        )
+    return rows
+
+
+def _resource_rows(summary: Mapping[str, object]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for run in _run_objects(summary):
+        resources = run.get("resources")
+        if not isinstance(resources, Mapping):
+            raise ValueError("pilot run has no resource summary")
+        cpu = resources.get("cpu_usage_pct")
+        if not isinstance(cpu, Mapping):
+            raise ValueError("pilot run has no CPU summary")
+        cpu_mean = sum(
+            value
+            for description in cpu.values()
+            if (value := _metric_value(description, "mean")) is not None
+        )
+        gr3d = resources.get("gr3d_usage_pct")
+        ram = resources.get("ram_used_mb")
+        temperatures = resources.get("temperatures_c")
+        power = resources.get("power_instant_mw")
+        temperature_map = temperatures if isinstance(temperatures, Mapping) else {}
+        power_map = power if isinstance(power, Mapping) else {}
+        rows.append(
+            {
+                "sequence": run.get("sequence"),
+                "condition": run.get("condition"),
+                "service_time_s": run.get("service_time_s"),
+                "sample_count": resources.get("sample_count"),
+                "aggregate_cpu_mean_pct": round(cpu_mean, 6),
+                "gr3d_mean_pct": _metric_value(gr3d, "mean"),
+                "gr3d_p95_pct": _metric_value(gr3d, "p95"),
+                "gr3d_max_pct": _metric_value(gr3d, "max"),
+                "ram_mean_mb": _metric_value(ram, "mean"),
+                "ram_max_mb": _metric_value(ram, "max"),
+                "tj_mean_c": _metric_value(temperature_map.get("tj"), "mean"),
+                "tj_max_c": _metric_value(temperature_map.get("tj"), "max"),
+                "vdd_in_mean_mw": _metric_value(power_map.get("VDD_IN"), "mean"),
+                "vdd_in_p95_mw": _metric_value(power_map.get("VDD_IN"), "p95"),
+                "vdd_in_max_mw": _metric_value(power_map.get("VDD_IN"), "max"),
+            }
+        )
+    return rows
+
+
+def _cpu_total(sample: Mapping[str, object]) -> float:
+    cores = sample.get("cpu")
+    if not isinstance(cores, list):
+        raise ValueError("resource sample has no CPU list")
+    total = 0.0
+    for core in cores:
+        if not isinstance(core, Mapping):
+            raise ValueError("resource CPU entry is not an object")
+        usage = core.get("usage_pct")
+        if usage is None and core.get("online") is False:
+            continue
+        if isinstance(usage, bool) or not isinstance(usage, (int, float)):
+            raise ValueError("resource CPU usage is not numeric")
+        total += float(usage)
+    return total
+
+
+def _detect_cpu_activity(
+    samples: Sequence[Mapping[str, object]],
+    runs: Sequence[Mapping[str, object]],
+    *,
+    threshold_pct: float,
+    minimum_samples: int,
+    merge_gap_ms: float,
+) -> list[dict[str, object]]:
+    threshold = _finite_positive(threshold_pct, "cpu_activity_threshold_pct")
+    minimum = _positive_integer(minimum_samples, "cpu_activity_min_samples")
+    merge_gap_ns = int(
+        _finite_positive(merge_gap_ms, "cpu_activity_merge_gap_ms") * 1_000_000
+    )
+    selected = [sample for sample in samples if _cpu_total(sample) >= threshold]
+    groups: list[list[Mapping[str, object]]] = []
+    for sample in selected:
+        monotonic_ns = sample.get("sample_monotonic_ns")
+        if isinstance(monotonic_ns, bool) or not isinstance(monotonic_ns, int):
+            raise ValueError("resource sample has an invalid monotonic timestamp")
+        if not groups:
+            groups.append([sample])
+            continue
+        previous_ns = groups[-1][-1].get("sample_monotonic_ns")
+        if (
+            not isinstance(previous_ns, int)
+            or monotonic_ns - previous_ns > merge_gap_ns
+        ):
+            groups.append([sample])
+        else:
+            groups[-1].append(sample)
+
+    episodes: list[dict[str, object]] = []
+    first_sample_ns = int(samples[0]["sample_monotonic_ns"]) if samples else 0
+    for group in groups:
+        if len(group) < minimum:
+            continue
+        start_ns = int(group[0]["sample_monotonic_ns"])
+        end_ns = int(group[-1]["sample_monotonic_ns"])
+        totals = [_cpu_total(sample) for sample in group]
+        overlapping: list[dict[str, object]] = []
+        for run in runs:
+            run_start = run.get("started_monotonic_ns")
+            run_finish = run.get("finished_monotonic_ns")
+            if not isinstance(run_start, int) or not isinstance(run_finish, int):
+                raise ValueError("pilot run has an invalid monotonic interval")
+            if run_start <= end_ns and run_finish >= start_ns:
+                overlapping.append(
+                    {
+                        "sequence": run.get("sequence"),
+                        "condition": run.get("condition"),
+                        "service_time_s": run.get("service_time_s"),
+                    }
+                )
+        episodes.append(
+            {
+                "start_offset_s": round((start_ns - first_sample_ns) / 1e9, 6),
+                "end_offset_s": round((end_ns - first_sample_ns) / 1e9, 6),
+                "duration_s": round((end_ns - start_ns) / 1e9, 6),
+                "sample_count": len(group),
+                "aggregate_cpu_mean_pct": round(sum(totals) / len(totals), 6),
+                "aggregate_cpu_max_pct": round(max(totals), 6),
+                "overlapping_runs": overlapping,
+            }
+        )
+    return episodes
+
+
+def _resource_capabilities(
+    samples: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    sample_count = len(samples)
+    emc_available = sum(isinstance(sample.get("emc"), Mapping) for sample in samples)
+    warning_counts = Counter(
+        warning
+        for sample in samples
+        for warning in sample.get("parse_warnings", [])
+        if isinstance(warning, str)
+    )
+    error_counts = Counter(
+        error
+        for sample in samples
+        for error in sample.get("parse_errors", [])
+        if isinstance(error, str)
+    )
+    return {
+        "sample_count": sample_count,
+        "emc": {
+            "available_sample_count": emc_available,
+            "missing_sample_count": sample_count - emc_available,
+            "coverage_rate": emc_available / sample_count if sample_count else None,
+        },
+        "parse_warning_counts": dict(sorted(warning_counts.items())),
+        "parse_error_counts": dict(sorted(error_counts.items())),
+    }
+
+
+def _limitations(
+    plan: Mapping[str, object],
+    capabilities: Mapping[str, object],
+    clocks: Mapping[str, object],
+    activity: Sequence[Mapping[str, object]],
+) -> list[str]:
+    limitations = ["simulated_workload_only", "fixed_condition_order"]
+    if plan.get("repetitions") == 1:
+        limitations.append("single_repetition")
+    emc = capabilities.get("emc")
+    if isinstance(emc, Mapping) and emc.get("available_sample_count") == 0:
+        limitations.append("emc_unavailable")
+    if clocks.get("available") is not True:
+        limitations.append("jetson_clocks_snapshot_unavailable")
+    if activity:
+        limitations.append("unattributed_cpu_activity_detected")
+    return limitations
+
+
+def analyze_pilot_dir(
+    session_dir: Path | str,
+    *,
+    source_archive_sha256: str | None = None,
+    cpu_activity_threshold_pct: float = DEFAULT_CPU_ACTIVITY_THRESHOLD_PCT,
+    cpu_activity_min_samples: int = DEFAULT_CPU_ACTIVITY_MIN_SAMPLES,
+    cpu_activity_merge_gap_ms: float = DEFAULT_CPU_ACTIVITY_MERGE_GAP_MS,
+) -> dict[str, object]:
+    """Validate and reconstruct one non-inferential Jetson pilot analysis."""
+
+    directory = Path(session_dir).resolve()
+    errors = validate_pilot_dir(directory)
+    if errors:
+        raise ValueError("invalid Jetson pilot: " + "; ".join(errors))
+    if source_archive_sha256 is not None:
+        normalized_hash = source_archive_sha256.lower()
+        if not _SHA256_RE.fullmatch(normalized_hash):
+            raise ValueError("source_archive_sha256 must contain 64 hexadecimal digits")
+    else:
+        normalized_hash = None
+
+    manifest = _read_object(directory / "session_manifest.json")
+    plan = _read_object(directory / "pilot_plan.json")
+    preflight = _read_object(directory / "preflight.json")
+    summary = _read_object(directory / "pilot_summary.json")
+    samples = load_resource_samples(directory / "resources.jsonl")
+    runs = _run_objects(summary)
+
+    environment = preflight.get("environment")
+    if not isinstance(environment, Mapping):
+        raise ValueError("preflight has no environment object")
+    git = environment.get("git")
+    git_record = git if isinstance(git, Mapping) else {}
+    clocks = _snapshot_status(environment.get("jetson_clocks"))
+    capabilities = _resource_capabilities(samples)
+    activity = _detect_cpu_activity(
+        samples,
+        runs,
+        threshold_pct=cpu_activity_threshold_pct,
+        minimum_samples=cpu_activity_min_samples,
+        merge_gap_ms=cpu_activity_merge_gap_ms,
+    )
+    gates = summary.get("gates")
+    if not isinstance(gates, list):
+        raise ValueError("pilot summary has no Gate list")
+
+    return {
+        "analysis_schema_version": ANALYSIS_SCHEMA_VERSION,
+        "analysis_kind": "phase1_jetson_simulation_pilot",
+        "session_id": summary.get("session_id"),
+        "source": {
+            "git_commit": git_record.get("commit"),
+            "git_branch": git_record.get("branch"),
+            "source_archive_sha256": normalized_hash,
+            "session_artifacts": manifest.get("artifacts"),
+        },
+        "claim_boundary": {
+            "design_role": "descriptive_pilot",
+            "descriptive_only": True,
+            "inference_claim_permitted": False,
+            "asynchronous_performance_superiority_claim_permitted": False,
+            "hard_real_time_claim_permitted": False,
+            "heterogeneous_inference_claim_permitted": False,
+            "condition_resource_attribution_permitted": False,
+        },
+        "analysis_parameters": {
+            "percentile_method": "nearest-rank",
+            "cpu_activity_screen": {
+                "metric": "sum of per-core tegrastats usage percentages",
+                "threshold_pct": float(cpu_activity_threshold_pct),
+                "minimum_samples": cpu_activity_min_samples,
+                "merge_gap_ms": float(cpu_activity_merge_gap_ms),
+                "role": "descriptive contamination screen; no samples excluded",
+            },
+        },
+        "environment": {
+            "platform": environment.get("platform"),
+            "machine": environment.get("machine"),
+            "python": environment.get("python"),
+            "l4t_release": environment.get("l4t_release"),
+            "jetpack_packages": _snapshot_status(environment.get("jetpack_packages")),
+            "nvpmodel": _snapshot_status(environment.get("nvpmodel")),
+            "jetson_clocks": clocks,
+            "motion_disabled": (
+                preflight.get("safety", {}).get("motion_enabled") is False
+                if isinstance(preflight.get("safety"), Mapping)
+                else False
+            ),
+        },
+        "validation": {
+            "session_status": manifest.get("status"),
+            "session_valid": summary.get("valid") is True,
+            "run_count": summary.get("run_count"),
+            "gates": gates,
+        },
+        "responsiveness": _condition_rows(summary),
+        "runtime_overhead": _runtime_rows(summary),
+        "lifecycle": _lifecycle_rows(summary),
+        "resources": {
+            "session": summary.get("resources"),
+            "per_run": _resource_rows(summary),
+            "capabilities": capabilities,
+        },
+        "data_quality": {
+            "unattributed_cpu_activity": activity,
+            "limitations": _limitations(plan, capabilities, clocks, activity),
+        },
+    }
+
+
+def _format_number(value: object, digits: int = 3) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value).replace("|", "\\|")
+
+
+def _snapshot_output(environment: Mapping[str, object], name: str) -> str:
+    snapshot = environment.get(name)
+    if not isinstance(snapshot, Mapping):
+        return "unavailable"
+    output = str(snapshot.get("output", "")).replace("\n", "; ").replace("\t", " ")
+    return output or "unavailable"
+
+
+def render_markdown(analysis: Mapping[str, object]) -> str:
+    """Render the public, descriptive result report."""
+
+    source = analysis["source"]
+    environment = analysis["environment"]
+    validation = analysis["validation"]
+    resources = analysis["resources"]
+    quality = analysis["data_quality"]
+    parameters = analysis["analysis_parameters"]
+    if not all(
+        isinstance(item, Mapping)
+        for item in (
+            source,
+            environment,
+            validation,
+            resources,
+            quality,
+            parameters,
+        )
+    ):
+        raise ValueError("analysis contains an invalid report section")
+
+    lines = [
+        "# Phase 1 Jetson Simulation Pilot",
+        "",
+        (
+            "This report records one descriptive, motion-disabled pilot on the "
+            "Jetson Orin Nano. It validates the measurement protocol and runtime "
+            "semantics; it is not a formal performance comparison."
+        ),
+        "",
+        "## Evidence boundary",
+        "",
+        "- Workload: deterministic simulated service time; no model inference.",
+        "- Repetitions: one fixed-order R0--R4 matrix.",
+        "- Physical motion and UART access: disabled.",
+        "- Permitted interpretation: descriptive timing and correctness evidence only.",
+        "- Not permitted: asynchronous superiority, hard-real-time or heterogeneous-inference claims.",
+        "",
+        "## Provenance",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Session | `{analysis.get('session_id')}` |",
+        f"| Source commit | `{source.get('git_commit')}` |",
+        f"| Source branch | `{source.get('git_branch')}` |",
+        f"| Transfer archive SHA-256 | `{source.get('source_archive_sha256') or 'not recorded'}` |",
+        f"| Session status | `{validation.get('session_status')}` |",
+        f"| Independently valid | {_format_number(validation.get('session_valid'))} |",
+        "",
+        "Machine-readable derived data: [`analysis.json`](analysis.json).",
+        "",
+        "## Device context",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Platform | {_format_number(environment.get('platform'))} |",
+        f"| Architecture | {_format_number(environment.get('machine'))} |",
+        f"| Python | {_format_number(environment.get('python'))} |",
+        f"| JetPack packages | {_snapshot_output(environment, 'jetpack_packages')} |",
+        f"| Power mode | {_snapshot_output(environment, 'nvpmodel')} |",
+        f"| `jetson_clocks` snapshot | {'available' if environment.get('jetson_clocks', {}).get('available') else 'unavailable'} |",
+        "",
+        "## Validation Gates",
+        "",
+        "| Gate | Passed |",
+        "| --- | --- |",
+    ]
+    gates = validation.get("gates")
+    if not isinstance(gates, list):
+        raise ValueError("analysis validation Gates are missing")
+    for gate in gates:
+        if not isinstance(gate, Mapping):
+            raise ValueError("analysis validation Gate is invalid")
+        lines.append(f"| `{gate.get('name')}` | {_format_number(gate.get('passed'))} |")
+
+    lines.extend(
+        [
+            "",
+            "## Responsiveness decomposition",
+            "",
+            "| Seq. | Condition | Service (s) | Ticks | Skipped | Deadline misses | Lateness p99 (ms) | Maximum gap (ms) |",
+            "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    responsiveness = analysis.get("responsiveness")
+    if not isinstance(responsiveness, list):
+        raise ValueError("analysis responsiveness rows are missing")
+    for row in responsiveness:
+        if not isinstance(row, Mapping):
+            raise ValueError("analysis responsiveness row is invalid")
+        lines.append(
+            "| {sequence} | `{condition}` | {service} | {ticks} | {skipped} | "
+            "{misses} | {p99} | {gap} |".format(
+                sequence=row.get("sequence"),
+                condition=row.get("condition"),
+                service=_format_number(row.get("service_time_s")),
+                ticks=_format_number(row.get("tick_count")),
+                skipped=_format_number(row.get("skipped_releases")),
+                misses=_format_number(row.get("deadline_miss_count")),
+                p99=_format_number(row.get("start_lateness_p99_ms")),
+                gap=_format_number(row.get("maximum_observed_gap_ms")),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            (
+                "The inline condition recorded skipped releases rather than executed "
+                "ticks that missed their deadline. R2 and R3 both isolate the periodic "
+                "probe from the slow call; R3 additionally supplies bounded ownership, "
+                "freshness and cancellation semantics."
+            ),
+            "",
+            "## R3 runtime timing",
+            "",
+            "| Service (s) | Queue wait (ms) | Measured service (ms) | Terminal age (ms) | Excess over configured (ms) |",
+            "| ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    overhead = analysis.get("runtime_overhead")
+    if not isinstance(overhead, list):
+        raise ValueError("analysis runtime overhead rows are missing")
+    for row in overhead:
+        if not isinstance(row, Mapping):
+            raise ValueError("analysis runtime overhead row is invalid")
+        lines.append(
+            "| {service} | {queue} | {measured} | {terminal} | {excess} |".format(
+                service=_format_number(row.get("service_time_s")),
+                queue=_format_number(row.get("queue_wait_ms")),
+                measured=_format_number(row.get("measured_service_time_ms")),
+                terminal=_format_number(row.get("terminal_age_ms")),
+                excess=_format_number(
+                    row.get("terminal_age_excess_over_configured_ms")
+                ),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Runtime correctness",
+            "",
+            "| Condition | Service (s) | Submissions | Accepted | Stale consumed | Max pending | Max result | Dispositions |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    lifecycle = analysis.get("lifecycle")
+    if not isinstance(lifecycle, list):
+        raise ValueError("analysis lifecycle rows are missing")
+    for row in lifecycle:
+        if not isinstance(row, Mapping):
+            raise ValueError("analysis lifecycle row is invalid")
+        disposition = row.get("disposition_counts")
+        rendered = (
+            ", ".join(f"{key}={value}" for key, value in disposition.items())
+            if isinstance(disposition, Mapping)
+            else "n/a"
+        )
+        lines.append(
+            "| `{condition}` | {service} | {submitted} | {accepted} | {stale} | "
+            "{pending} | {result} | {disposition} |".format(
+                condition=row.get("condition"),
+                service=_format_number(row.get("service_time_s")),
+                submitted=_format_number(row.get("submission_attempts")),
+                accepted=_format_number(row.get("accepted_result_count")),
+                stale=_format_number(row.get("stale_consumed_count")),
+                pending=_format_number(row.get("max_pending_depth")),
+                result=_format_number(row.get("max_result_depth")),
+                disposition=rendered,
+            )
+        )
+
+    session_resources = resources.get("session")
+    capabilities = resources.get("capabilities")
+    if not isinstance(session_resources, Mapping) or not isinstance(
+        capabilities, Mapping
+    ):
+        raise ValueError("analysis resource sections are invalid")
+    temperature = session_resources.get("temperatures_c")
+    power = session_resources.get("power_instant_mw")
+    temperature_map = temperature if isinstance(temperature, Mapping) else {}
+    power_map = power if isinstance(power, Mapping) else {}
+    sample_interval = session_resources.get("sample_interval_ns")
+    sample_span_s = _metric_value(
+        {"value": session_resources.get("sample_span_ns")},
+        "value",
+        divisor=1_000_000_000.0,
+    )
+    lines.extend(
+        [
+            "",
+            "## Session resources",
+            "",
+            "| Metric | Mean | p95 | Maximum |",
+            "| --- | ---: | ---: | ---: |",
+            "| RAM used (MB) | {mean} | {p95} | {maximum} |".format(
+                mean=_format_number(
+                    _metric_value(session_resources.get("ram_used_mb"), "mean")
+                ),
+                p95=_format_number(
+                    _metric_value(session_resources.get("ram_used_mb"), "p95")
+                ),
+                maximum=_format_number(
+                    _metric_value(session_resources.get("ram_used_mb"), "max")
+                ),
+            ),
+            "| GR3D usage (%) | {mean} | {p95} | {maximum} |".format(
+                mean=_format_number(
+                    _metric_value(session_resources.get("gr3d_usage_pct"), "mean")
+                ),
+                p95=_format_number(
+                    _metric_value(session_resources.get("gr3d_usage_pct"), "p95")
+                ),
+                maximum=_format_number(
+                    _metric_value(session_resources.get("gr3d_usage_pct"), "max")
+                ),
+            ),
+            "| Junction temperature (C) | {mean} | {p95} | {maximum} |".format(
+                mean=_format_number(_metric_value(temperature_map.get("tj"), "mean")),
+                p95=_format_number(_metric_value(temperature_map.get("tj"), "p95")),
+                maximum=_format_number(_metric_value(temperature_map.get("tj"), "max")),
+            ),
+            "| VDD_IN instantaneous power (mW) | {mean} | {p95} | {maximum} |".format(
+                mean=_format_number(_metric_value(power_map.get("VDD_IN"), "mean")),
+                p95=_format_number(_metric_value(power_map.get("VDD_IN"), "p95")),
+                maximum=_format_number(_metric_value(power_map.get("VDD_IN"), "max")),
+            ),
+            "",
+            (
+                "Telemetry coverage: {count} samples across {span} s; mean interval "
+                "{mean} ms, p99 interval {p99} ms, parse errors {errors}."
+            ).format(
+                count=_format_number(session_resources.get("sample_count")),
+                span=_format_number(sample_span_s),
+                mean=_format_number(
+                    _metric_value(sample_interval, "mean", divisor=1_000_000.0)
+                ),
+                p99=_format_number(
+                    _metric_value(sample_interval, "p99", divisor=1_000_000.0)
+                ),
+                errors=_format_number(session_resources.get("parse_error_count")),
+            ),
+            "",
+            "## Data-quality observations",
+            "",
+        ]
+    )
+    limitations = quality.get("limitations")
+    if not isinstance(limitations, list):
+        raise ValueError("analysis limitations are missing")
+    for item in limitations:
+        lines.append(f"- `{item}`")
+
+    emc = capabilities.get("emc")
+    if isinstance(emc, Mapping):
+        lines.append(
+            "- EMC coverage: {available}/{total} samples; missing values are not "
+            "interpreted as zero.".format(
+                available=emc.get("available_sample_count"),
+                total=capabilities.get("sample_count"),
+            )
+        )
+    warnings = capabilities.get("parse_warning_counts")
+    if isinstance(warnings, Mapping):
+        lines.append(
+            "- Resource parse warnings: "
+            + (", ".join(f"{key}={value}" for key, value in warnings.items()) or "none")
+            + "."
+        )
+
+    activity_screen = parameters.get("cpu_activity_screen")
+    if not isinstance(activity_screen, Mapping):
+        raise ValueError("analysis CPU activity parameters are missing")
+    lines.extend(
+        [
+            "",
+            "### Unattributed CPU activity screen",
+            "",
+            (
+                "The screen sums per-core usage percentages and marks sustained "
+                "intervals at or above {threshold}%. It does not identify a process "
+                "and does not exclude any sample."
+            ).format(threshold=_format_number(activity_screen.get("threshold_pct"), 1)),
+            "",
+            "| Start offset (s) | End offset (s) | Samples | CPU mean (%) | CPU max (%) | Overlapping runs |",
+            "| ---: | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    episodes = quality.get("unattributed_cpu_activity")
+    if not isinstance(episodes, list):
+        raise ValueError("analysis activity episodes are missing")
+    for episode in episodes:
+        if not isinstance(episode, Mapping):
+            raise ValueError("analysis activity episode is invalid")
+        overlapping = episode.get("overlapping_runs")
+        rendered_runs = ""
+        if isinstance(overlapping, list):
+            rendered_runs = ", ".join(
+                f"{item.get('sequence')}:{item.get('condition')}"
+                for item in overlapping
+                if isinstance(item, Mapping)
+            )
+        lines.append(
+            "| {start} | {end} | {count} | {mean} | {maximum} | {runs} |".format(
+                start=_format_number(episode.get("start_offset_s")),
+                end=_format_number(episode.get("end_offset_s")),
+                count=_format_number(episode.get("sample_count")),
+                mean=_format_number(episode.get("aggregate_cpu_mean_pct")),
+                maximum=_format_number(episode.get("aggregate_cpu_max_pct")),
+                runs=rendered_runs or "none",
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            (
+                "The pilot shows that an inline slow call creates a control-proxy "
+                "gap on the same scale as the configured service time. A separate "
+                "thread is sufficient for timing-domain isolation, while the bounded "
+                "runtime adds explicit queue, cancellation and freshness behavior."
+            ),
+            "",
+            (
+                "Resource differences between conditions are not attributed to the "
+                "runtime because the matrix has one fixed-order repetition and the "
+                "CPU screen crosses condition boundaries. The simulated adapter also "
+                "does not exercise a heterogeneous inference workload. A fixed-input "
+                "VLM slice and a balanced repeated protocol are required before those "
+                "questions can be tested."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _refuse_output_inside_session(output: Path | None, session_dir: Path) -> None:
+    if output is None:
+        return
+    resolved = output.resolve()
+    try:
+        resolved.relative_to(session_dir.resolve())
+    except ValueError:
+        return
+    raise ValueError("analysis output must not be written inside the source session")
+
+
+def _require_distinct_outputs(
+    json_output: Path | None,
+    markdown_output: Path | None,
+) -> None:
+    if (
+        json_output is not None
+        and markdown_output is not None
+        and json_output.resolve() == markdown_output.resolve()
+    ):
+        raise ValueError("JSON and Markdown outputs must use distinct paths")
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(text, encoding="utf-8", newline="\n")
+    os.replace(temporary, path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("session_dir", type=Path)
+    parser.add_argument("--source-archive-sha256")
+    parser.add_argument("--json-output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument(
+        "--cpu-activity-threshold-pct",
+        type=float,
+        default=DEFAULT_CPU_ACTIVITY_THRESHOLD_PCT,
+    )
+    parser.add_argument(
+        "--cpu-activity-min-samples",
+        type=int,
+        default=DEFAULT_CPU_ACTIVITY_MIN_SAMPLES,
+    )
+    parser.add_argument(
+        "--cpu-activity-merge-gap-ms",
+        type=float,
+        default=DEFAULT_CPU_ACTIVITY_MERGE_GAP_MS,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    session_dir = args.session_dir.resolve()
+    try:
+        _refuse_output_inside_session(args.json_output, session_dir)
+        _refuse_output_inside_session(args.markdown_output, session_dir)
+        _require_distinct_outputs(args.json_output, args.markdown_output)
+        analysis = analyze_pilot_dir(
+            session_dir,
+            source_archive_sha256=args.source_archive_sha256,
+            cpu_activity_threshold_pct=args.cpu_activity_threshold_pct,
+            cpu_activity_min_samples=args.cpu_activity_min_samples,
+            cpu_activity_merge_gap_ms=args.cpu_activity_merge_gap_ms,
+        )
+        markdown_text = (
+            render_markdown(analysis) if args.markdown_output is not None else None
+        )
+        json_text = json.dumps(
+            analysis,
+            ensure_ascii=False,
+            indent=2,
+            allow_nan=False,
+        )
+        if args.json_output is not None:
+            _write_text_atomic(args.json_output, json_text + "\n")
+        else:
+            print(json_text)
+        if args.markdown_output is not None and markdown_text is not None:
+            _write_text_atomic(args.markdown_output, markdown_text)
+    except (OSError, TypeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/README.md
+++ b/experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/README.md
@@ -1,0 +1,129 @@
+# Phase 1 Jetson Simulation Pilot
+
+This report records one descriptive, motion-disabled pilot on the Jetson Orin Nano. It validates the measurement protocol and runtime semantics; it is not a formal performance comparison.
+
+## Evidence boundary
+
+- Workload: deterministic simulated service time; no model inference.
+- Repetitions: one fixed-order R0--R4 matrix.
+- Physical motion and UART access: disabled.
+- Permitted interpretation: descriptive timing and correctness evidence only.
+- Not permitted: asynchronous superiority, hard-real-time or heterogeneous-inference claims.
+
+## Provenance
+
+| Field | Value |
+| --- | --- |
+| Session | `20260828T121142Z_phase1_jetson_pilot` |
+| Source commit | `77138f2eb5db73acad24ef1fd61c03ddfbb336bc` |
+| Source branch | `main` |
+| Transfer archive SHA-256 | `dd7c33fa0a19b8a709cdfc7eca29a178234b39e842ad756d763d3fd33810697a` |
+| Session status | `completed` |
+| Independently valid | yes |
+
+Machine-readable derived data: [`analysis.json`](analysis.json).
+
+## Device context
+
+| Field | Value |
+| --- | --- |
+| Platform | Linux-5.15.185-tegra-aarch64-with-glibc2.35 |
+| Architecture | aarch64 |
+| Python | 3.10.12 |
+| JetPack packages | nvidia-jetpack 6.2.2+b24; nvidia-l4t-core 36.5.0-20260115194252 |
+| Power mode | NV Power Mode: MAXN_SUPER; 2 |
+| `jetson_clocks` snapshot | unavailable |
+
+## Validation Gates
+
+| Gate | Passed |
+| --- | --- |
+| `preflight_passed` | yes |
+| `run_matrix_complete` | yes |
+| `all_run_gates_passed` | yes |
+| `resource_stream_valid` | yes |
+| `resource_sampler_stopped` | yes |
+| `every_run_has_resource_coverage` | yes |
+| `stale_consumed_zero` | yes |
+
+## Responsiveness decomposition
+
+| Seq. | Condition | Service (s) | Ticks | Skipped | Deadline misses | Lateness p99 (ms) | Maximum gap (ms) |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | `r0_idle` | 2.000 | 41 | 0 | 0 | 0.842 | 100.650 |
+| 2 | `r1_inline_sync` | 2.000 | 22 | 19 | 0 | 1.455 | 2001.267 |
+| 3 | `r2_threaded_sync` | 2.000 | 41 | 0 | 0 | 0.377 | 100.226 |
+| 4 | `r3_async` | 2.000 | 41 | 0 | 0 | 0.365 | 100.253 |
+| 5 | `r0_idle` | 5.000 | 71 | 0 | 0 | 1.006 | 100.210 |
+| 6 | `r1_inline_sync` | 5.000 | 22 | 49 | 0 | 1.302 | 5001.142 |
+| 7 | `r2_threaded_sync` | 5.000 | 71 | 0 | 0 | 0.471 | 100.374 |
+| 8 | `r3_async` | 5.000 | 71 | 0 | 0 | 0.365 | 100.260 |
+| 9 | `r0_idle` | 70.000 | 721 | 0 | 0 | 0.381 | 100.276 |
+| 10 | `r1_inline_sync` | 70.000 | 22 | 699 | 0 | 1.310 | 70001.149 |
+| 11 | `r2_threaded_sync` | 70.000 | 721 | 0 | 0 | 0.579 | 101.452 |
+| 12 | `r3_async` | 70.000 | 721 | 0 | 0 | 0.351 | 100.342 |
+| 13 | `r4_stale` | 2.000 | 41 | 0 | 0 | 0.233 | 100.081 |
+| 14 | `r4_overflow` | 2.000 | 41 | 0 | 0 | 0.247 | 100.068 |
+
+The inline condition recorded skipped releases rather than executed ticks that missed their deadline. R2 and R3 both isolate the periodic probe from the slow call; R3 additionally supplies bounded ownership, freshness and cancellation semantics.
+
+## R3 runtime timing
+
+| Service (s) | Queue wait (ms) | Measured service (ms) | Terminal age (ms) | Excess over configured (ms) |
+| ---: | ---: | ---: | ---: | ---: |
+| 2.000 | 0.628 | 2000.106 | 2001.812 | 1.812 |
+| 5.000 | 0.618 | 5000.088 | 5001.336 | 1.336 |
+| 70.000 | 0.608 | 70000.113 | 70001.753 | 1.753 |
+
+## Runtime correctness
+
+| Condition | Service (s) | Submissions | Accepted | Stale consumed | Max pending | Max result | Dispositions |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| `r3_async` | 2.000 | 1 | 1 | 0 | 1 | 1 | consumed=1 |
+| `r3_async` | 5.000 | 1 | 1 | 0 | 1 | 1 | consumed=1 |
+| `r3_async` | 70.000 | 1 | 1 | 0 | 1 | 1 | consumed=1 |
+| `r4_stale` | 2.000 | 1 | 0 | 0 | 1 | 0 | rejected_state=1 |
+| `r4_overflow` | 2.000 | 4 | 1 | 0 | 1 | 1 | consumed=1, dropped_overflow=2, rejected_cancelled=1 |
+
+## Session resources
+
+| Metric | Mean | p95 | Maximum |
+| --- | ---: | ---: | ---: |
+| RAM used (MB) | 3433.157 | 3501.000 | 3555.000 |
+| GR3D usage (%) | 0.450 | 0.000 | 80.000 |
+| Junction temperature (C) | 52.068 | 52.593 | 52.875 |
+| VDD_IN instantaneous power (mW) | 5293.238 | 6348.000 | 7697.000 |
+
+Telemetry coverage: 1660 samples across 341.590 s; mean interval 205.901 ms, p99 interval 207.612 ms, parse errors 0.
+
+## Data-quality observations
+
+- `simulated_workload_only`
+- `fixed_condition_order`
+- `single_repetition`
+- `emc_unavailable`
+- `jetson_clocks_snapshot_unavailable`
+- `unattributed_cpu_activity_detected`
+- EMC coverage: 0/1660 samples; missing values are not interpreted as zero.
+- Resource parse warnings: emc_missing=1660.
+
+### Unattributed CPU activity screen
+
+The screen sums per-core usage percentages and marks sustained intervals at or above 80.0%. It does not identify a process and does not exclude any sample.
+
+| Start offset (s) | End offset (s) | Samples | CPU mean (%) | CPU max (%) | Overlapping runs |
+| ---: | ---: | ---: | ---: | ---: | --- |
+| 36.656 | 46.733 | 50 | 112.780 | 151.000 | 7:r2_threaded_sync, 8:r3_async, 9:r0_idle |
+| 178.943 | 189.444 | 52 | 138.942 | 311.000 | 10:r1_inline_sync, 11:r2_threaded_sync |
+| 195.211 | 202.620 | 37 | 131.108 | 386.000 | 11:r2_threaded_sync |
+| 208.383 | 230.590 | 108 | 202.185 | 547.000 | 11:r2_threaded_sync |
+| 234.090 | 243.338 | 46 | 111.370 | 181.000 | 11:r2_threaded_sync |
+| 243.960 | 246.447 | 11 | 113.545 | 158.000 | 11:r2_threaded_sync |
+| 247.069 | 257.617 | 45 | 97.133 | 152.000 | 11:r2_threaded_sync |
+| 313.191 | 315.041 | 10 | 114.600 | 136.000 | 12:r3_async |
+
+## Interpretation
+
+The pilot shows that an inline slow call creates a control-proxy gap on the same scale as the configured service time. A separate thread is sufficient for timing-domain isolation, while the bounded runtime adds explicit queue, cancellation and freshness behavior.
+
+Resource differences between conditions are not attributed to the runtime because the matrix has one fixed-order repetition and the CPU screen crosses condition boundaries. The simulated adapter also does not exercise a heterogeneous inference workload. A fixed-input VLM slice and a balanced repeated protocol are required before those questions can be tested.

--- a/experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/analysis.json
+++ b/experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/analysis.json
@@ -1,0 +1,1171 @@
+{
+  "analysis_schema_version": "0.1.0",
+  "analysis_kind": "phase1_jetson_simulation_pilot",
+  "session_id": "20260828T121142Z_phase1_jetson_pilot",
+  "source": {
+    "git_commit": "77138f2eb5db73acad24ef1fd61c03ddfbb336bc",
+    "git_branch": "main",
+    "source_archive_sha256": "dd7c33fa0a19b8a709cdfc7eca29a178234b39e842ad756d763d3fd33810697a",
+    "session_artifacts": {
+      "pilot_plan.json": {
+        "size_bytes": 3123,
+        "sha256": "f97b06ca25c546d699b995f41c8fcc4963941dfeb3d611b65800efde03e33604"
+      },
+      "preflight.json": {
+        "size_bytes": 3771,
+        "sha256": "ff907f9142d669a152ebf5d55f3a499be84d48f5e28142b26081af9385b72670"
+      },
+      "resources.jsonl": {
+        "size_bytes": 2172675,
+        "sha256": "0f8d7b626a247be7a471a252f9d928ca657d1de98ef711cd8c1870c613598d5e"
+      },
+      "pilot_summary.json": {
+        "size_bytes": 154960,
+        "sha256": "f25e4491135cb95bb298e79c93fa7a76ca37ed4c4f9059c3cc923b37056e720d"
+      }
+    }
+  },
+  "claim_boundary": {
+    "design_role": "descriptive_pilot",
+    "descriptive_only": true,
+    "inference_claim_permitted": false,
+    "asynchronous_performance_superiority_claim_permitted": false,
+    "hard_real_time_claim_permitted": false,
+    "heterogeneous_inference_claim_permitted": false,
+    "condition_resource_attribution_permitted": false
+  },
+  "analysis_parameters": {
+    "percentile_method": "nearest-rank",
+    "cpu_activity_screen": {
+      "metric": "sum of per-core tegrastats usage percentages",
+      "threshold_pct": 80.0,
+      "minimum_samples": 5,
+      "merge_gap_ms": 500.0,
+      "role": "descriptive contamination screen; no samples excluded"
+    }
+  },
+  "environment": {
+    "platform": "Linux-5.15.185-tegra-aarch64-with-glibc2.35",
+    "machine": "aarch64",
+    "python": "3.10.12",
+    "l4t_release": "# R36 (release), REVISION: 5.0, GCID: 43688277, BOARD: generic, EABI: aarch64, DATE: Fri Jan 16 03:50:45 UTC 2026\n# KERNEL_VARIANT: oot\nTARGET_USERSPACE_LIB_DIR=nvidia\nTARGET_USERSPACE_LIB_DIR_PATH=usr/lib/aarch64-linux-gnu/nvidia",
+    "jetpack_packages": {
+      "available": true,
+      "returncode": 0,
+      "error_code": null,
+      "output": "nvidia-jetpack\t6.2.2+b24\nnvidia-l4t-core\t36.5.0-20260115194252"
+    },
+    "nvpmodel": {
+      "available": true,
+      "returncode": 0,
+      "error_code": null,
+      "output": "NV Power Mode: MAXN_SUPER\n2"
+    },
+    "jetson_clocks": {
+      "available": false,
+      "returncode": 1,
+      "error_code": null,
+      "output": "SOC family:tegra234  Machine:NVIDIA Jetson Orin Nano Engineering Reference Developer Kit Super\nError: Run this script(/usr/bin/jetson_clocks) as a root user"
+    },
+    "motion_disabled": true
+  },
+  "validation": {
+    "session_status": "completed",
+    "session_valid": true,
+    "run_count": 14,
+    "gates": [
+      {
+        "name": "preflight_passed",
+        "passed": true,
+        "observed": true,
+        "requirement": "all Jetson, source-identity and motion-safety checks pass"
+      },
+      {
+        "name": "run_matrix_complete",
+        "passed": true,
+        "observed": {
+          "completed": 14,
+          "planned": 14
+        },
+        "requirement": "every predeclared pilot run completes"
+      },
+      {
+        "name": "all_run_gates_passed",
+        "passed": true,
+        "observed": 0,
+        "requirement": "every individual R0--R4 summary is valid"
+      },
+      {
+        "name": "resource_stream_valid",
+        "passed": true,
+        "observed": [],
+        "requirement": "resource samples are contiguous and have zero parse errors"
+      },
+      {
+        "name": "resource_sampler_stopped",
+        "passed": true,
+        "observed": {
+          "sample_count": 1660,
+          "parse_error_count": 0,
+          "first_sample_monotonic_ns": 699592070629,
+          "last_sample_monotonic_ns": 1041182473403,
+          "process_returncode": -15,
+          "stop_method": "terminated",
+          "reader_joined": true,
+          "reader_error_code": null,
+          "successful": true
+        },
+        "requirement": "tegrastats and its non-daemon reader stop cleanly"
+      },
+      {
+        "name": "every_run_has_resource_coverage",
+        "passed": true,
+        "observed": 0,
+        "requirement": "at least one resource sample falls inside every run interval"
+      },
+      {
+        "name": "stale_consumed_zero",
+        "passed": true,
+        "observed": 0,
+        "requirement": "no stale result is consumed in any pilot condition"
+      }
+    ]
+  },
+  "responsiveness": [
+    {
+      "sequence": 1,
+      "condition": "r0_idle",
+      "role": "responsiveness",
+      "service_time_s": 2.0,
+      "tick_count": 41,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.192019,
+      "start_lateness_p99_ms": 0.841524,
+      "start_lateness_max_ms": 0.841524,
+      "actual_period_p99_ms": 100.649505,
+      "maximum_observed_gap_ms": 100.649505,
+      "run_valid": true
+    },
+    {
+      "sequence": 2,
+      "condition": "r1_inline_sync",
+      "role": "responsiveness",
+      "service_time_s": 2.0,
+      "tick_count": 22,
+      "skipped_releases": 19,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.19088,
+      "start_lateness_p99_ms": 1.454732,
+      "start_lateness_max_ms": 1.454732,
+      "actual_period_p99_ms": 2001.266823,
+      "maximum_observed_gap_ms": 2001.266823,
+      "run_valid": true
+    },
+    {
+      "sequence": 3,
+      "condition": "r2_threaded_sync",
+      "role": "responsiveness",
+      "service_time_s": 2.0,
+      "tick_count": 41,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.179415,
+      "start_lateness_p99_ms": 0.377381,
+      "start_lateness_max_ms": 0.377381,
+      "actual_period_p99_ms": 100.226496,
+      "maximum_observed_gap_ms": 100.226496,
+      "run_valid": true
+    },
+    {
+      "sequence": 4,
+      "condition": "r3_async",
+      "role": "responsiveness",
+      "service_time_s": 2.0,
+      "tick_count": 41,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.289609,
+      "start_lateness_p99_ms": 0.36476,
+      "start_lateness_max_ms": 0.36476,
+      "actual_period_p99_ms": 100.25342,
+      "maximum_observed_gap_ms": 100.25342,
+      "run_valid": true
+    },
+    {
+      "sequence": 5,
+      "condition": "r0_idle",
+      "role": "responsiveness",
+      "service_time_s": 5.0,
+      "tick_count": 71,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.21042,
+      "start_lateness_p99_ms": 1.005758,
+      "start_lateness_max_ms": 1.005758,
+      "actual_period_p99_ms": 100.210366,
+      "maximum_observed_gap_ms": 100.210366,
+      "run_valid": true
+    },
+    {
+      "sequence": 6,
+      "condition": "r1_inline_sync",
+      "role": "responsiveness",
+      "service_time_s": 5.0,
+      "tick_count": 22,
+      "skipped_releases": 49,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.392172,
+      "start_lateness_p99_ms": 1.301904,
+      "start_lateness_max_ms": 1.301904,
+      "actual_period_p99_ms": 5001.141895,
+      "maximum_observed_gap_ms": 5001.141895,
+      "run_valid": true
+    },
+    {
+      "sequence": 7,
+      "condition": "r2_threaded_sync",
+      "role": "responsiveness",
+      "service_time_s": 5.0,
+      "tick_count": 71,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.197382,
+      "start_lateness_p99_ms": 0.471385,
+      "start_lateness_max_ms": 0.471385,
+      "actual_period_p99_ms": 100.374208,
+      "maximum_observed_gap_ms": 100.374208,
+      "run_valid": true
+    },
+    {
+      "sequence": 8,
+      "condition": "r3_async",
+      "role": "responsiveness",
+      "service_time_s": 5.0,
+      "tick_count": 71,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.181042,
+      "start_lateness_p99_ms": 0.365403,
+      "start_lateness_max_ms": 0.365403,
+      "actual_period_p99_ms": 100.26033,
+      "maximum_observed_gap_ms": 100.26033,
+      "run_valid": true
+    },
+    {
+      "sequence": 9,
+      "condition": "r0_idle",
+      "role": "responsiveness",
+      "service_time_s": 70.0,
+      "tick_count": 721,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.205004,
+      "start_lateness_p99_ms": 0.380848,
+      "start_lateness_max_ms": 0.415013,
+      "actual_period_p99_ms": 100.234707,
+      "maximum_observed_gap_ms": 100.275644,
+      "run_valid": true
+    },
+    {
+      "sequence": 10,
+      "condition": "r1_inline_sync",
+      "role": "responsiveness",
+      "service_time_s": 70.0,
+      "tick_count": 22,
+      "skipped_releases": 699,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.216077,
+      "start_lateness_p99_ms": 1.310314,
+      "start_lateness_max_ms": 1.310314,
+      "actual_period_p99_ms": 70001.148761,
+      "maximum_observed_gap_ms": 70001.148761,
+      "run_valid": true
+    },
+    {
+      "sequence": 11,
+      "condition": "r2_threaded_sync",
+      "role": "responsiveness",
+      "service_time_s": 70.0,
+      "tick_count": 721,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.195868,
+      "start_lateness_p99_ms": 0.578537,
+      "start_lateness_max_ms": 1.561679,
+      "actual_period_p99_ms": 100.313913,
+      "maximum_observed_gap_ms": 101.451684,
+      "run_valid": true
+    },
+    {
+      "sequence": 12,
+      "condition": "r3_async",
+      "role": "responsiveness",
+      "service_time_s": 70.0,
+      "tick_count": 721,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.153677,
+      "start_lateness_p99_ms": 0.350548,
+      "start_lateness_max_ms": 0.43965,
+      "actual_period_p99_ms": 100.142719,
+      "maximum_observed_gap_ms": 100.341671,
+      "run_valid": true
+    },
+    {
+      "sequence": 13,
+      "condition": "r4_stale",
+      "role": "correctness",
+      "service_time_s": 2.0,
+      "tick_count": 41,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.161872,
+      "start_lateness_p99_ms": 0.233188,
+      "start_lateness_max_ms": 0.233188,
+      "actual_period_p99_ms": 100.080598,
+      "maximum_observed_gap_ms": 100.080598,
+      "run_valid": true
+    },
+    {
+      "sequence": 14,
+      "condition": "r4_overflow",
+      "role": "correctness",
+      "service_time_s": 2.0,
+      "tick_count": 41,
+      "skipped_releases": 0,
+      "deadline_miss_count": 0,
+      "deadline_miss_rate": 0.0,
+      "start_lateness_p95_ms": 0.160331,
+      "start_lateness_p99_ms": 0.247013,
+      "start_lateness_max_ms": 0.247013,
+      "actual_period_p99_ms": 100.068435,
+      "maximum_observed_gap_ms": 100.068435,
+      "run_valid": true
+    }
+  ],
+  "runtime_overhead": [
+    {
+      "sequence": 4,
+      "service_time_s": 2.0,
+      "queue_wait_ms": 0.628083,
+      "measured_service_time_ms": 2000.106276,
+      "terminal_age_ms": 2001.812184,
+      "terminal_age_excess_over_configured_ms": 1.812184
+    },
+    {
+      "sequence": 8,
+      "service_time_s": 5.0,
+      "queue_wait_ms": 0.61845,
+      "measured_service_time_ms": 5000.087696,
+      "terminal_age_ms": 5001.336467,
+      "terminal_age_excess_over_configured_ms": 1.336467
+    },
+    {
+      "sequence": 12,
+      "service_time_s": 70.0,
+      "queue_wait_ms": 0.607852,
+      "measured_service_time_ms": 70000.11337,
+      "terminal_age_ms": 70001.753082,
+      "terminal_age_excess_over_configured_ms": 1.753082
+    }
+  ],
+  "lifecycle": [
+    {
+      "sequence": 4,
+      "condition": "r3_async",
+      "service_time_s": 2.0,
+      "submission_attempts": 1,
+      "admitted_total": 1,
+      "accepted_result_count": 1,
+      "stale_consumed_count": 0,
+      "max_pending_depth": 1,
+      "max_result_depth": 1,
+      "worker_joined": true,
+      "probe_joined": true,
+      "disposition_counts": {
+        "consumed": 1
+      }
+    },
+    {
+      "sequence": 8,
+      "condition": "r3_async",
+      "service_time_s": 5.0,
+      "submission_attempts": 1,
+      "admitted_total": 1,
+      "accepted_result_count": 1,
+      "stale_consumed_count": 0,
+      "max_pending_depth": 1,
+      "max_result_depth": 1,
+      "worker_joined": true,
+      "probe_joined": true,
+      "disposition_counts": {
+        "consumed": 1
+      }
+    },
+    {
+      "sequence": 12,
+      "condition": "r3_async",
+      "service_time_s": 70.0,
+      "submission_attempts": 1,
+      "admitted_total": 1,
+      "accepted_result_count": 1,
+      "stale_consumed_count": 0,
+      "max_pending_depth": 1,
+      "max_result_depth": 1,
+      "worker_joined": true,
+      "probe_joined": true,
+      "disposition_counts": {
+        "consumed": 1
+      }
+    },
+    {
+      "sequence": 13,
+      "condition": "r4_stale",
+      "service_time_s": 2.0,
+      "submission_attempts": 1,
+      "admitted_total": 1,
+      "accepted_result_count": 0,
+      "stale_consumed_count": 0,
+      "max_pending_depth": 1,
+      "max_result_depth": 0,
+      "worker_joined": true,
+      "probe_joined": true,
+      "disposition_counts": {
+        "rejected_state": 1
+      }
+    },
+    {
+      "sequence": 14,
+      "condition": "r4_overflow",
+      "service_time_s": 2.0,
+      "submission_attempts": 4,
+      "admitted_total": 4,
+      "accepted_result_count": 1,
+      "stale_consumed_count": 0,
+      "max_pending_depth": 1,
+      "max_result_depth": 1,
+      "worker_joined": true,
+      "probe_joined": true,
+      "disposition_counts": {
+        "consumed": 1,
+        "dropped_overflow": 2,
+        "rejected_cancelled": 1
+      }
+    }
+  ],
+  "resources": {
+    "session": {
+      "resource_schema_version": "0.1.0",
+      "sample_count": 1660,
+      "parse_error_count": 0,
+      "parse_warning_count": 1660,
+      "first_sample_monotonic_ns": 699592070629,
+      "last_sample_monotonic_ns": 1041182473403,
+      "sample_span_ns": 341590402774,
+      "sample_interval_ns": {
+        "count": 1659,
+        "min": 200991641.0,
+        "mean": 205901388.04942736,
+        "median": 205787402.0,
+        "p50": 205787402.0,
+        "p95": 206648595.0,
+        "p99": 207611642.0,
+        "max": 210858048.0
+      },
+      "ram_used_mb": {
+        "count": 1660,
+        "min": 3386.0,
+        "mean": 3433.156626506024,
+        "median": 3418.0,
+        "p50": 3418.0,
+        "p95": 3501.0,
+        "p99": 3531.0,
+        "max": 3555.0
+      },
+      "swap_used_mb": {
+        "count": 1660,
+        "min": 0.0,
+        "mean": 0.0,
+        "median": 0.0,
+        "p50": 0.0,
+        "p95": 0.0,
+        "p99": 0.0,
+        "max": 0.0
+      },
+      "cpu_usage_pct": {
+        "0": {
+          "count": 1660,
+          "min": 0.0,
+          "mean": 7.844578313253012,
+          "median": 0.0,
+          "p50": 0.0,
+          "p95": 47.0,
+          "p99": 100.0,
+          "max": 100.0
+        },
+        "1": {
+          "count": 1660,
+          "min": 0.0,
+          "mean": 6.271084337349397,
+          "median": 0.0,
+          "p50": 0.0,
+          "p95": 22.0,
+          "p99": 100.0,
+          "max": 100.0
+        },
+        "2": {
+          "count": 1660,
+          "min": 0.0,
+          "mean": 9.7355421686747,
+          "median": 0.0,
+          "p50": 0.0,
+          "p95": 94.0,
+          "p99": 100.0,
+          "max": 100.0
+        },
+        "3": {
+          "count": 1660,
+          "min": 0.0,
+          "mean": 7.347590361445783,
+          "median": 0.0,
+          "p50": 0.0,
+          "p95": 35.0,
+          "p99": 100.0,
+          "max": 100.0
+        },
+        "4": {
+          "count": 1660,
+          "min": 0.0,
+          "mean": 7.352409638554217,
+          "median": 0.0,
+          "p50": 0.0,
+          "p95": 94.0,
+          "p99": 100.0,
+          "max": 100.0
+        },
+        "5": {
+          "count": 1660,
+          "min": 0.0,
+          "mean": 3.1150602409638553,
+          "median": 0.0,
+          "p50": 0.0,
+          "p95": 14.0,
+          "p99": 90.0,
+          "max": 100.0
+        }
+      },
+      "cpu_frequency_mhz": {
+        "0": {
+          "count": 1660,
+          "min": 729.0,
+          "mean": 889.4012048192772,
+          "median": 729.0,
+          "p50": 729.0,
+          "p95": 1728.0,
+          "p99": 1728.0,
+          "max": 1728.0
+        },
+        "1": {
+          "count": 1660,
+          "min": 729.0,
+          "mean": 888.7993975903614,
+          "median": 729.0,
+          "p50": 729.0,
+          "p95": 1728.0,
+          "p99": 1728.0,
+          "max": 1728.0
+        },
+        "2": {
+          "count": 1660,
+          "min": 729.0,
+          "mean": 889.4475903614458,
+          "median": 729.0,
+          "p50": 729.0,
+          "p95": 1728.0,
+          "p99": 1728.0,
+          "max": 1728.0
+        },
+        "3": {
+          "count": 1660,
+          "min": 729.0,
+          "mean": 889.4475903614458,
+          "median": 729.0,
+          "p50": 729.0,
+          "p95": 1728.0,
+          "p99": 1728.0,
+          "max": 1728.0
+        },
+        "4": {
+          "count": 1660,
+          "min": 729.0,
+          "mean": 797.605421686747,
+          "median": 729.0,
+          "p50": 729.0,
+          "p95": 1728.0,
+          "p99": 1728.0,
+          "max": 1728.0
+        },
+        "5": {
+          "count": 1660,
+          "min": 729.0,
+          "mean": 797.605421686747,
+          "median": 729.0,
+          "p50": 729.0,
+          "p95": 1728.0,
+          "p99": 1728.0,
+          "max": 1728.0
+        }
+      },
+      "gr3d_usage_pct": {
+        "count": 1660,
+        "min": 0.0,
+        "mean": 0.45,
+        "median": 0.0,
+        "p50": 0.0,
+        "p95": 0.0,
+        "p99": 21.0,
+        "max": 80.0
+      },
+      "emc_usage_pct": null,
+      "temperatures_c": {
+        "cpu": {
+          "count": 1660,
+          "min": 50.093,
+          "mean": 50.794921686746996,
+          "median": 50.625,
+          "p50": 50.625,
+          "p95": 51.875,
+          "p99": 52.562,
+          "max": 52.875
+        },
+        "gpu": {
+          "count": 1660,
+          "min": 50.437,
+          "mean": 51.03410783132531,
+          "median": 50.968,
+          "p50": 50.968,
+          "p95": 51.687,
+          "p99": 51.906,
+          "max": 52.093
+        },
+        "soc0": {
+          "count": 1660,
+          "min": 50.968,
+          "mean": 51.458334939759034,
+          "median": 51.406,
+          "p50": 51.406,
+          "p95": 52.031,
+          "p99": 52.156,
+          "max": 52.281
+        },
+        "soc1": {
+          "count": 1660,
+          "min": 51.656,
+          "mean": 52.06659277108433,
+          "median": 52.0,
+          "p50": 52.0,
+          "p95": 52.593,
+          "p99": 52.687,
+          "max": 52.75
+        },
+        "soc2": {
+          "count": 1660,
+          "min": 50.25,
+          "mean": 50.79793132530121,
+          "median": 50.718,
+          "p50": 50.718,
+          "p95": 51.468,
+          "p99": 51.687,
+          "max": 51.875
+        },
+        "tj": {
+          "count": 1660,
+          "min": 51.656,
+          "mean": 52.068229518072286,
+          "median": 52.0,
+          "p50": 52.0,
+          "p95": 52.593,
+          "p99": 52.718,
+          "max": 52.875
+        }
+      },
+      "power_instant_mw": {
+        "VDD_CPU_GPU_CV": {
+          "count": 1660,
+          "min": 515.0,
+          "mean": 724.0246987951807,
+          "median": 554.0,
+          "p50": 554.0,
+          "p95": 1584.0,
+          "p99": 2416.0,
+          "max": 2614.0
+        },
+        "VDD_IN": {
+          "count": 1660,
+          "min": 4999.0,
+          "mean": 5293.237951807229,
+          "median": 5079.0,
+          "p50": 5079.0,
+          "p95": 6348.0,
+          "p99": 7352.0,
+          "max": 7697.0
+        },
+        "VDD_SOC": {
+          "count": 1660,
+          "min": 1426.0,
+          "mean": 1461.4054216867469,
+          "median": 1465.0,
+          "p50": 1465.0,
+          "p95": 1507.0,
+          "p99": 1547.0,
+          "max": 1624.0
+        }
+      },
+      "power_reported_average_mw": {
+        "VDD_CPU_GPU_CV": {
+          "count": 1660,
+          "min": 536.0,
+          "mean": 657.2861445783133,
+          "median": 642.0,
+          "p50": 642.0,
+          "p95": 773.0,
+          "p99": 777.0,
+          "max": 777.0
+        },
+        "VDD_IN": {
+          "count": 1660,
+          "min": 5059.0,
+          "mean": 5209.108433734939,
+          "median": 5189.5,
+          "p50": 5189.0,
+          "p95": 5356.0,
+          "p99": 5360.0,
+          "max": 5361.0
+        },
+        "VDD_SOC": {
+          "count": 1660,
+          "min": 1447.0,
+          "mean": 1456.1036144578313,
+          "median": 1457.0,
+          "p50": 1457.0,
+          "p95": 1462.0,
+          "p99": 1463.0,
+          "max": 1465.0
+        }
+      }
+    },
+    "per_run": [
+      {
+        "sequence": 1,
+        "condition": "r0_idle",
+        "service_time_s": 2.0,
+        "sample_count": 19,
+        "aggregate_cpu_mean_pct": 10.578947,
+        "gr3d_mean_pct": 0.0,
+        "gr3d_p95_pct": 0.0,
+        "gr3d_max_pct": 0.0,
+        "ram_mean_mb": 3388.631579,
+        "ram_max_mb": 3389.0,
+        "tj_mean_c": 51.996421,
+        "tj_max_c": 52.156,
+        "vdd_in_mean_mw": 5072.421053,
+        "vdd_in_p95_mw": 5237.0,
+        "vdd_in_max_mw": 5237.0
+      },
+      {
+        "sequence": 2,
+        "condition": "r1_inline_sync",
+        "service_time_s": 2.0,
+        "sample_count": 20,
+        "aggregate_cpu_mean_pct": 10.35,
+        "gr3d_mean_pct": 1.9,
+        "gr3d_p95_pct": 17.0,
+        "gr3d_max_pct": 21.0,
+        "ram_mean_mb": 3391.4,
+        "ram_max_mb": 3397.0,
+        "tj_mean_c": 51.9606,
+        "tj_max_c": 52.093,
+        "vdd_in_mean_mw": 5060.9,
+        "vdd_in_p95_mw": 5118.0,
+        "vdd_in_max_mw": 5118.0
+      },
+      {
+        "sequence": 3,
+        "condition": "r2_threaded_sync",
+        "service_time_s": 2.0,
+        "sample_count": 19,
+        "aggregate_cpu_mean_pct": 6.999999,
+        "gr3d_mean_pct": 0.0,
+        "gr3d_p95_pct": 0.0,
+        "gr3d_max_pct": 0.0,
+        "ram_mean_mb": 3397.0,
+        "ram_max_mb": 3397.0,
+        "tj_mean_c": 51.922368,
+        "tj_max_c": 52.031,
+        "vdd_in_mean_mw": 5041.105263,
+        "vdd_in_p95_mw": 5079.0,
+        "vdd_in_max_mw": 5079.0
+      },
+      {
+        "sequence": 4,
+        "condition": "r3_async",
+        "service_time_s": 2.0,
+        "sample_count": 19,
+        "aggregate_cpu_mean_pct": 11.157895,
+        "gr3d_mean_pct": 3.0,
+        "gr3d_p95_pct": 29.0,
+        "gr3d_max_pct": 29.0,
+        "ram_mean_mb": 3397.052632,
+        "ram_max_mb": 3398.0,
+        "tj_mean_c": 51.872947,
+        "tj_max_c": 52.031,
+        "vdd_in_mean_mw": 5051.631579,
+        "vdd_in_p95_mw": 5079.0,
+        "vdd_in_max_mw": 5079.0
+      },
+      {
+        "sequence": 5,
+        "condition": "r0_idle",
+        "service_time_s": 5.0,
+        "sample_count": 34,
+        "aggregate_cpu_mean_pct": 14.117647,
+        "gr3d_mean_pct": 0.941176,
+        "gr3d_p95_pct": 9.0,
+        "gr3d_max_pct": 23.0,
+        "ram_mean_mb": 3394.970588,
+        "ram_max_mb": 3398.0,
+        "tj_mean_c": 51.872794,
+        "tj_max_c": 52.031,
+        "vdd_in_mean_mw": 5062.470588,
+        "vdd_in_p95_mw": 5118.0,
+        "vdd_in_max_mw": 5118.0
+      },
+      {
+        "sequence": 6,
+        "condition": "r1_inline_sync",
+        "service_time_s": 5.0,
+        "sample_count": 34,
+        "aggregate_cpu_mean_pct": 18.5,
+        "gr3d_mean_pct": 1.323529,
+        "gr3d_p95_pct": 17.0,
+        "gr3d_max_pct": 22.0,
+        "ram_mean_mb": 3392.970588,
+        "ram_max_mb": 3397.0,
+        "tj_mean_c": 51.874588,
+        "tj_max_c": 52.0,
+        "vdd_in_mean_mw": 5068.235294,
+        "vdd_in_p95_mw": 5118.0,
+        "vdd_in_max_mw": 5158.0
+      },
+      {
+        "sequence": 7,
+        "condition": "r2_threaded_sync",
+        "service_time_s": 5.0,
+        "sample_count": 34,
+        "aggregate_cpu_mean_pct": 28.264706,
+        "gr3d_mean_pct": 1.117647,
+        "gr3d_p95_pct": 17.0,
+        "gr3d_max_pct": 21.0,
+        "ram_mean_mb": 3396.529412,
+        "ram_max_mb": 3421.0,
+        "tj_mean_c": 51.901294,
+        "tj_max_c": 52.062,
+        "vdd_in_mean_mw": 5166.294118,
+        "vdd_in_p95_mw": 5872.0,
+        "vdd_in_max_mw": 5952.0
+      },
+      {
+        "sequence": 8,
+        "condition": "r3_async",
+        "service_time_s": 5.0,
+        "sample_count": 34,
+        "aggregate_cpu_mean_pct": 113.205882,
+        "gr3d_mean_pct": 0.264706,
+        "gr3d_p95_pct": 0.0,
+        "gr3d_max_pct": 9.0,
+        "ram_mean_mb": 3436.264706,
+        "ram_max_mb": 3442.0,
+        "tj_mean_c": 51.990471,
+        "tj_max_c": 52.187,
+        "vdd_in_mean_mw": 5955.088235,
+        "vdd_in_p95_mw": 6071.0,
+        "vdd_in_max_mw": 6110.0
+      },
+      {
+        "sequence": 9,
+        "condition": "r0_idle",
+        "service_time_s": 70.0,
+        "sample_count": 350,
+        "aggregate_cpu_mean_pct": 14.248571,
+        "gr3d_mean_pct": 0.088571,
+        "gr3d_p95_pct": 0.0,
+        "gr3d_max_pct": 22.0,
+        "ram_mean_mb": 3396.36,
+        "ram_max_mb": 3442.0,
+        "tj_mean_c": 51.936671,
+        "tj_max_c": 52.218,
+        "vdd_in_mean_mw": 5079.285714,
+        "vdd_in_p95_mw": 5118.0,
+        "vdd_in_max_mw": 5952.0
+      },
+      {
+        "sequence": 10,
+        "condition": "r1_inline_sync",
+        "service_time_s": 70.0,
+        "sample_count": 350,
+        "aggregate_cpu_mean_pct": 28.902858,
+        "gr3d_mean_pct": 0.0,
+        "gr3d_p95_pct": 0.0,
+        "gr3d_max_pct": 0.0,
+        "ram_mean_mb": 3406.405714,
+        "ram_max_mb": 3500.0,
+        "tj_mean_c": 51.814537,
+        "tj_max_c": 52.062,
+        "vdd_in_mean_mw": 5205.222857,
+        "vdd_in_p95_mw": 6309.0,
+        "vdd_in_max_mw": 6705.0
+      },
+      {
+        "sequence": 11,
+        "condition": "r2_threaded_sync",
+        "service_time_s": 70.0,
+        "sample_count": 350,
+        "aggregate_cpu_mean_pct": 115.699999,
+        "gr3d_mean_pct": 1.368571,
+        "gr3d_p95_pct": 4.0,
+        "gr3d_max_pct": 80.0,
+        "ram_mean_mb": 3473.425714,
+        "ram_max_mb": 3555.0,
+        "tj_mean_c": 52.379009,
+        "tj_max_c": 52.875,
+        "vdd_in_mean_mw": 5865.377143,
+        "vdd_in_p95_mw": 7352.0,
+        "vdd_in_max_mw": 7697.0
+      },
+      {
+        "sequence": 12,
+        "condition": "r3_async",
+        "service_time_s": 70.0,
+        "sample_count": 349,
+        "aggregate_cpu_mean_pct": 17.696275,
+        "gr3d_mean_pct": 0.051576,
+        "gr3d_p95_pct": 0.0,
+        "gr3d_max_pct": 18.0,
+        "ram_mean_mb": 3470.412607,
+        "ram_max_mb": 3483.0,
+        "tj_mean_c": 52.239338,
+        "tj_max_c": 52.625,
+        "vdd_in_mean_mw": 5096.530086,
+        "vdd_in_p95_mw": 5198.0,
+        "vdd_in_max_mw": 6190.0
+      },
+      {
+        "sequence": 13,
+        "condition": "r4_stale",
+        "service_time_s": 2.0,
+        "sample_count": 19,
+        "aggregate_cpu_mean_pct": 11.052631,
+        "gr3d_mean_pct": 0.0,
+        "gr3d_p95_pct": 0.0,
+        "gr3d_max_pct": 0.0,
+        "ram_mean_mb": 3482.0,
+        "ram_max_mb": 3482.0,
+        "tj_mean_c": 52.040842,
+        "tj_max_c": 52.156,
+        "vdd_in_mean_mw": 5080.894737,
+        "vdd_in_p95_mw": 5237.0,
+        "vdd_in_max_mw": 5237.0
+      },
+      {
+        "sequence": 14,
+        "condition": "r4_overflow",
+        "service_time_s": 2.0,
+        "sample_count": 20,
+        "aggregate_cpu_mean_pct": 9.65,
+        "gr3d_mean_pct": 0.0,
+        "gr3d_p95_pct": 0.0,
+        "gr3d_max_pct": 0.0,
+        "ram_mean_mb": 3483.0,
+        "ram_max_mb": 3483.0,
+        "tj_mean_c": 52.034,
+        "tj_max_c": 52.156,
+        "vdd_in_mean_mw": 5039.0,
+        "vdd_in_p95_mw": 5079.0,
+        "vdd_in_max_mw": 5079.0
+      }
+    ],
+    "capabilities": {
+      "sample_count": 1660,
+      "emc": {
+        "available_sample_count": 0,
+        "missing_sample_count": 1660,
+        "coverage_rate": 0.0
+      },
+      "parse_warning_counts": {
+        "emc_missing": 1660
+      },
+      "parse_error_counts": {}
+    }
+  },
+  "data_quality": {
+    "unattributed_cpu_activity": [
+      {
+        "start_offset_s": 36.655912,
+        "end_offset_s": 46.732906,
+        "duration_s": 10.076995,
+        "sample_count": 50,
+        "aggregate_cpu_mean_pct": 112.78,
+        "aggregate_cpu_max_pct": 151.0,
+        "overlapping_runs": [
+          {
+            "sequence": 7,
+            "condition": "r2_threaded_sync",
+            "service_time_s": 5.0
+          },
+          {
+            "sequence": 8,
+            "condition": "r3_async",
+            "service_time_s": 5.0
+          },
+          {
+            "sequence": 9,
+            "condition": "r0_idle",
+            "service_time_s": 70.0
+          }
+        ]
+      },
+      {
+        "start_offset_s": 178.942758,
+        "end_offset_s": 189.444077,
+        "duration_s": 10.501319,
+        "sample_count": 52,
+        "aggregate_cpu_mean_pct": 138.942308,
+        "aggregate_cpu_max_pct": 311.0,
+        "overlapping_runs": [
+          {
+            "sequence": 10,
+            "condition": "r1_inline_sync",
+            "service_time_s": 70.0
+          },
+          {
+            "sequence": 11,
+            "condition": "r2_threaded_sync",
+            "service_time_s": 70.0
+          }
+        ]
+      },
+      {
+        "start_offset_s": 195.211245,
+        "end_offset_s": 202.619577,
+        "duration_s": 7.408332,
+        "sample_count": 37,
+        "aggregate_cpu_mean_pct": 131.108108,
+        "aggregate_cpu_max_pct": 386.0,
+        "overlapping_runs": [
+          {
+            "sequence": 11,
+            "condition": "r2_threaded_sync",
+            "service_time_s": 70.0
+          }
+        ]
+      },
+      {
+        "start_offset_s": 208.383002,
+        "end_offset_s": 230.589622,
+        "duration_s": 22.20662,
+        "sample_count": 108,
+        "aggregate_cpu_mean_pct": 202.185185,
+        "aggregate_cpu_max_pct": 547.0,
+        "overlapping_runs": [
+          {
+            "sequence": 11,
+            "condition": "r2_threaded_sync",
+            "service_time_s": 70.0
+          }
+        ]
+      },
+      {
+        "start_offset_s": 234.089738,
+        "end_offset_s": 243.337975,
+        "duration_s": 9.248237,
+        "sample_count": 46,
+        "aggregate_cpu_mean_pct": 111.369565,
+        "aggregate_cpu_max_pct": 181.0,
+        "overlapping_runs": [
+          {
+            "sequence": 11,
+            "condition": "r2_threaded_sync",
+            "service_time_s": 70.0
+          }
+        ]
+      },
+      {
+        "start_offset_s": 243.959996,
+        "end_offset_s": 246.446917,
+        "duration_s": 2.486921,
+        "sample_count": 11,
+        "aggregate_cpu_mean_pct": 113.545455,
+        "aggregate_cpu_max_pct": 158.0,
+        "overlapping_runs": [
+          {
+            "sequence": 11,
+            "condition": "r2_threaded_sync",
+            "service_time_s": 70.0
+          }
+        ]
+      },
+      {
+        "start_offset_s": 247.068807,
+        "end_offset_s": 257.616888,
+        "duration_s": 10.548081,
+        "sample_count": 45,
+        "aggregate_cpu_mean_pct": 97.133333,
+        "aggregate_cpu_max_pct": 152.0,
+        "overlapping_runs": [
+          {
+            "sequence": 11,
+            "condition": "r2_threaded_sync",
+            "service_time_s": 70.0
+          }
+        ]
+      },
+      {
+        "start_offset_s": 313.19138,
+        "end_offset_s": 315.040632,
+        "duration_s": 1.849252,
+        "sample_count": 10,
+        "aggregate_cpu_mean_pct": 114.6,
+        "aggregate_cpu_max_pct": 136.0,
+        "overlapping_runs": [
+          {
+            "sequence": 12,
+            "condition": "r3_async",
+            "service_time_s": 70.0
+          }
+        ]
+      }
+    ],
+    "limitations": [
+      "simulated_workload_only",
+      "fixed_condition_order",
+      "single_repetition",
+      "emc_unavailable",
+      "jetson_clocks_snapshot_unavailable",
+      "unattributed_cpu_activity_detected"
+    ]
+  }
+}

--- a/experiments/phase1/run_vlm_slice.py
+++ b/experiments/phase1/run_vlm_slice.py
@@ -1,0 +1,376 @@
+"""Run one fixed-input, motion-disabled Phase 1 VLM condition on Jetson."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from experiments.phase1.jetson_telemetry import (
+    TegrastatsSampler,
+    load_resource_samples,
+)
+from experiments.phase1.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    collect_environment,
+    require_motion_disabled,
+    sha256_file,
+    utc_now_iso,
+    write_json_atomic,
+)
+from experiments.phase1.summarize_vlm_slice import build_vlm_summary
+from experiments.phase1.telemetry import EventRecorder, SCHEMA_VERSION
+from experiments.phase1.vlm_adapter import FixedInputVLMAdapter, fixed_c100_payload
+from experiments.phase1.vlm_preflight import (
+    build_vlm_preflight,
+    vlm_preflight_errors,
+)
+from experiments.phase1.vlm_slice import (
+    VLMSliceCondition,
+    VLMSliceSpec,
+    run_vlm_slice,
+)
+
+
+DEFAULT_INPUT = (
+    Path(__file__).resolve().parents[1]
+    / "raw"
+    / "phase0-inputs"
+    / "vlm"
+    / "c100-camera-product.jpg"
+)
+DEFAULT_OUTPUT_ROOT = Path(__file__).resolve().parents[1] / "runs" / "phase1-vlm-slice"
+_SESSION_ID_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z_phase1_vlm_[a-z][a-z0-9_-]{0,31}$")
+
+
+class VLMRunError(RuntimeError):
+    """The real-workload run could not produce valid closed evidence."""
+
+
+def make_vlm_run_id(
+    condition: VLMSliceCondition,
+    repetition: int,
+    *,
+    now: datetime | None = None,
+) -> str:
+    if not isinstance(condition, VLMSliceCondition):
+        raise TypeError("condition must be a VLMSliceCondition")
+    if (
+        isinstance(repetition, bool)
+        or not isinstance(repetition, int)
+        or not 0 <= repetition <= 999
+    ):
+        raise ValueError("repetition must be an integer from 0 to 999")
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    stamp = current.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}_phase1_{condition.value}_vlm_{repetition:03d}"
+
+
+def make_vlm_session_id(now: datetime | None = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    stamp = current.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}_phase1_vlm_slice"
+
+
+def _validate_session_id(value: str) -> str:
+    if not isinstance(value, str) or not _SESSION_ID_RE.fullmatch(value):
+        raise ValueError(
+            "session_id must use YYYYMMDDTHHMMSSZ_phase1_vlm_<lowercase-label>"
+        )
+    return value
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_output_root(output_root: Path, repo_root: Path) -> Path:
+    expanded = output_root.expanduser()
+    resolved = (expanded if expanded.is_absolute() else repo_root / expanded).resolve()
+    phase0_source = (repo_root / "experiments" / "phase0").resolve()
+    if _is_relative_to(resolved, phase0_source):
+        raise VLMRunError("Phase 1 VLM output must not be inside experiments/phase0")
+    if _is_relative_to(resolved, repo_root):
+        ignored_root = (repo_root / "experiments" / "runs").resolve()
+        if not _is_relative_to(resolved, ignored_root):
+            raise VLMRunError(
+                "repository-local VLM output must be inside experiments/runs"
+            )
+    return resolved
+
+
+def _artifact_identity(path: Path) -> dict[str, object]:
+    return {
+        "size_bytes": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
+
+
+def _reproducibility(
+    environment: dict[str, object],
+    *,
+    injected_components: list[str],
+) -> dict[str, object]:
+    git = environment.get("git")
+    record = git if isinstance(git, dict) else {}
+    identity_complete = (
+        not record.get("error_codes")
+        and bool(record.get("commit"))
+        and bool(record.get("branch"))
+    )
+    git_clean = identity_complete and record.get("dirty") is False
+    synchronized_main = (
+        git_clean
+        and record.get("branch") == "main"
+        and record.get("upstream") == "origin/main"
+        and record.get("upstream_commit") == record.get("commit")
+        and str(record.get("ahead_behind", "")).split() == ["0", "0"]
+    )
+    return {
+        "git_identity_complete": identity_complete,
+        "git_clean": git_clean,
+        "synchronized_main": synchronized_main,
+        "development_injection": bool(injected_components),
+        "injected_components": injected_components,
+        "formal_evidence_eligible": False,
+    }
+
+
+def run_once(
+    args: argparse.Namespace,
+    *,
+    repo_root: Path | str | None = None,
+    preflight_builder: Callable[..., dict[str, object]] | None = None,
+    sampler_factory: Callable[..., TegrastatsSampler] | None = None,
+    adapter_factory: Callable[[], FixedInputVLMAdapter] | None = None,
+) -> Path:
+    """Execute one preflighted VLM request and independently validate it."""
+
+    root = (
+        Path(repo_root).resolve()
+        if repo_root is not None
+        else Path(__file__).resolve().parents[2]
+    )
+    condition = VLMSliceCondition(args.condition)
+    session_id = _validate_session_id(args.session_id or make_vlm_session_id())
+    injected_components = [
+        name
+        for name, value in (
+            ("preflight_builder", preflight_builder),
+            ("sampler_factory", sampler_factory),
+            ("adapter_factory", adapter_factory),
+        )
+        if value is not None
+    ]
+    resolved_preflight_builder = preflight_builder or build_vlm_preflight
+    resolved_sampler_factory = sampler_factory or TegrastatsSampler
+    resolved_adapter_factory = adapter_factory or FixedInputVLMAdapter
+    safety = require_motion_disabled()
+    payload = fixed_c100_payload(args.input)
+    preflight = resolved_preflight_builder(
+        root,
+        input_payload=payload,
+        expected_branch="main",
+    )
+    failed_checks = vlm_preflight_errors(preflight)
+    if failed_checks:
+        raise VLMRunError("VLM preflight failed: " + "; ".join(failed_checks))
+
+    output_root = _resolve_output_root(Path(args.output_root), root)
+    run_id = make_vlm_run_id(condition, args.repetition)
+    run_dir = output_root / session_id / condition.value / run_id
+    if run_dir.exists():
+        raise FileExistsError(f"refusing to overwrite VLM run: {run_dir}")
+    run_dir.mkdir(parents=True)
+    preflight_path = run_dir / "preflight.json"
+    manifest_path = run_dir / "manifest.json"
+    write_json_atomic(preflight_path, preflight)
+
+    spec = VLMSliceSpec(
+        condition=condition,
+        result_validity_s=args.result_validity_s,
+        completion_timeout_s=args.completion_timeout_s,
+        join_timeout_s=args.join_timeout_s,
+        probe_join_timeout_s=args.probe_join_timeout_s,
+        prelude_s=args.prelude_s,
+        postlude_s=args.postlude_s,
+        probe_period_ns=int(args.probe_period_ms * 1_000_000),
+        probe_deadline_ns=int(args.probe_deadline_ms * 1_000_000),
+    )
+    environment = collect_environment(root)
+    manifest: dict[str, object] = {
+        "manifest_schema_version": MANIFEST_SCHEMA_VERSION,
+        "event_schema_version": SCHEMA_VERSION,
+        "artifact_kind": "phase1_fixed_input_vlm_run",
+        "run_id": run_id,
+        "session_id": session_id,
+        "condition": condition.value,
+        "trace_profile": "runtime_threaded_probe",
+        "status": "running",
+        "created_at": utc_now_iso(),
+        "completed_at": None,
+        "descriptive_only": True,
+        "formal_performance_claim_permitted": False,
+        "heterogeneous_inference_claim_permitted": False,
+        "safety": safety,
+        "environment": environment,
+        "reproducibility": _reproducibility(
+            environment,
+            injected_components=injected_components,
+        ),
+        "input": {
+            "sha256": payload.sha256,
+            "size_bytes": payload.size_bytes,
+            "media_type": payload.media_type,
+            "path_recorded": False,
+        },
+        "workload_contract": {
+            "source": "jetson.vision_vlm",
+            "moondream": {
+                "temperature": 0.1,
+                "num_predict": 100,
+                "request_timeout_s": 180,
+            },
+            "qwen_rewrite": {
+                "temperature": 0.2,
+                "max_tokens": 96,
+                "request_timeout_s": 30,
+            },
+            "translation_fallback": "argos_en_zh",
+            "unload_after_request": True,
+            "unload_confirmation": "not_available",
+            "raw_output_recorded": False,
+        },
+        "spec": spec.to_dict(),
+        "resource_interval_ms": args.resource_interval_ms,
+        "resource_sampler_report": None,
+        "artifacts": {},
+        "failure_code": None,
+        "cleanup_error_code": None,
+    }
+    write_json_atomic(manifest_path, manifest)
+
+    sampler: TegrastatsSampler | None = None
+    recorder: EventRecorder | None = None
+    try:
+        sampler = resolved_sampler_factory(run_dir, args.resource_interval_ms)
+        sampler.start(first_sample_timeout_s=args.resource_first_sample_timeout_s)
+        recorder = EventRecorder(run_dir, run_id)
+        report = run_vlm_slice(
+            spec,
+            payload,
+            recorder,
+            adapter=resolved_adapter_factory(),
+        )
+        recorder.close()
+        recorder = None
+        sampler_report = sampler.stop()
+        manifest["resource_sampler_report"] = sampler_report.to_dict()
+        if not sampler_report.successful:
+            raise VLMRunError("tegrastats did not produce a valid closed trace")
+
+        scenario = {"spec": spec.to_dict(), "report": report.to_dict()}
+        scenario_path = run_dir / "scenario.json"
+        write_json_atomic(scenario_path, scenario)
+        samples = load_resource_samples(run_dir / "resources.jsonl")
+        summary = build_vlm_summary(
+            run_dir / "events.jsonl",
+            condition=condition,
+            spec=spec.to_dict(),
+            report=report.to_dict(),
+            resource_samples=samples,
+            sampler_report=sampler_report.to_dict(),
+            development_injection=bool(injected_components),
+        )
+        summary_path = run_dir / "summary.json"
+        write_json_atomic(summary_path, summary)
+        if summary.get("valid") is not True:
+            raise VLMRunError("one or more VLM slice Gates failed")
+
+        manifest["artifacts"] = {
+            name: _artifact_identity(run_dir / name)
+            for name in (
+                "preflight.json",
+                "events.jsonl",
+                "resources.jsonl",
+                "scenario.json",
+                "summary.json",
+            )
+        }
+        manifest["status"] = "completed"
+        manifest["completed_at"] = utc_now_iso()
+        write_json_atomic(manifest_path, manifest)
+
+        from experiments.phase1.validate_vlm_slice import validate_vlm_slice_dir
+
+        validation_errors = validate_vlm_slice_dir(run_dir)
+        if validation_errors:
+            raise VLMRunError(
+                "final VLM validation failed: " + "; ".join(validation_errors)
+            )
+    except Exception as exc:
+        if recorder is not None:
+            recorder.close()
+        if sampler is not None and sampler.is_running:
+            try:
+                sampler.stop()
+            except Exception as cleanup_exc:
+                manifest["cleanup_error_code"] = type(cleanup_exc).__name__.lower()
+        if sampler is not None and sampler.stop_report is not None:
+            manifest["resource_sampler_report"] = sampler.stop_report.to_dict()
+        manifest["status"] = "failed"
+        manifest["completed_at"] = utc_now_iso()
+        manifest["failure_code"] = type(exc).__name__.lower()
+        write_json_atomic(manifest_path, manifest)
+        raise
+    return run_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--condition",
+        choices=[condition.value for condition in VLMSliceCondition],
+        required=True,
+    )
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--session-id")
+    parser.add_argument("--repetition", type=int, default=1)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--result-validity-s", type=float, default=900.0)
+    parser.add_argument("--completion-timeout-s", type=float, default=720.0)
+    parser.add_argument("--join-timeout-s", type=float, default=720.0)
+    parser.add_argument("--probe-join-timeout-s", type=float, default=5.0)
+    parser.add_argument("--prelude-s", type=float, default=1.0)
+    parser.add_argument("--postlude-s", type=float, default=1.0)
+    parser.add_argument("--probe-period-ms", type=float, default=100.0)
+    parser.add_argument("--probe-deadline-ms", type=float, default=100.0)
+    parser.add_argument("--resource-interval-ms", type=int, default=200)
+    parser.add_argument("--resource-first-sample-timeout-s", type=float, default=5.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        run_dir = run_once(args)
+    except Exception as exc:
+        print(f"Phase 1 VLM run failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    print(run_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/phase1/summarize_vlm_slice.py
+++ b/experiments/phase1/summarize_vlm_slice.py
@@ -1,0 +1,295 @@
+"""Independent summary construction for one fixed-input VLM slice run."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from experiments.phase1.jetson_telemetry import summarize_resource_samples
+from experiments.phase1.replay_lifecycle import TraceProfile, replay_file
+from experiments.phase1.vlm_adapter import (
+    C100_INPUT_SHA256,
+    C100_INPUT_SIZE_BYTES,
+)
+from experiments.phase1.vlm_slice import VLMSliceCondition
+
+
+VLM_SUMMARY_SCHEMA_VERSION = "0.1.0"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _gate(
+    name: str,
+    passed: bool,
+    *,
+    observed: object,
+    requirement: str,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "passed": passed,
+        "observed": observed,
+        "requirement": requirement,
+    }
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def build_vlm_summary(
+    event_path: Path | str,
+    *,
+    condition: VLMSliceCondition,
+    spec: Mapping[str, object],
+    report: Mapping[str, object],
+    resource_samples: Sequence[dict[str, object]],
+    sampler_report: Mapping[str, object],
+    development_injection: bool = False,
+) -> dict[str, object]:
+    """Rebuild lifecycle, adapter and resource Gates from serialized facts."""
+
+    if not isinstance(condition, VLMSliceCondition):
+        raise TypeError("condition must be a VLMSliceCondition")
+    if not isinstance(development_injection, bool):
+        raise TypeError("development_injection must be boolean")
+    replay = replay_file(
+        event_path,
+        profile=TraceProfile.RUNTIME_THREADED_PROBE,
+    )
+    lifecycle = asdict(replay)
+    disposition_counts = dict(replay.disposition_counts)
+    adapter = _mapping(report.get("adapter"))
+    adapter_input = _mapping(adapter.get("input"))
+    adapter_output = _mapping(adapter.get("output"))
+    cancellation = _mapping(adapter.get("cancellation"))
+    model_residency = _mapping(adapter.get("model_residency"))
+    stages = _mapping(adapter.get("stage_status"))
+    stage_durations = _mapping(adapter.get("stage_durations_ns"))
+    shutdown = _mapping(report.get("shutdown"))
+    probe = _mapping(report.get("probe"))
+    final_snapshot = _mapping(report.get("final_snapshot"))
+    resource_summary = summarize_resource_samples(resource_samples)
+
+    fixed_stages_ok = all(
+        stages.get(name) == "ok"
+        for name in (
+            "input_verify_before",
+            "module_import",
+            "moondream_inference",
+            "output_normalization",
+            "model_unload",
+            "input_verify_after",
+        )
+    )
+    route = adapter.get("translation_route")
+    route_ok = (route == "qwen" and stages.get("qwen_rewrite") == "ok") or (
+        route == "argos"
+        and stages.get("qwen_rewrite") == "error"
+        and stages.get("argos_fallback") == "ok"
+    )
+    durations_ok = bool(stage_durations) and all(
+        isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        for value in stage_durations.values()
+    )
+    output_sha256 = adapter_output.get("sha256")
+    output_length = adapter_output.get("length")
+    output_private = (
+        isinstance(output_sha256, str)
+        and _SHA256_RE.fullmatch(output_sha256) is not None
+        and isinstance(output_length, int)
+        and not isinstance(output_length, bool)
+        and output_length > 0
+        and adapter_output.get("raw_text_recorded") is False
+    )
+    resource_times = [sample.get("sample_monotonic_ns") for sample in resource_samples]
+    started_ns = adapter.get("started_monotonic_ns")
+    finished_ns = adapter.get("finished_monotonic_ns")
+    covered_samples = sum(
+        isinstance(value, int)
+        and isinstance(started_ns, int)
+        and isinstance(finished_ns, int)
+        and started_ns <= value <= finished_ns
+        for value in resource_times
+    )
+
+    expected_disposition = (
+        "consumed" if condition is VLMSliceCondition.ASYNC else "rejected_state"
+    )
+    expected_accepted = int(condition is VLMSliceCondition.ASYNC)
+    expected_outcome = (
+        "ok" if condition is VLMSliceCondition.ASYNC else "cancel_observed"
+    )
+    gates = [
+        _gate(
+            "single_request",
+            replay.submission_attempts == 1
+            and replay.admitted_total == 1
+            and replay.terminal_admitted_total == 1,
+            observed={
+                "submission_attempts": replay.submission_attempts,
+                "admitted_total": replay.admitted_total,
+                "terminal_admitted_total": replay.terminal_admitted_total,
+            },
+            requirement="exactly one VLM request is admitted and terminal",
+        ),
+        _gate(
+            "bounded_lane",
+            replay.max_pending_depth <= 1
+            and replay.max_result_depth <= 1
+            and final_snapshot.get("accounting_holds") is True,
+            observed={
+                "max_pending_depth": replay.max_pending_depth,
+                "max_result_depth": replay.max_result_depth,
+                "accounting_holds": final_snapshot.get("accounting_holds"),
+            },
+            requirement="pending and result depths remain at most one",
+        ),
+        _gate(
+            "expected_disposition",
+            disposition_counts == {expected_disposition: 1}
+            and report.get("final_disposition") == expected_disposition
+            and replay.accepted_result_count == expected_accepted
+            and report.get("consumed") is bool(expected_accepted),
+            observed={
+                "disposition_counts": disposition_counts,
+                "accepted_result_count": replay.accepted_result_count,
+                "reported_disposition": report.get("final_disposition"),
+                "reported_consumed": report.get("consumed"),
+            },
+            requirement=(
+                "nominal output is consumed once"
+                if condition is VLMSliceCondition.ASYNC
+                else "old-generation output is rejected before consumption"
+            ),
+        ),
+        _gate(
+            "stale_zero_consumed",
+            replay.stale_consumed_count == 0,
+            observed=replay.stale_consumed_count,
+            requirement="no stale result is consumed",
+        ),
+        _gate(
+            "fixed_input_verified",
+            adapter_input.get("sha256") == C100_INPUT_SHA256
+            and adapter_input.get("size_bytes") == C100_INPUT_SIZE_BYTES
+            and fixed_stages_ok,
+            observed={
+                "sha256": adapter_input.get("sha256"),
+                "size_bytes": adapter_input.get("size_bytes"),
+                "verification_before": stages.get("input_verify_before"),
+                "verification_after": stages.get("input_verify_after"),
+            },
+            requirement="the Phase 0 C100 identity holds before and after inference",
+        ),
+        _gate(
+            "pipeline_completed",
+            adapter.get("execution_outcome") == expected_outcome
+            and fixed_stages_ok
+            and route_ok
+            and durations_ok,
+            observed={
+                "execution_outcome": adapter.get("execution_outcome"),
+                "translation_route": route,
+                "stage_status": dict(stages),
+            },
+            requirement=(
+                "Moondream, translation, normalization and the unload call complete"
+            ),
+        ),
+        _gate(
+            "model_unload_claim_bounded",
+            model_residency.get("unload_requested") is True
+            and model_residency.get("unload_confirmed") is None,
+            observed=dict(model_residency),
+            requirement=(
+                "the unload request returns without claiming confirmed eviction"
+            ),
+        ),
+        _gate(
+            "output_private",
+            output_private,
+            observed={
+                "sha256_present": isinstance(output_sha256, str),
+                "length": output_length,
+                "raw_text_recorded": adapter_output.get("raw_text_recorded"),
+            },
+            requirement="only output hash and length enter public artifacts",
+        ),
+        _gate(
+            "cancellation_claim_bounded",
+            (
+                cancellation.get("requested") is False
+                and cancellation.get("worker_observed") is False
+                if condition is VLMSliceCondition.ASYNC
+                else cancellation.get("requested") is True
+                and cancellation.get("worker_observed") is True
+                and cancellation.get("backend_stop_confirmed") is None
+            ),
+            observed=dict(cancellation),
+            requirement=(
+                "nominal execution has no cancellation request"
+                if condition is VLMSliceCondition.ASYNC
+                else "state invalidation does not claim backend preemption"
+            ),
+        ),
+        _gate(
+            "threads_closed",
+            shutdown.get("complete") is True
+            and shutdown.get("joined") is True
+            and probe.get("joined") is True
+            and probe.get("error_code") is None,
+            observed={
+                "shutdown_complete": shutdown.get("complete"),
+                "worker_joined": shutdown.get("joined"),
+                "probe_joined": probe.get("joined"),
+                "probe_error_code": probe.get("error_code"),
+            },
+            requirement="worker and periodic probe terminate within their budgets",
+        ),
+        _gate(
+            "resource_trace_valid",
+            sampler_report.get("successful") is True
+            and sampler_report.get("sample_count") == len(resource_samples)
+            and covered_samples > 0,
+            observed={
+                "sampler_successful": sampler_report.get("successful"),
+                "sample_count": len(resource_samples),
+                "inference_interval_samples": covered_samples,
+            },
+            requirement="valid resource samples cover the VLM execution interval",
+        ),
+    ]
+    return {
+        "vlm_summary_schema_version": VLM_SUMMARY_SCHEMA_VERSION,
+        "run_id": replay.run_id,
+        "condition": condition.value,
+        "trace_profile": TraceProfile.RUNTIME_THREADED_PROBE.value,
+        "descriptive_only": True,
+        "development_injection": development_injection,
+        "real_vlm_path_executed": all(
+            gate["passed"] is True
+            for gate in gates
+            if gate["name"]
+            in {
+                "fixed_input_verified",
+                "pipeline_completed",
+                "output_private",
+            }
+        )
+        and not development_injection,
+        "formal_performance_claim_permitted": False,
+        "heterogeneous_inference_claim_permitted": False,
+        "lifecycle": lifecycle,
+        "spec": dict(spec),
+        "adapter": dict(adapter),
+        "resources": {
+            "sampler_report": dict(sampler_report),
+            "inference_interval_sample_count": covered_samples,
+            "summary": resource_summary,
+        },
+        "gates": gates,
+        "valid": all(gate["passed"] is True for gate in gates),
+    }

--- a/experiments/phase1/tests/test_jetson_pilot_analysis.py
+++ b/experiments/phase1/tests/test_jetson_pilot_analysis.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from experiments.phase1.analyze_jetson_pilot import (
+    _detect_cpu_activity,
+    analyze_pilot_dir,
+    main,
+    render_markdown,
+)
+from experiments.phase1.jetson_telemetry import TegrastatsSampler
+from experiments.phase1.run_jetson_pilot import run_pilot_session
+from experiments.phase1.tests.test_jetson_pilot import (
+    REPO_ROOT,
+    clean_environment,
+    passing_preflight,
+    pilot_args,
+)
+from experiments.phase1.tests.test_jetson_telemetry import (
+    TEGRASTATS_SAMPLE,
+    sampler_command,
+)
+
+
+ARCHIVE_SHA256 = "b" * 64
+
+
+def make_session(output_root: Path, line: str = TEGRASTATS_SAMPLE) -> Path:
+    def sampler_factory(session_dir: Path, interval_ms: int):
+        return TegrastatsSampler(
+            session_dir,
+            interval_ms,
+            command=sampler_command(line),
+        )
+
+    with patch(
+        "experiments.phase1.run_simulation.collect_environment",
+        return_value=clean_environment(),
+    ):
+        return run_pilot_session(
+            pilot_args(output_root),
+            repo_root=REPO_ROOT,
+            preflight_builder=lambda *args, **kwargs: passing_preflight(),
+            sampler_factory=sampler_factory,
+        )
+
+
+class JetsonPilotAnalysisTests(unittest.TestCase):
+    def test_analysis_preserves_claim_boundary_and_runtime_facts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session_dir = make_session(Path(temp_dir))
+            analysis = analyze_pilot_dir(
+                session_dir,
+                source_archive_sha256=ARCHIVE_SHA256,
+            )
+
+        self.assertEqual(analysis["analysis_schema_version"], "0.1.0")
+        self.assertEqual(analysis["source"]["source_archive_sha256"], ARCHIVE_SHA256)
+        self.assertTrue(analysis["validation"]["session_valid"])
+        self.assertEqual(analysis["validation"]["run_count"], 6)
+        self.assertFalse(analysis["claim_boundary"]["inference_claim_permitted"])
+        self.assertFalse(
+            analysis["claim_boundary"]["condition_resource_attribution_permitted"]
+        )
+        self.assertEqual(len(analysis["responsiveness"]), 6)
+        self.assertGreater(
+            next(
+                row
+                for row in analysis["responsiveness"]
+                if row["condition"] == "r1_inline_sync"
+            )["skipped_releases"],
+            0,
+        )
+        self.assertEqual(len(analysis["runtime_overhead"]), 1)
+        lifecycle = {row["condition"]: row for row in analysis["lifecycle"]}
+        self.assertEqual(
+            lifecycle["r4_stale"]["disposition_counts"],
+            {"rejected_state": 1},
+        )
+        self.assertEqual(
+            lifecycle["r4_overflow"]["disposition_counts"],
+            {
+                "consumed": 1,
+                "dropped_overflow": 2,
+                "rejected_cancelled": 1,
+            },
+        )
+        self.assertIn(
+            "simulated_workload_only", analysis["data_quality"]["limitations"]
+        )
+
+    def test_missing_emc_is_reported_as_unavailable_not_zero(self) -> None:
+        sample_without_emc = TEGRASTATS_SAMPLE.replace("EMC_FREQ 2%@2133 ", "")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session_dir = make_session(Path(temp_dir), sample_without_emc)
+            analysis = analyze_pilot_dir(session_dir)
+
+        capabilities = analysis["resources"]["capabilities"]
+        self.assertEqual(capabilities["emc"]["available_sample_count"], 0)
+        self.assertEqual(
+            capabilities["emc"]["missing_sample_count"],
+            capabilities["sample_count"],
+        )
+        self.assertEqual(
+            capabilities["parse_warning_counts"],
+            {"emc_missing": capabilities["sample_count"]},
+        )
+        self.assertIn("emc_unavailable", analysis["data_quality"]["limitations"])
+
+    def test_activity_screen_groups_sustained_samples_and_maps_runs(self) -> None:
+        samples = []
+        for sequence, usage in enumerate((10, 80, 90, 100, 95, 85, 10)):
+            samples.append(
+                {
+                    "sample_monotonic_ns": sequence * 200_000_000,
+                    "cpu": [{"usage_pct": usage}],
+                }
+            )
+        runs = [
+            {
+                "sequence": 1,
+                "condition": "r2_threaded_sync",
+                "service_time_s": 2.0,
+                "started_monotonic_ns": 0,
+                "finished_monotonic_ns": 700_000_000,
+            },
+            {
+                "sequence": 2,
+                "condition": "r3_async",
+                "service_time_s": 2.0,
+                "started_monotonic_ns": 700_000_001,
+                "finished_monotonic_ns": 1_400_000_000,
+            },
+        ]
+
+        episodes = _detect_cpu_activity(
+            samples,
+            runs,
+            threshold_pct=80.0,
+            minimum_samples=5,
+            merge_gap_ms=500.0,
+        )
+
+        self.assertEqual(len(episodes), 1)
+        self.assertEqual(episodes[0]["sample_count"], 5)
+        self.assertEqual(episodes[0]["aggregate_cpu_max_pct"], 100.0)
+        self.assertEqual(
+            [row["condition"] for row in episodes[0]["overlapping_runs"]],
+            ["r2_threaded_sync", "r3_async"],
+        )
+
+    def test_cli_writes_deterministic_outputs_outside_the_session(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            session_dir = make_session(root / "runs")
+            json_path = root / "published" / "analysis.json"
+            markdown_path = root / "published" / "report.md"
+
+            result = main(
+                [
+                    str(session_dir),
+                    "--source-archive-sha256",
+                    ARCHIVE_SHA256,
+                    "--json-output",
+                    str(json_path),
+                    "--markdown-output",
+                    str(markdown_path),
+                ]
+            )
+            first_json = json_path.read_text(encoding="utf-8")
+            first_markdown = markdown_path.read_text(encoding="utf-8")
+            result_again = main(
+                [
+                    str(session_dir),
+                    "--source-archive-sha256",
+                    ARCHIVE_SHA256,
+                    "--json-output",
+                    str(json_path),
+                    "--markdown-output",
+                    str(markdown_path),
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            self.assertEqual(result_again, 0)
+            self.assertEqual(first_json, json_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                first_markdown,
+                markdown_path.read_text(encoding="utf-8"),
+            )
+            self.assertNotIn(str(session_dir), first_json)
+            self.assertIn("# Phase 1 Jetson Simulation Pilot", first_markdown)
+            self.assertFalse(list(root.rglob("*.tmp")))
+
+    def test_analysis_rejects_bad_archive_hash_and_session_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            session_dir = make_session(root)
+            with self.assertRaisesRegex(ValueError, "64 hexadecimal"):
+                analyze_pilot_dir(
+                    session_dir,
+                    source_archive_sha256="not-a-digest",
+                )
+            stderr = StringIO()
+            with redirect_stderr(stderr):
+                result = main(
+                    [
+                        str(session_dir),
+                        "--json-output",
+                        str(session_dir / "analysis.json"),
+                    ]
+                )
+            duplicate_output = root / "duplicate.out"
+            with redirect_stderr(stderr):
+                duplicate_result = main(
+                    [
+                        str(session_dir),
+                        "--json-output",
+                        str(duplicate_output),
+                        "--markdown-output",
+                        str(duplicate_output),
+                    ]
+                )
+            self.assertFalse(duplicate_output.exists())
+
+        self.assertEqual(result, 1)
+        self.assertIn("must not be written inside", stderr.getvalue())
+        self.assertEqual(duplicate_result, 1)
+        self.assertIn("must use distinct paths", stderr.getvalue())
+
+    def test_markdown_renderer_contains_no_inferential_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            analysis = analyze_pilot_dir(make_session(Path(temp_dir)))
+
+        report = render_markdown(analysis)
+        self.assertIn("not a formal performance comparison", report)
+        self.assertIn("does not exercise a heterogeneous inference workload", report)
+        self.assertNotIn("statistically significant", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_vlm_adapter.py
+++ b/experiments/phase1/tests/test_vlm_adapter.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from experiments.phase1.vlm_adapter import (
+    FixedInputVLMAdapter,
+    VLMPipeline,
+    fixed_c100_payload,
+)
+from jetson.phase1_runtime import (
+    CancellationToken,
+    ClaimedTask,
+    ExecutionOutcome,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+)
+
+
+def make_pipeline(
+    *,
+    qwen_error: bool = False,
+    description_delay_s: float = 0.0,
+) -> VLMPipeline:
+    def describe(_path: Path) -> str:
+        print("private English model output")
+        if description_delay_s:
+            threading.Event().wait(description_delay_s)
+        return "A camera is centered in the image."
+
+    def rewrite(_english: str) -> str:
+        if qwen_error:
+            raise OSError("private Qwen error")
+        return "画面中间是一台摄像机"
+
+    return VLMPipeline(
+        describe_english=describe,
+        rewrite_chinese=rewrite,
+        translate_fallback=lambda _english: "图像中有一台摄像机",
+        normalize_output=lambda chinese, _english: chinese + "。",
+        unload_model=lambda: print("private unload message"),
+    )
+
+
+class FixedInputVLMAdapterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.input_path = Path(self.temporary.name) / "fixed.jpg"
+        self.input_bytes = b"phase1-fixed-test-image"
+        self.input_path.write_bytes(self.input_bytes)
+        self.digest = hashlib.sha256(self.input_bytes).hexdigest()
+        self.constants = patch.multiple(
+            "experiments.phase1.vlm_adapter",
+            C100_INPUT_SHA256=self.digest,
+            C100_INPUT_SIZE_BYTES=len(self.input_bytes),
+        )
+        self.constants.start()
+        self.addCleanup(self.constants.stop)
+
+    def claimed_task(self, *, cancellation: CancellationToken | None = None):
+        payload = fixed_c100_payload(self.input_path)
+        now = time.monotonic_ns()
+        task = TaskEnvelope(
+            task_id="vlm-test",
+            task_kind=TaskKind.VLM,
+            source_monotonic_ns=now,
+            created_monotonic_ns=now,
+            deadline_monotonic_ns=now + 10_000_000_000,
+            state_token=StateToken("vlm-test", 0),
+            payload=payload,
+        )
+        return ClaimedTask(
+            task=task,
+            cancellation_token=cancellation or CancellationToken(),
+            started_monotonic_ns=now,
+        )
+
+    def test_module_import_does_not_load_the_device_pipeline(self) -> None:
+        code = (
+            "import sys\n"
+            "import experiments.phase1.vlm_adapter\n"
+            "assert 'jetson.vision_vlm' not in sys.modules\n"
+            "assert 'jetson.app' not in sys.modules\n"
+            "assert 'jetson.robot_comm' not in sys.modules\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=Path(__file__).resolve().parents[3],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=5,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+
+    def test_pipeline_loading_is_lazy_and_output_is_hash_only(self) -> None:
+        load_count = 0
+
+        def load_pipeline() -> VLMPipeline:
+            nonlocal load_count
+            load_count += 1
+            return make_pipeline()
+
+        adapter = FixedInputVLMAdapter(pipeline_loader=load_pipeline)
+        self.assertEqual(load_count, 0)
+        result = adapter(self.claimed_task())
+        self.assertEqual(load_count, 1)
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.OK)
+        self.assertIsNotNone(result.output_sha256)
+        self.assertEqual(result.output_length, len("画面中间是一台摄像机。"))
+
+        record = adapter.last_record
+        self.assertIsNotNone(record)
+        assert record is not None
+        serialized = json.dumps(record.to_dict(), ensure_ascii=False)
+        self.assertNotIn("A camera is centered", serialized)
+        self.assertNotIn("画面中间是一台摄像机", serialized)
+        self.assertNotIn("private unload message", serialized)
+        self.assertFalse(record.to_dict()["output"]["raw_text_recorded"])
+        self.assertEqual(record.translation_route, "qwen")
+        self.assertTrue(record.model_unload_requested)
+        self.assertIsNone(record.model_unload_confirmed)
+        for stage in (
+            "input_verify_before",
+            "module_import",
+            "moondream_inference",
+            "qwen_rewrite",
+            "output_normalization",
+            "model_unload",
+            "input_verify_after",
+        ):
+            self.assertEqual(record.stage_status[stage], "ok")
+
+    def test_qwen_failure_uses_argos_without_recording_error_text(self) -> None:
+        adapter = FixedInputVLMAdapter(
+            pipeline_loader=lambda: make_pipeline(qwen_error=True)
+        )
+        result = adapter(self.claimed_task())
+        record = adapter.last_record
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.OK)
+        self.assertIsNotNone(record)
+        assert record is not None
+        self.assertEqual(record.translation_route, "argos")
+        self.assertEqual(record.stage_status["qwen_rewrite"], "error")
+        self.assertEqual(record.stage_status["argos_fallback"], "ok")
+        self.assertNotIn("private Qwen error", json.dumps(record.to_dict()))
+
+    def test_input_mismatch_fails_before_loading_the_pipeline(self) -> None:
+        claimed = self.claimed_task()
+        self.input_path.write_bytes(b"changed")
+        loaded = False
+
+        def load_pipeline() -> VLMPipeline:
+            nonlocal loaded
+            loaded = True
+            return make_pipeline()
+
+        adapter = FixedInputVLMAdapter(pipeline_loader=load_pipeline)
+        result = adapter(claimed)
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.ERROR)
+        self.assertEqual(result.error_code, "input_size_mismatch")
+        self.assertFalse(loaded)
+        self.assertIsNone(result.output_sha256)
+
+    def test_post_backend_cancellation_is_observed_without_stop_claim(self) -> None:
+        token = CancellationToken()
+        claimed = self.claimed_task(cancellation=token)
+        adapter = FixedInputVLMAdapter(
+            pipeline_loader=lambda: make_pipeline(description_delay_s=0.03)
+        )
+        result_holder = []
+        worker = threading.Thread(
+            target=lambda: result_holder.append(adapter(claimed)),
+            name="vlm-adapter-test",
+        )
+        worker.start()
+        self.assertTrue(adapter.inference_started_event.wait(1.0))
+        token.request("state_changed", time.monotonic_ns())
+        worker.join(1.0)
+
+        self.assertFalse(worker.is_alive())
+        result = result_holder[0]
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.CANCEL_OBSERVED)
+        self.assertTrue(result.cancellation_report.requested)
+        self.assertTrue(result.cancellation_report.worker_observed)
+        self.assertIsNone(result.cancellation_report.backend_stop_confirmed)
+        self.assertIsNotNone(result.output_sha256)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_vlm_runner.py
+++ b/experiments/phase1/tests/test_vlm_runner.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from experiments.phase1.jetson_preflight import build_jetson_preflight
+from experiments.phase1.jetson_telemetry import TegrastatsSampler
+from experiments.phase1.manifest import sha256_file
+from experiments.phase1.run_vlm_slice import build_parser, run_once
+from experiments.phase1.tests.test_jetson_pilot import clean_environment
+from experiments.phase1.tests.test_jetson_telemetry import sampler_command
+from experiments.phase1.validate_vlm_slice import validate_vlm_slice_dir
+from experiments.phase1.vlm_adapter import FixedInputVLMAdapter, VLMPipeline
+from experiments.phase1.vlm_preflight import (
+    build_vlm_preflight,
+    probe_vlm_services,
+)
+from experiments.phase1.vlm_slice import VLMSliceCondition
+
+
+SESSION_ID = "20260828T170000Z_phase1_vlm_test"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def service_status() -> dict[str, object]:
+    return {
+        "ollama": {
+            "endpoint_local": True,
+            "reachable": True,
+            "model": "moondream",
+            "model_present": True,
+            "model_digest": "a" * 64,
+            "error_code": None,
+        },
+        "qwen": {
+            "endpoint_local": True,
+            "reachable": True,
+            "model": "qwen",
+            "model_present": True,
+            "served_model_ids": ["qwen2.5-1.5b-instruct-q4_k_m.gguf"],
+            "error_code": None,
+        },
+        "python_dependencies": {"argostranslate": True, "cv2": True},
+        "ollama_cli_available": True,
+    }
+
+
+def base_preflight() -> dict[str, object]:
+    return build_jetson_preflight(
+        REPO_ROOT,
+        environment=clean_environment(),
+        tegrastats_available=True,
+        loaded_modules={"experiments.phase1.run_vlm_slice"},
+    )
+
+
+class VLMRunnerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.input_path = self.root / "fixed.jpg"
+        self.input_bytes = b"phase1-vlm-runner-fixed-image"
+        self.input_path.write_bytes(self.input_bytes)
+        self.digest = hashlib.sha256(self.input_bytes).hexdigest()
+        self.constants = [
+            patch.multiple(
+                module,
+                C100_INPUT_SHA256=self.digest,
+                C100_INPUT_SIZE_BYTES=len(self.input_bytes),
+            )
+            for module in (
+                "experiments.phase1.vlm_adapter",
+                "experiments.phase1.vlm_preflight",
+                "experiments.phase1.summarize_vlm_slice",
+                "experiments.phase1.validate_vlm_slice",
+            )
+        ]
+        for constant_patch in self.constants:
+            constant_patch.start()
+            self.addCleanup(constant_patch.stop)
+
+    def args(self, condition: VLMSliceCondition):
+        return build_parser().parse_args(
+            [
+                "--condition",
+                condition.value,
+                "--input",
+                str(self.input_path),
+                "--session-id",
+                SESSION_ID,
+                "--output-root",
+                str(self.root / "runs"),
+                "--result-validity-s",
+                "2",
+                "--completion-timeout-s",
+                "1",
+                "--join-timeout-s",
+                "1",
+                "--probe-join-timeout-s",
+                "1",
+                "--prelude-s",
+                "0.02",
+                "--postlude-s",
+                "0.02",
+                "--probe-period-ms",
+                "5",
+                "--probe-deadline-ms",
+                "10",
+                "--resource-interval-ms",
+                "50",
+                "--resource-first-sample-timeout-s",
+                "2",
+            ]
+        )
+
+    def preflight_builder(self, _root, *, input_payload, expected_branch):
+        self.assertEqual(expected_branch, "main")
+        return build_vlm_preflight(
+            REPO_ROOT,
+            input_payload=input_payload,
+            expected_branch=expected_branch,
+            base_preflight=base_preflight(),
+            services=service_status(),
+        )
+
+    @staticmethod
+    def sampler_factory(run_dir, interval_ms):
+        return TegrastatsSampler(
+            run_dir,
+            interval_ms,
+            command=sampler_command(),
+        )
+
+    @staticmethod
+    def adapter_factory() -> FixedInputVLMAdapter:
+        def describe(_path: Path) -> str:
+            threading.Event().wait(0.04)
+            return "private runner model output"
+
+        return FixedInputVLMAdapter(
+            pipeline_loader=lambda: VLMPipeline(
+                describe_english=describe,
+                rewrite_chinese=lambda _text: "固定结果",
+                translate_fallback=lambda _text: "备用结果",
+                normalize_output=lambda chinese, _english: chinese + "。",
+                unload_model=lambda: None,
+            )
+        )
+
+    def test_local_service_probe_records_identity_without_endpoint_text(self) -> None:
+        def query(url: str) -> dict[str, object]:
+            if url.endswith("/tags"):
+                return {"models": [{"name": "moondream:latest", "digest": "b" * 64}]}
+            return {"data": [{"id": "qwen"}]}
+
+        with patch.dict(
+            os.environ,
+            {
+                "ROBOT_OLLAMA_CHAT_URL": "http://127.0.0.1:11434/api/chat",
+                "ROBOT_LLAMA_API_URL": ("http://127.0.0.1:8080/v1/chat/completions"),
+            },
+        ):
+            status = probe_vlm_services(query=query)
+        self.assertTrue(status["ollama"]["endpoint_local"])
+        self.assertTrue(status["ollama"]["model_present"])
+        self.assertEqual(status["ollama"]["model_digest"], "b" * 64)
+        self.assertTrue(status["qwen"]["model_present"])
+        self.assertEqual(status["qwen"]["served_model_ids"], ["qwen"])
+        self.assertNotIn("endpoint", status["ollama"])
+
+    def test_nonlocal_service_configuration_is_not_contacted(self) -> None:
+        requested_urls: list[str] = []
+
+        def query(url: str) -> dict[str, object]:
+            requested_urls.append(url)
+            return {}
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "ROBOT_OLLAMA_CHAT_URL": "http://192.0.2.1:11434/api/chat",
+                    "ROBOT_LLAMA_API_URL": (
+                        "http://192.0.2.2:8080/v1/chat/completions"
+                    ),
+                },
+            ),
+            patch(
+                "jetson.config.OLLAMA_CHAT_URL",
+                "http://192.0.2.1:11434/api/chat",
+            ),
+            patch(
+                "jetson.config.LLAMA_API_URL",
+                "http://192.0.2.2:8080/v1/chat/completions",
+            ),
+        ):
+            status = probe_vlm_services(query=query)
+        self.assertEqual(requested_urls, [])
+        self.assertEqual(status["ollama"]["error_code"], "nonlocal_endpoint")
+        self.assertEqual(status["qwen"]["error_code"], "nonlocal_endpoint")
+
+    def test_failed_preflight_creates_no_run_directory(self) -> None:
+        def failed_builder(_root, *, input_payload, expected_branch):
+            preflight = self.preflight_builder(
+                _root,
+                input_payload=input_payload,
+                expected_branch=expected_branch,
+            )
+            preflight["checks"][0]["passed"] = False
+            preflight["eligible"] = False
+            return preflight
+
+        with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+            with self.assertRaisesRegex(RuntimeError, "preflight failed"):
+                run_once(
+                    self.args(VLMSliceCondition.ASYNC),
+                    repo_root=REPO_ROOT,
+                    preflight_builder=failed_builder,
+                    sampler_factory=self.sampler_factory,
+                    adapter_factory=self.adapter_factory,
+                )
+        self.assertFalse((self.root / "runs" / SESSION_ID).exists())
+
+    def test_both_conditions_create_independently_validated_artifacts(self) -> None:
+        baseline_threads = {thread.name for thread in threading.enumerate()}
+        with (
+            patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}),
+            patch(
+                "experiments.phase1.run_vlm_slice.collect_environment",
+                return_value=clean_environment(),
+            ),
+        ):
+            run_dirs = [
+                run_once(
+                    self.args(condition),
+                    repo_root=REPO_ROOT,
+                    preflight_builder=self.preflight_builder,
+                    sampler_factory=self.sampler_factory,
+                    adapter_factory=self.adapter_factory,
+                )
+                for condition in VLMSliceCondition
+            ]
+
+        for run_dir, condition in zip(run_dirs, VLMSliceCondition):
+            with self.subTest(condition=condition.value):
+                self.assertEqual(validate_vlm_slice_dir(run_dir), [])
+                manifest = json.loads(
+                    (run_dir / "manifest.json").read_text(encoding="utf-8")
+                )
+                summary = json.loads(
+                    (run_dir / "summary.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(manifest["status"], "completed")
+                self.assertTrue(summary["valid"])
+                self.assertTrue(summary["development_injection"])
+                self.assertFalse(summary["real_vlm_path_executed"])
+                self.assertFalse(summary["formal_performance_claim_permitted"])
+                self.assertFalse(summary["heterogeneous_inference_claim_permitted"])
+                combined = "\n".join(
+                    (run_dir / name).read_text(encoding="utf-8")
+                    for name in (
+                        "manifest.json",
+                        "preflight.json",
+                        "events.jsonl",
+                        "scenario.json",
+                        "summary.json",
+                    )
+                )
+                self.assertNotIn("private runner model output", combined)
+                self.assertNotIn(str(self.input_path), combined)
+
+        nominal_summary = json.loads(
+            (run_dirs[0] / "summary.json").read_text(encoding="utf-8")
+        )
+        stale_summary = json.loads(
+            (run_dirs[1] / "summary.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            dict(nominal_summary["lifecycle"]["disposition_counts"]),
+            {"consumed": 1},
+        )
+        self.assertEqual(
+            dict(stale_summary["lifecycle"]["disposition_counts"]),
+            {"rejected_state": 1},
+        )
+        self.assertEqual(stale_summary["lifecycle"]["accepted_result_count"], 0)
+        remaining_threads = {thread.name for thread in threading.enumerate()}
+        self.assertEqual(remaining_threads, baseline_threads)
+
+    def test_validator_rebuilds_summary_after_hash_consistent_tampering(self) -> None:
+        with (
+            patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}),
+            patch(
+                "experiments.phase1.run_vlm_slice.collect_environment",
+                return_value=clean_environment(),
+            ),
+        ):
+            run_dir = run_once(
+                self.args(VLMSliceCondition.ASYNC),
+                repo_root=REPO_ROOT,
+                preflight_builder=self.preflight_builder,
+                sampler_factory=self.sampler_factory,
+                adapter_factory=self.adapter_factory,
+            )
+        summary_path = run_dir / "summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        summary["resources"]["inference_interval_sample_count"] += 1
+        summary_path.write_text(
+            json.dumps(summary, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        manifest_path = run_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["artifacts"]["summary.json"] = {
+            "size_bytes": summary_path.stat().st_size,
+            "sha256": sha256_file(summary_path),
+        }
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+        errors = validate_vlm_slice_dir(run_dir)
+        self.assertTrue(any("independently rebuilt" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_vlm_slice.py
+++ b/experiments/phase1/tests/test_vlm_slice.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from experiments.phase1.replay_lifecycle import (
+    TraceProfile,
+    load_events,
+    replay_events,
+)
+from experiments.phase1.telemetry import EventRecorder
+from experiments.phase1.vlm_adapter import (
+    FixedInputVLMAdapter,
+    VLMPipeline,
+    fixed_c100_payload,
+)
+from experiments.phase1.vlm_slice import (
+    VLMSliceCondition,
+    VLMSliceSpec,
+    run_vlm_slice,
+)
+
+
+class VLMSliceTests(unittest.TestCase):
+    def run_condition(self, condition: VLMSliceCondition):
+        baseline_threads = {thread.name for thread in threading.enumerate()}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            image_path = root / "fixed.jpg"
+            content = b"phase1-vlm-slice-image"
+            image_path.write_bytes(content)
+            digest = hashlib.sha256(content).hexdigest()
+            run_id = f"20260828T160000Z_phase1_{condition.value}_vlm_001"
+            adapter = FixedInputVLMAdapter(
+                pipeline_loader=lambda: VLMPipeline(
+                    describe_english=self.describe,
+                    rewrite_chinese=lambda _text: "固定输出",
+                    translate_fallback=lambda _text: "备用输出",
+                    normalize_output=lambda chinese, _english: chinese + "。",
+                    unload_model=lambda: None,
+                )
+            )
+            spec = VLMSliceSpec(
+                condition=condition,
+                result_validity_s=2.0,
+                completion_timeout_s=1.0,
+                join_timeout_s=1.0,
+                probe_join_timeout_s=1.0,
+                prelude_s=0.005,
+                postlude_s=0.005,
+                probe_period_ns=1_000_000,
+                probe_deadline_ns=2_000_000,
+            )
+            with patch.multiple(
+                "experiments.phase1.vlm_adapter",
+                C100_INPUT_SHA256=digest,
+                C100_INPUT_SIZE_BYTES=len(content),
+            ):
+                payload = fixed_c100_payload(image_path)
+                with EventRecorder(root / "run", run_id) as recorder:
+                    report = run_vlm_slice(
+                        spec,
+                        payload,
+                        recorder,
+                        adapter=adapter,
+                    )
+                replay = replay_events(
+                    load_events(root / "run" / "events.jsonl"),
+                    profile=TraceProfile.RUNTIME_THREADED_PROBE,
+                )
+                trace_text = (root / "run" / "events.jsonl").read_text(encoding="utf-8")
+                report_text = json.dumps(report.to_dict(), ensure_ascii=False)
+
+        remaining_threads = {thread.name for thread in threading.enumerate()}
+        self.assertEqual(remaining_threads, baseline_threads)
+        self.assertNotIn("private model output", trace_text)
+        self.assertNotIn("private model output", report_text)
+        self.assertEqual(replay.admitted_total, 1)
+        self.assertEqual(replay.terminal_admitted_total, 1)
+        self.assertEqual(replay.stale_consumed_count, 0)
+        self.assertTrue(report.shutdown.complete)
+        self.assertTrue(report.probe.joined)
+        self.assertGreater(report.probe.tick_count, 0)
+        return report, replay
+
+    @staticmethod
+    def describe(_path: Path) -> str:
+        threading.Event().wait(0.03)
+        return "private model output"
+
+    def test_nominal_result_is_consumed_once(self) -> None:
+        report, replay = self.run_condition(VLMSliceCondition.ASYNC)
+        self.assertTrue(report.consumed)
+        self.assertFalse(report.state_advanced)
+        self.assertEqual(report.final_disposition, "consumed")
+        self.assertEqual(replay.accepted_result_count, 1)
+
+    def test_state_change_rejects_completed_backend_result(self) -> None:
+        report, replay = self.run_condition(VLMSliceCondition.STALE)
+        self.assertFalse(report.consumed)
+        self.assertTrue(report.state_advanced)
+        self.assertEqual(report.final_disposition, "rejected_state")
+        self.assertEqual(replay.accepted_result_count, 0)
+        self.assertTrue(report.adapter.cancellation_requested)
+        self.assertTrue(report.adapter.worker_observed_cancellation)
+        self.assertIsNone(report.adapter.backend_stop_confirmed)
+        self.assertIsNotNone(report.adapter.output_sha256)
+
+    def test_spec_requires_deadline_beyond_completion_budget(self) -> None:
+        with self.assertRaisesRegex(ValueError, "result_validity_s"):
+            VLMSliceSpec(
+                condition=VLMSliceCondition.ASYNC,
+                result_validity_s=1.0,
+                completion_timeout_s=1.0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/validate_vlm_slice.py
+++ b/experiments/phase1/validate_vlm_slice.py
@@ -1,0 +1,383 @@
+"""Validate one complete fixed-input Phase 1 VLM run directory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from experiments.phase1.jetson_telemetry import (
+    load_resource_samples,
+    validate_resource_samples,
+)
+from experiments.phase1.manifest import MANIFEST_SCHEMA_VERSION, sha256_file
+from experiments.phase1.summarize_vlm_slice import (
+    VLM_SUMMARY_SCHEMA_VERSION,
+    build_vlm_summary,
+)
+from experiments.phase1.telemetry import SCHEMA_VERSION as EVENT_SCHEMA_VERSION
+from experiments.phase1.vlm_adapter import (
+    C100_INPUT_MEDIA_TYPE,
+    C100_INPUT_SHA256,
+    C100_INPUT_SIZE_BYTES,
+)
+from experiments.phase1.vlm_preflight import vlm_preflight_errors
+from experiments.phase1.vlm_slice import VLMSliceCondition
+
+
+REQUIRED_FILES = (
+    "manifest.json",
+    "preflight.json",
+    "events.jsonl",
+    "resources.jsonl",
+    "scenario.json",
+    "summary.json",
+)
+_REPORT_KEYS = {
+    "condition",
+    "task_id",
+    "state_advanced",
+    "consumed",
+    "final_disposition",
+    "adapter",
+    "shutdown",
+    "probe",
+    "final_snapshot",
+}
+_ADAPTER_KEYS = {
+    "task_id",
+    "worker_thread_id",
+    "started_monotonic_ns",
+    "finished_monotonic_ns",
+    "duration_ns",
+    "execution_outcome",
+    "error_code",
+    "input",
+    "output",
+    "translation_route",
+    "model_residency",
+    "stage_durations_ns",
+    "stage_status",
+    "cancellation",
+}
+
+
+def _read_object(path: Path, errors: list[str]) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        errors.append(f"{path.name}: {type(exc).__name__}: {exc}")
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"{path.name}: root must be an object")
+        return {}
+    return value
+
+
+def _json_value(value: object) -> object:
+    return json.loads(json.dumps(value, ensure_ascii=False, allow_nan=False))
+
+
+def _check_artifacts(
+    directory: Path,
+    artifacts: object,
+    errors: list[str],
+) -> None:
+    if not isinstance(artifacts, Mapping):
+        errors.append("manifest artifact identities are missing")
+        return
+    expected = set(REQUIRED_FILES) - {"manifest.json"}
+    if set(artifacts) != expected:
+        errors.append("manifest artifact identity set is incomplete or unsupported")
+    for name in sorted(expected):
+        identity = artifacts.get(name)
+        path = directory / name
+        if not isinstance(identity, Mapping):
+            errors.append(f"manifest identity is missing for {name}")
+            continue
+        if identity.get("size_bytes") != path.stat().st_size:
+            errors.append(f"manifest size does not match {name}")
+        if identity.get("sha256") != sha256_file(path):
+            errors.append(f"manifest SHA-256 does not match {name}")
+
+
+def validate_vlm_slice_dir(run_dir: Path | str) -> list[str]:
+    directory = Path(run_dir)
+    errors: list[str] = []
+    for name in REQUIRED_FILES:
+        if not (directory / name).is_file():
+            errors.append(f"missing file: {name}")
+    if list(directory.glob("*.tmp")):
+        errors.append("run directory contains an unfinished temporary file")
+    if errors:
+        return errors
+
+    manifest = _read_object(directory / "manifest.json", errors)
+    preflight = _read_object(directory / "preflight.json", errors)
+    scenario = _read_object(directory / "scenario.json", errors)
+    summary = _read_object(directory / "summary.json", errors)
+    if errors:
+        return errors
+
+    run_id = manifest.get("run_id")
+    if not isinstance(run_id, str) or run_id != directory.name:
+        errors.append("manifest run_id does not match the run directory")
+    if manifest.get("manifest_schema_version") != MANIFEST_SCHEMA_VERSION:
+        errors.append("unsupported manifest schema version")
+    if manifest.get("event_schema_version") != EVENT_SCHEMA_VERSION:
+        errors.append("unsupported event schema version")
+    if manifest.get("artifact_kind") != "phase1_fixed_input_vlm_run":
+        errors.append("manifest artifact kind is not a fixed-input VLM run")
+    if manifest.get("trace_profile") != "runtime_threaded_probe":
+        errors.append("manifest trace profile is not runtime_threaded_probe")
+    if manifest.get("status") != "completed":
+        errors.append(f"manifest status is not completed: {manifest.get('status')!r}")
+    if manifest.get("descriptive_only") is not True:
+        errors.append("manifest is not marked descriptive-only")
+    if manifest.get("formal_performance_claim_permitted") is not False:
+        errors.append("manifest incorrectly permits a formal performance claim")
+    if manifest.get("heterogeneous_inference_claim_permitted") is not False:
+        errors.append("manifest incorrectly permits a heterogeneous inference claim")
+
+    environment = manifest.get("environment")
+    git = environment.get("git") if isinstance(environment, Mapping) else None
+    reproducibility = manifest.get("reproducibility")
+    if not isinstance(reproducibility, Mapping):
+        errors.append("manifest reproducibility record is missing")
+    else:
+        synchronized_main = (
+            isinstance(git, Mapping)
+            and not git.get("error_codes")
+            and git.get("dirty") is False
+            and git.get("branch") == "main"
+            and git.get("upstream") == "origin/main"
+            and git.get("upstream_commit") == git.get("commit")
+            and str(git.get("ahead_behind", "")).split() == ["0", "0"]
+        )
+        if reproducibility.get("synchronized_main") is not synchronized_main:
+            errors.append("manifest synchronized-main fact is inconsistent")
+        development_injection = reproducibility.get("development_injection")
+        injected_components = reproducibility.get("injected_components")
+        if not isinstance(development_injection, bool):
+            errors.append("development injection fact must be boolean")
+        if not isinstance(injected_components, list) or any(
+            item
+            not in {
+                "preflight_builder",
+                "sampler_factory",
+                "adapter_factory",
+            }
+            for item in injected_components
+        ):
+            errors.append("injected component list is invalid")
+        elif development_injection is not bool(injected_components):
+            errors.append("development injection facts are inconsistent")
+        if reproducibility.get("formal_evidence_eligible") is not False:
+            errors.append("VLM pilot must remain ineligible for a formal claim")
+
+    safety = manifest.get("safety")
+    if not isinstance(safety, Mapping):
+        errors.append("manifest safety record is missing")
+    elif (
+        safety.get("motion_enabled") is not False
+        or safety.get("motion_value_valid") is not True
+    ):
+        errors.append("manifest does not prove physical motion was disabled")
+
+    input_identity = manifest.get("input")
+    if input_identity != {
+        "sha256": C100_INPUT_SHA256,
+        "size_bytes": C100_INPUT_SIZE_BYTES,
+        "media_type": C100_INPUT_MEDIA_TYPE,
+        "path_recorded": False,
+    }:
+        errors.append("manifest input identity does not match the fixed C100 image")
+
+    errors.extend(f"preflight: {error}" for error in vlm_preflight_errors(preflight))
+    base = preflight.get("base")
+    base_environment = base.get("environment") if isinstance(base, Mapping) else None
+    base_git = (
+        base_environment.get("git") if isinstance(base_environment, Mapping) else None
+    )
+    if isinstance(git, Mapping) and isinstance(base_git, Mapping):
+        for key in (
+            "commit",
+            "branch",
+            "dirty",
+            "upstream",
+            "upstream_commit",
+            "ahead_behind",
+        ):
+            if git.get(key) != base_git.get(key):
+                errors.append(f"manifest and preflight Git {key} differ")
+
+    workload_contract = manifest.get("workload_contract")
+    if not isinstance(workload_contract, Mapping):
+        errors.append("manifest workload contract is missing")
+    else:
+        moondream = workload_contract.get("moondream")
+        qwen = workload_contract.get("qwen_rewrite")
+        if (
+            workload_contract.get("source") != "jetson.vision_vlm"
+            or workload_contract.get("translation_fallback") != "argos_en_zh"
+            or workload_contract.get("unload_after_request") is not True
+            or workload_contract.get("unload_confirmation") != "not_available"
+            or workload_contract.get("raw_output_recorded") is not False
+            or moondream
+            != {
+                "temperature": 0.1,
+                "num_predict": 100,
+                "request_timeout_s": 180,
+            }
+            or qwen
+            != {
+                "temperature": 0.2,
+                "max_tokens": 96,
+                "request_timeout_s": 30,
+            }
+        ):
+            errors.append("manifest workload contract differs from Phase 0")
+    try:
+        condition = VLMSliceCondition(manifest.get("condition"))
+    except ValueError:
+        errors.append("manifest VLM condition is not supported")
+        return errors
+    spec = manifest.get("spec")
+    report = scenario.get("report")
+    if spec != scenario.get("spec"):
+        errors.append("manifest and scenario specifications differ")
+    if not isinstance(spec, Mapping):
+        errors.append("manifest VLM specification is missing")
+    elif (
+        spec.get("condition") != condition.value
+        or spec.get("task_kind") != "vlm"
+        or spec.get("request_count") != 1
+    ):
+        errors.append("manifest VLM specification is inconsistent")
+    if not isinstance(report, Mapping):
+        errors.append("scenario VLM report is missing")
+    elif report.get("condition") != condition.value:
+        errors.append("scenario condition does not match the manifest")
+    else:
+        if set(report) != _REPORT_KEYS:
+            errors.append("scenario VLM report fields are incomplete or unsupported")
+        adapter = report.get("adapter")
+        if not isinstance(adapter, Mapping) or set(adapter) != _ADAPTER_KEYS:
+            errors.append("scenario adapter fields are incomplete or unsupported")
+        else:
+            adapter_input = adapter.get("input")
+            adapter_output = adapter.get("output")
+            cancellation = adapter.get("cancellation")
+            model_residency = adapter.get("model_residency")
+            if not isinstance(adapter_input, Mapping) or set(adapter_input) != {
+                "sha256",
+                "size_bytes",
+                "media_type",
+            }:
+                errors.append("scenario adapter input fields are unsupported")
+            if not isinstance(adapter_output, Mapping) or set(adapter_output) != {
+                "sha256",
+                "length",
+                "raw_text_recorded",
+            }:
+                errors.append("scenario adapter output fields are unsupported")
+            if not isinstance(cancellation, Mapping) or set(cancellation) != {
+                "requested",
+                "worker_observed",
+                "client_wait_stopped",
+                "backend_stop_confirmed",
+            }:
+                errors.append("scenario cancellation fields are unsupported")
+            if not isinstance(model_residency, Mapping) or set(model_residency) != {
+                "unload_requested",
+                "unload_confirmed",
+            }:
+                errors.append("scenario model-residency fields are unsupported")
+
+    _check_artifacts(directory, manifest.get("artifacts"), errors)
+    try:
+        samples = load_resource_samples(directory / "resources.jsonl")
+    except (OSError, UnicodeError, ValueError) as exc:
+        errors.append(f"resources.jsonl: {type(exc).__name__}: {exc}")
+        samples = []
+    else:
+        errors.extend(validate_resource_samples(samples))
+
+    sampler_report = manifest.get("resource_sampler_report")
+    if not isinstance(sampler_report, Mapping):
+        errors.append("manifest resource sampler report is missing")
+        sampler_report = {}
+    elif sampler_report.get("successful") is not True:
+        errors.append("manifest resource sampler did not close successfully")
+
+    if summary.get("vlm_summary_schema_version") != VLM_SUMMARY_SCHEMA_VERSION:
+        errors.append("unsupported VLM summary schema version")
+    if summary.get("run_id") != run_id:
+        errors.append("summary run_id does not match the manifest")
+    if summary.get("condition") != condition.value:
+        errors.append("summary condition does not match the manifest")
+    if summary.get("descriptive_only") is not True:
+        errors.append("summary is not marked descriptive-only")
+    expected_injection = (
+        reproducibility.get("development_injection")
+        if isinstance(reproducibility, Mapping)
+        else None
+    )
+    if summary.get("development_injection") is not expected_injection:
+        errors.append("summary development injection fact is inconsistent")
+    if (
+        expected_injection is True
+        and summary.get("real_vlm_path_executed") is not False
+    ):
+        errors.append("development injection cannot claim real VLM execution")
+    if summary.get("formal_performance_claim_permitted") is not False:
+        errors.append("summary incorrectly permits a formal performance claim")
+    if summary.get("heterogeneous_inference_claim_permitted") is not False:
+        errors.append("summary incorrectly permits a heterogeneous inference claim")
+    if summary.get("valid") is not True:
+        errors.append("summary Gates did not all pass")
+    gates = summary.get("gates")
+    if not isinstance(gates, list) or not gates:
+        errors.append("summary contains no Gates")
+    elif any(
+        not isinstance(gate, Mapping) or gate.get("passed") is not True
+        for gate in gates
+    ):
+        errors.append("one or more VLM summary Gates failed")
+
+    if isinstance(spec, Mapping) and isinstance(report, Mapping) and samples:
+        try:
+            rebuilt = build_vlm_summary(
+                directory / "events.jsonl",
+                condition=condition,
+                spec=spec,
+                report=report,
+                resource_samples=samples,
+                sampler_report=sampler_report,
+                development_injection=bool(expected_injection),
+            )
+        except (OSError, TypeError, ValueError) as exc:
+            errors.append(f"summary rebuild failed: {type(exc).__name__}: {exc}")
+        else:
+            if summary != _json_value(rebuilt):
+                errors.append("summary does not match independently rebuilt metrics")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir", type=Path)
+    args = parser.parse_args(argv)
+    errors = validate_vlm_slice_dir(args.run_dir)
+    if errors:
+        print("INVALID")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("VALID")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/phase1/vlm_adapter.py
+++ b/experiments/phase1/vlm_adapter.py
@@ -1,0 +1,450 @@
+"""Fixed-input VLM adapter for the first real Phase 1 workload slice."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Callable, Mapping
+
+from jetson.phase1_runtime import (
+    CancellationReport,
+    ClaimedTask,
+    ExecutionOutcome,
+    PayloadRef,
+    ResultEnvelope,
+    TaskKind,
+)
+
+
+C100_INPUT_SHA256 = "607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7"
+C100_INPUT_SIZE_BYTES = 9009
+C100_INPUT_MEDIA_TYPE = "image/jpeg"
+
+
+class VLMInputError(ValueError):
+    """The fixed input does not match the frozen Phase 0 identity."""
+
+
+class VLMExecutionError(RuntimeError):
+    """One bounded stage of the VLM pipeline failed."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class VLMPipeline:
+    """Callables loaded from the validated Phase 0 VLM path."""
+
+    describe_english: Callable[[Path], str]
+    rewrite_chinese: Callable[[str], str]
+    translate_fallback: Callable[[str], str]
+    normalize_output: Callable[[str, str], str]
+    unload_model: Callable[[], None]
+
+
+@dataclass(frozen=True, slots=True)
+class VLMExecutionRecord:
+    """Privacy-preserving facts from one adapter invocation."""
+
+    task_id: str
+    worker_thread_id: int
+    started_monotonic_ns: int
+    finished_monotonic_ns: int
+    execution_outcome: str
+    error_code: str | None
+    input_sha256: str
+    input_size_bytes: int
+    output_sha256: str | None
+    output_length: int | None
+    translation_route: str | None
+    model_unload_requested: bool
+    model_unload_confirmed: bool | None
+    stage_durations_ns: Mapping[str, int]
+    stage_status: Mapping[str, str]
+    cancellation_requested: bool
+    worker_observed_cancellation: bool
+    backend_stop_confirmed: bool | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "stage_durations_ns",
+            MappingProxyType(dict(self.stage_durations_ns)),
+        )
+        object.__setattr__(
+            self,
+            "stage_status",
+            MappingProxyType(dict(self.stage_status)),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "task_id": self.task_id,
+            "worker_thread_id": self.worker_thread_id,
+            "started_monotonic_ns": self.started_monotonic_ns,
+            "finished_monotonic_ns": self.finished_monotonic_ns,
+            "duration_ns": self.finished_monotonic_ns - self.started_monotonic_ns,
+            "execution_outcome": self.execution_outcome,
+            "error_code": self.error_code,
+            "input": {
+                "sha256": self.input_sha256,
+                "size_bytes": self.input_size_bytes,
+                "media_type": C100_INPUT_MEDIA_TYPE,
+            },
+            "output": (
+                None
+                if self.output_sha256 is None
+                else {
+                    "sha256": self.output_sha256,
+                    "length": self.output_length,
+                    "raw_text_recorded": False,
+                }
+            ),
+            "translation_route": self.translation_route,
+            "model_residency": {
+                "unload_requested": self.model_unload_requested,
+                "unload_confirmed": self.model_unload_confirmed,
+            },
+            "stage_durations_ns": dict(self.stage_durations_ns),
+            "stage_status": dict(self.stage_status),
+            "cancellation": {
+                "requested": self.cancellation_requested,
+                "worker_observed": self.worker_observed_cancellation,
+                "client_wait_stopped": False,
+                "backend_stop_confirmed": self.backend_stop_confirmed,
+            },
+        }
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fixed_c100_payload(path: Path | str) -> PayloadRef:
+    """Verify and reference the exact C100 image used by Phase 0."""
+
+    resolved = Path(path).expanduser().resolve()
+    if not resolved.is_file():
+        raise VLMInputError("fixed VLM input is not a regular file")
+    size_bytes = resolved.stat().st_size
+    if size_bytes != C100_INPUT_SIZE_BYTES:
+        raise VLMInputError("fixed VLM input size does not match Phase 0")
+    digest = _sha256_file(resolved)
+    if digest != C100_INPUT_SHA256:
+        raise VLMInputError("fixed VLM input hash does not match Phase 0")
+    return PayloadRef(
+        ref=str(resolved),
+        sha256=digest,
+        size_bytes=size_bytes,
+        media_type=C100_INPUT_MEDIA_TYPE,
+    )
+
+
+def _load_phase0_pipeline() -> VLMPipeline:
+    from jetson.vision_vlm import (
+        ask_moondream_english,
+        make_speech_friendly,
+        translate_en_to_zh,
+        translate_with_qwen,
+        unload_moondream,
+    )
+
+    return VLMPipeline(
+        describe_english=ask_moondream_english,
+        rewrite_chinese=translate_with_qwen,
+        translate_fallback=translate_en_to_zh,
+        normalize_output=make_speech_friendly,
+        unload_model=unload_moondream,
+    )
+
+
+class FixedInputVLMAdapter:
+    """Run the Phase 0 VLM path without exposing model text to artifacts."""
+
+    def __init__(
+        self,
+        *,
+        pipeline_loader: Callable[[], VLMPipeline] | None = None,
+        clock_ns: Callable[[], int] = time.monotonic_ns,
+    ) -> None:
+        if pipeline_loader is not None and not callable(pipeline_loader):
+            raise TypeError("pipeline_loader must be callable or None")
+        if not callable(clock_ns):
+            raise TypeError("clock_ns must be callable")
+        self._pipeline_loader = pipeline_loader or _load_phase0_pipeline
+        self._clock_ns = clock_ns
+        self._invocation_lock = threading.Lock()
+        self._record_lock = threading.Lock()
+        self._last_record: VLMExecutionRecord | None = None
+        self.inference_started_event = threading.Event()
+
+    @property
+    def last_record(self) -> VLMExecutionRecord | None:
+        with self._record_lock:
+            return self._last_record
+
+    def _verify_claimed_input(self, claimed: ClaimedTask) -> Path:
+        task = claimed.task
+        if task.task_kind is not TaskKind.VLM:
+            raise VLMExecutionError("invalid_task_kind")
+        payload = task.payload
+        if (
+            payload.sha256 != C100_INPUT_SHA256
+            or payload.size_bytes != C100_INPUT_SIZE_BYTES
+            or payload.media_type != C100_INPUT_MEDIA_TYPE
+        ):
+            raise VLMExecutionError("unsupported_fixed_input")
+        path = Path(payload.ref).expanduser().resolve()
+        if not path.is_file():
+            raise VLMExecutionError("input_missing")
+        if path.stat().st_size != payload.size_bytes:
+            raise VLMExecutionError("input_size_mismatch")
+        if _sha256_file(path) != payload.sha256:
+            raise VLMExecutionError("input_hash_mismatch")
+        return path
+
+    def _stage(
+        self,
+        name: str,
+        operation: Callable[[], object],
+        durations: dict[str, int],
+        statuses: dict[str, str],
+    ) -> object:
+        started = self._clock_ns()
+        try:
+            value = operation()
+        except Exception:
+            statuses[name] = "error"
+            raise
+        else:
+            statuses[name] = "ok"
+            return value
+        finally:
+            durations[name] = max(0, self._clock_ns() - started)
+
+    def _result(
+        self,
+        claimed: ClaimedTask,
+        *,
+        outcome: ExecutionOutcome,
+        error_code: str | None,
+        output_sha256: str | None,
+        output_length: int | None,
+        route: str | None,
+        durations: Mapping[str, int],
+        statuses: Mapping[str, str],
+    ) -> ResultEnvelope:
+        task = claimed.task
+        finished = max(claimed.started_monotonic_ns, self._clock_ns())
+        cancellation_requested = claimed.cancellation_token.is_requested()
+        observed = cancellation_requested
+        resolved_outcome = (
+            ExecutionOutcome.CANCEL_OBSERVED
+            if outcome is ExecutionOutcome.OK and observed
+            else outcome
+        )
+        resolved_error = error_code
+        cancellation = CancellationReport(
+            requested=cancellation_requested,
+            client_wait_stopped=False,
+            worker_observed=observed,
+            backend_stop_confirmed=None,
+        )
+        result = ResultEnvelope(
+            task_id=task.task_id,
+            task_kind=task.task_kind,
+            state_token=task.state_token,
+            source_monotonic_ns=task.source_monotonic_ns,
+            deadline_monotonic_ns=task.deadline_monotonic_ns,
+            input_sha256=task.payload.sha256,
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=resolved_outcome,
+            output_sha256=output_sha256,
+            output_length=output_length,
+            error_code=resolved_error,
+            cancellation_report=cancellation,
+        )
+        record = VLMExecutionRecord(
+            task_id=task.task_id,
+            worker_thread_id=threading.get_ident(),
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=resolved_outcome.value,
+            error_code=resolved_error,
+            input_sha256=task.payload.sha256,
+            input_size_bytes=task.payload.size_bytes,
+            output_sha256=output_sha256,
+            output_length=output_length,
+            translation_route=route,
+            model_unload_requested="model_unload" in statuses,
+            model_unload_confirmed=None,
+            stage_durations_ns=durations,
+            stage_status=statuses,
+            cancellation_requested=cancellation_requested,
+            worker_observed_cancellation=observed,
+            backend_stop_confirmed=None,
+        )
+        with self._record_lock:
+            self._last_record = record
+        return result
+
+    def __call__(self, claimed: ClaimedTask) -> ResultEnvelope:
+        if not isinstance(claimed, ClaimedTask):
+            raise TypeError("claimed must be a ClaimedTask")
+        if not self._invocation_lock.acquire(blocking=False):
+            raise VLMExecutionError("vlm_adapter_busy")
+
+        self.inference_started_event.clear()
+        durations: dict[str, int] = {}
+        statuses: dict[str, str] = {}
+        output_sha256: str | None = None
+        output_length: int | None = None
+        route: str | None = None
+        outcome = ExecutionOutcome.OK
+        error_code: str | None = None
+        pipeline: VLMPipeline | None = None
+
+        try:
+            if claimed.cancellation_token.is_requested():
+                return self._result(
+                    claimed,
+                    outcome=ExecutionOutcome.CANCEL_OBSERVED,
+                    error_code=None,
+                    output_sha256=None,
+                    output_length=None,
+                    route=None,
+                    durations=durations,
+                    statuses=statuses,
+                )
+
+            try:
+                input_path = self._stage(
+                    "input_verify_before",
+                    lambda: self._verify_claimed_input(claimed),
+                    durations,
+                    statuses,
+                )
+                assert isinstance(input_path, Path)
+                pipeline_value = self._stage(
+                    "module_import",
+                    self._pipeline_loader,
+                    durations,
+                    statuses,
+                )
+                if not isinstance(pipeline_value, VLMPipeline):
+                    raise VLMExecutionError("invalid_pipeline")
+                pipeline = pipeline_value
+
+                captured_stdout = io.StringIO()
+                captured_stderr = io.StringIO()
+                with (
+                    contextlib.redirect_stdout(captured_stdout),
+                    contextlib.redirect_stderr(captured_stderr),
+                ):
+                    self.inference_started_event.set()
+                    english_value = self._stage(
+                        "moondream_inference",
+                        lambda: pipeline.describe_english(input_path),
+                        durations,
+                        statuses,
+                    )
+                    english = str(english_value).strip()
+                    if not english:
+                        raise VLMExecutionError("empty_vlm_description")
+
+                    try:
+                        chinese_value = self._stage(
+                            "qwen_rewrite",
+                            lambda: pipeline.rewrite_chinese(english),
+                            durations,
+                            statuses,
+                        )
+                        chinese = str(chinese_value).strip()
+                        route = "qwen"
+                    except Exception:
+                        fallback_value = self._stage(
+                            "argos_fallback",
+                            lambda: pipeline.translate_fallback(english),
+                            durations,
+                            statuses,
+                        )
+                        chinese = str(fallback_value).strip()
+                        route = "argos"
+
+                    output_value = self._stage(
+                        "output_normalization",
+                        lambda: pipeline.normalize_output(chinese, english),
+                        durations,
+                        statuses,
+                    )
+                    output = str(output_value).strip()
+                    if not output:
+                        raise VLMExecutionError("empty_vlm_output")
+                    encoded_output = output.encode("utf-8")
+                    output_sha256 = hashlib.sha256(encoded_output).hexdigest()
+                    output_length = len(output)
+            except VLMExecutionError as exc:
+                outcome = ExecutionOutcome.ERROR
+                error_code = exc.code
+            except Exception as exc:
+                outcome = ExecutionOutcome.ERROR
+                error_code = "vlm_pipeline_" + type(exc).__name__.lower()
+                error_code = "".join(
+                    character if character.isalnum() else "_"
+                    for character in error_code
+                )[:64]
+            finally:
+                if pipeline is not None:
+                    try:
+                        with contextlib.redirect_stdout(
+                            io.StringIO()
+                        ), contextlib.redirect_stderr(io.StringIO()):
+                            self._stage(
+                                "model_unload",
+                                pipeline.unload_model,
+                                durations,
+                                statuses,
+                            )
+                    except Exception:
+                        outcome = ExecutionOutcome.ERROR
+                        error_code = "model_unload_failed"
+                if (
+                    "input_verify_before" in statuses
+                    and statuses["input_verify_before"] == "ok"
+                ):
+                    try:
+                        self._stage(
+                            "input_verify_after",
+                            lambda: self._verify_claimed_input(claimed),
+                            durations,
+                            statuses,
+                        )
+                    except Exception:
+                        outcome = ExecutionOutcome.ERROR
+                        error_code = "input_changed_during_execution"
+
+            return self._result(
+                claimed,
+                outcome=outcome,
+                error_code=error_code,
+                output_sha256=output_sha256,
+                output_length=output_length,
+                route=route,
+                durations=durations,
+                statuses=statuses,
+            )
+        finally:
+            self._invocation_lock.release()

--- a/experiments/phase1/vlm_preflight.py
+++ b/experiments/phase1/vlm_preflight.py
@@ -1,0 +1,319 @@
+"""Fail-closed Jetson and service checks for the Phase 1 VLM slice."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Callable, Mapping
+
+from experiments.phase1.jetson_preflight import (
+    build_jetson_preflight,
+    preflight_errors,
+)
+from experiments.phase1.vlm_adapter import (
+    C100_INPUT_MEDIA_TYPE,
+    C100_INPUT_SHA256,
+    C100_INPUT_SIZE_BYTES,
+)
+from jetson.phase1_runtime import PayloadRef
+
+
+VLM_PREFLIGHT_SCHEMA_VERSION = "0.1.0"
+_LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
+_REQUIRED_CHECKS = {
+    "fixed_input_identity",
+    "python_dependencies_available",
+    "ollama_endpoint_local",
+    "ollama_cli_available",
+    "ollama_service_reachable",
+    "moondream_model_present",
+    "qwen_endpoint_local",
+    "qwen_service_reachable",
+    "qwen_model_present",
+}
+
+
+def _local_endpoint(url: str) -> bool:
+    parts = urllib.parse.urlsplit(url)
+    return parts.scheme == "http" and parts.hostname in _LOCAL_HOSTS
+
+
+def _read_json(url: str, *, timeout_s: float = 5.0) -> dict[str, object]:
+    request = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout_s) as response:
+        value = json.loads(response.read().decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("service response is not an object")
+    return value
+
+
+def _llama_models_url(api_url: str) -> str:
+    parts = urllib.parse.urlsplit(api_url)
+    prefix = parts.path.split("/v1/", 1)[0]
+    return urllib.parse.urlunsplit(
+        (parts.scheme, parts.netloc, f"{prefix}/v1/models", "", "")
+    )
+
+
+def probe_vlm_services(
+    *,
+    query: Callable[[str], dict[str, object]] = _read_json,
+) -> dict[str, object]:
+    """Probe local model services without importing the VLM implementation."""
+
+    from jetson.config import LLAMA_API_URL, OLLAMA_CHAT_URL, VLM_MODEL
+
+    ollama: dict[str, object] = {
+        "endpoint_local": _local_endpoint(OLLAMA_CHAT_URL),
+        "reachable": False,
+        "model": VLM_MODEL,
+        "model_present": False,
+        "model_digest": None,
+        "error_code": None,
+    }
+    if ollama["endpoint_local"] is not True:
+        ollama["error_code"] = "nonlocal_endpoint"
+    else:
+        try:
+            models = query(OLLAMA_CHAT_URL.rsplit("/", 1)[0] + "/tags").get(
+                "models", []
+            )
+            if not isinstance(models, list):
+                raise ValueError("Ollama models is not a list")
+            ollama["reachable"] = True
+            selected = next(
+                (
+                    item
+                    for item in models
+                    if isinstance(item, Mapping)
+                    and item.get("name") in {VLM_MODEL, f"{VLM_MODEL}:latest"}
+                ),
+                None,
+            )
+            if selected is not None:
+                ollama["model_present"] = True
+                digest = selected.get("digest")
+                if isinstance(digest, str) and digest:
+                    ollama["model_digest"] = digest
+        except Exception as exc:
+            ollama["error_code"] = type(exc).__name__.lower()
+
+    qwen: dict[str, object] = {
+        "endpoint_local": _local_endpoint(LLAMA_API_URL),
+        "reachable": False,
+        "model": "qwen",
+        "model_present": False,
+        "served_model_ids": [],
+        "error_code": None,
+    }
+    if qwen["endpoint_local"] is not True:
+        qwen["error_code"] = "nonlocal_endpoint"
+    else:
+        try:
+            models = query(_llama_models_url(LLAMA_API_URL)).get("data", [])
+            if not isinstance(models, list):
+                raise ValueError("llama.cpp models is not a list")
+            qwen["reachable"] = True
+            identifiers = sorted(
+                {
+                    item.get("id")
+                    for item in models
+                    if isinstance(item, Mapping)
+                    and isinstance(item.get("id"), str)
+                    and item.get("id")
+                }
+            )
+            qwen["served_model_ids"] = identifiers[:4]
+            qwen["model_present"] = bool(identifiers)
+        except Exception as exc:
+            qwen["error_code"] = type(exc).__name__.lower()
+
+    dependencies = {
+        name: importlib.util.find_spec(name) is not None
+        for name in ("argostranslate", "cv2")
+    }
+    return {
+        "ollama": ollama,
+        "qwen": qwen,
+        "python_dependencies": dependencies,
+        "ollama_cli_available": shutil.which("ollama") is not None,
+    }
+
+
+def _check(
+    name: str,
+    passed: bool,
+    *,
+    observed: object,
+    requirement: str,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "required": True,
+        "passed": passed,
+        "observed": observed,
+        "requirement": requirement,
+    }
+
+
+def build_vlm_preflight(
+    repo_root: Path | str,
+    *,
+    input_payload: PayloadRef,
+    expected_branch: str = "main",
+    base_preflight: Mapping[str, object] | None = None,
+    services: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Build the complete platform, input and local-service eligibility record."""
+
+    if not isinstance(input_payload, PayloadRef):
+        raise TypeError("input_payload must be a PayloadRef")
+    base = dict(
+        base_preflight
+        if base_preflight is not None
+        else build_jetson_preflight(repo_root, expected_branch=expected_branch)
+    )
+    observed_services = dict(services or probe_vlm_services())
+    ollama = observed_services.get("ollama")
+    qwen = observed_services.get("qwen")
+    dependencies = observed_services.get("python_dependencies")
+    ollama_cli_available = observed_services.get("ollama_cli_available")
+    ollama_record = ollama if isinstance(ollama, Mapping) else {}
+    qwen_record = qwen if isinstance(qwen, Mapping) else {}
+    dependency_record = dependencies if isinstance(dependencies, Mapping) else {}
+    input_identity = {
+        "sha256": input_payload.sha256,
+        "size_bytes": input_payload.size_bytes,
+        "media_type": input_payload.media_type,
+    }
+    input_matches = input_identity == {
+        "sha256": C100_INPUT_SHA256,
+        "size_bytes": C100_INPUT_SIZE_BYTES,
+        "media_type": C100_INPUT_MEDIA_TYPE,
+    }
+    checks = [
+        _check(
+            "fixed_input_identity",
+            input_matches,
+            observed=input_identity,
+            requirement="input matches the frozen Phase 0 C100 image",
+        ),
+        _check(
+            "python_dependencies_available",
+            dependency_record.get("argostranslate") is True
+            and dependency_record.get("cv2") is True,
+            observed=dict(dependency_record),
+            requirement="Argos Translate and OpenCV packages are installed",
+        ),
+        _check(
+            "ollama_endpoint_local",
+            ollama_record.get("endpoint_local") is True,
+            observed=ollama_record.get("endpoint_local"),
+            requirement="the Ollama endpoint is loopback-only",
+        ),
+        _check(
+            "ollama_cli_available",
+            ollama_cli_available is True,
+            observed=ollama_cli_available,
+            requirement="the Ollama CLI is available for the unload request",
+        ),
+        _check(
+            "ollama_service_reachable",
+            ollama_record.get("reachable") is True,
+            observed={
+                "reachable": ollama_record.get("reachable"),
+                "error_code": ollama_record.get("error_code"),
+            },
+            requirement="the local Ollama service answers its model query",
+        ),
+        _check(
+            "moondream_model_present",
+            ollama_record.get("model_present") is True,
+            observed={
+                "model": ollama_record.get("model"),
+                "model_present": ollama_record.get("model_present"),
+                "model_digest": ollama_record.get("model_digest"),
+            },
+            requirement="the configured Moondream model is installed",
+        ),
+        _check(
+            "qwen_endpoint_local",
+            qwen_record.get("endpoint_local") is True,
+            observed=qwen_record.get("endpoint_local"),
+            requirement="the Qwen rewrite endpoint is loopback-only",
+        ),
+        _check(
+            "qwen_service_reachable",
+            qwen_record.get("reachable") is True,
+            observed={
+                "reachable": qwen_record.get("reachable"),
+                "error_code": qwen_record.get("error_code"),
+            },
+            requirement="the local llama.cpp service answers its model query",
+        ),
+        _check(
+            "qwen_model_present",
+            qwen_record.get("model_present") is True,
+            observed={
+                "model": qwen_record.get("model"),
+                "model_present": qwen_record.get("model_present"),
+                "served_model_ids": qwen_record.get("served_model_ids"),
+            },
+            requirement="the local rewrite endpoint exposes a model identity",
+        ),
+    ]
+    base_errors = preflight_errors(base)
+    return {
+        "vlm_preflight_schema_version": VLM_PREFLIGHT_SCHEMA_VERSION,
+        "expected_branch": expected_branch,
+        "base": base,
+        "input": input_identity,
+        "services": observed_services,
+        "checks": checks,
+        "eligible": not base_errors
+        and all(check["passed"] is True for check in checks),
+    }
+
+
+def vlm_preflight_errors(preflight: Mapping[str, object]) -> list[str]:
+    errors: list[str] = []
+    if preflight.get("vlm_preflight_schema_version") != VLM_PREFLIGHT_SCHEMA_VERSION:
+        errors.append("unsupported VLM preflight schema version")
+    base = preflight.get("base")
+    if not isinstance(base, Mapping):
+        errors.append("VLM preflight base record is missing")
+    else:
+        errors.extend(f"base: {error}" for error in preflight_errors(base))
+    checks = preflight.get("checks")
+    check_by_name: dict[str, Mapping[str, object]] = {}
+    if not isinstance(checks, list):
+        errors.append("VLM preflight checks are missing")
+    else:
+        for item in checks:
+            if not isinstance(item, Mapping):
+                errors.append("VLM preflight check is not an object")
+                continue
+            name = item.get("name")
+            if not isinstance(name, str) or name in check_by_name:
+                errors.append(f"VLM preflight check name is invalid: {name!r}")
+                continue
+            check_by_name[name] = item
+            if item.get("required") is not True or item.get("passed") is not True:
+                errors.append(f"VLM preflight check failed: {name}")
+    if set(check_by_name) != _REQUIRED_CHECKS:
+        errors.append("VLM preflight check set is incomplete or unsupported")
+
+    input_identity = preflight.get("input")
+    if input_identity != {
+        "sha256": C100_INPUT_SHA256,
+        "size_bytes": C100_INPUT_SIZE_BYTES,
+        "media_type": C100_INPUT_MEDIA_TYPE,
+    }:
+        errors.append("VLM preflight input identity does not match Phase 0")
+    if preflight.get("eligible") is not (not errors):
+        errors.append("VLM preflight eligibility is inconsistent")
+    return errors

--- a/experiments/phase1/vlm_slice.py
+++ b/experiments/phase1/vlm_slice.py
@@ -1,0 +1,358 @@
+"""Single-request orchestration for the fixed-input Phase 1 VLM slice."""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+from jetson.phase1_runtime import (
+    BoundedTaskBroker,
+    BrokerSnapshot,
+    ExecutorShutdownReport,
+    FinalDisposition,
+    LaneConfig,
+    ObservableExecutor,
+    OverflowPolicy,
+    PayloadRef,
+    PeriodicProbe,
+    ProbeStopReport,
+    RuntimeEventSink,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+)
+
+from .vlm_adapter import FixedInputVLMAdapter, VLMExecutionRecord
+
+
+class VLMSliceCondition(str, Enum):
+    """The first two real-workload correctness conditions."""
+
+    ASYNC = "vlm_async"
+    STALE = "vlm_stale"
+
+
+def _finite_seconds(value: object, name: str, *, positive: bool = False) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+        or (positive and value <= 0)
+    ):
+        qualifier = "positive" if positive else "non-negative"
+        raise ValueError(f"{name} must be a finite {qualifier} number")
+    return float(value)
+
+
+@dataclass(frozen=True, slots=True)
+class VLMSliceSpec:
+    """Frozen controls for one real VLM request."""
+
+    condition: VLMSliceCondition
+    result_validity_s: float = 900.0
+    completion_timeout_s: float = 720.0
+    join_timeout_s: float = 720.0
+    probe_join_timeout_s: float = 5.0
+    prelude_s: float = 1.0
+    postlude_s: float = 1.0
+    probe_period_ns: int = 100_000_000
+    probe_deadline_ns: int = 100_000_000
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.condition, VLMSliceCondition):
+            raise TypeError("condition must be a VLMSliceCondition")
+        for field_name in (
+            "result_validity_s",
+            "completion_timeout_s",
+            "join_timeout_s",
+            "probe_join_timeout_s",
+        ):
+            _finite_seconds(getattr(self, field_name), field_name, positive=True)
+        for field_name in ("prelude_s", "postlude_s"):
+            _finite_seconds(getattr(self, field_name), field_name)
+        for field_name in ("probe_period_ns", "probe_deadline_ns"):
+            value = getattr(self, field_name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{field_name} must be a positive integer")
+        if self.result_validity_s <= self.completion_timeout_s:
+            raise ValueError("result_validity_s must exceed completion_timeout_s")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "condition": self.condition.value,
+            "task_kind": TaskKind.VLM.value,
+            "request_count": 1,
+            "pending_capacity": 1,
+            "result_capacity": 1,
+            "overflow_policy": OverflowPolicy.REJECT_NEW.value,
+            "result_validity_s": self.result_validity_s,
+            "completion_timeout_s": self.completion_timeout_s,
+            "join_timeout_s": self.join_timeout_s,
+            "probe_join_timeout_s": self.probe_join_timeout_s,
+            "prelude_s": self.prelude_s,
+            "postlude_s": self.postlude_s,
+            "probe_period_ns": self.probe_period_ns,
+            "probe_deadline_ns": self.probe_deadline_ns,
+            "state_advance_after_inference_start": (
+                self.condition is VLMSliceCondition.STALE
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class VLMSliceReport:
+    """Closed runtime, probe and adapter facts for one request."""
+
+    condition: VLMSliceCondition
+    task_id: str
+    state_advanced: bool
+    consumed: bool
+    final_disposition: str
+    adapter: VLMExecutionRecord
+    shutdown: ExecutorShutdownReport
+    probe: ProbeStopReport
+    final_snapshot: BrokerSnapshot
+
+    def to_dict(self) -> dict[str, object]:
+        snapshot = self.final_snapshot
+        return {
+            "condition": self.condition.value,
+            "task_id": self.task_id,
+            "state_advanced": self.state_advanced,
+            "consumed": self.consumed,
+            "final_disposition": self.final_disposition,
+            "adapter": self.adapter.to_dict(),
+            "shutdown": {
+                "complete": self.shutdown.complete,
+                "broker_state": self.shutdown.broker_state.value,
+                "joined": self.shutdown.joined,
+                "join_latency_ns": self.shutdown.join_latency_ns,
+                "active_cancellation_requested": (
+                    self.shutdown.active_cancellation_requested
+                ),
+                "worker_error_code": self.shutdown.worker_error_code,
+                "event_error_code": self.shutdown.event_error_code,
+            },
+            "probe": {
+                "joined": self.probe.joined,
+                "tick_count": self.probe.tick_count,
+                "skipped_releases": self.probe.skipped_releases,
+                "deadline_miss_count": self.probe.deadline_miss_count,
+                "max_lateness_ns": self.probe.max_lateness_ns,
+                "max_gap_ns": self.probe.max_gap_ns,
+                "error_code": self.probe.error_code,
+            },
+            "final_snapshot": {
+                "state": snapshot.state.value,
+                "submission_attempts": snapshot.submission_attempts,
+                "admitted_total": snapshot.admitted_total,
+                "terminal_admitted_total": snapshot.terminal_admitted_total,
+                "queued": snapshot.queued,
+                "running": snapshot.running,
+                "result_pending": snapshot.result_pending,
+                "max_pending_depth": snapshot.max_pending_depth,
+                "max_result_depth": snapshot.max_result_depth,
+                "disposition_counts": {
+                    key.value: value for key, value in snapshot.disposition_counts
+                },
+                "accounting_holds": snapshot.accounting_holds,
+            },
+        }
+
+
+def make_vlm_task(
+    payload: PayloadRef,
+    *,
+    state_token: StateToken,
+    task_id: str,
+    result_validity_s: float,
+    clock_ns: Callable[[], int] = time.monotonic_ns,
+) -> TaskEnvelope:
+    """Create the only request admitted by one Phase 1C run."""
+
+    if not isinstance(payload, PayloadRef):
+        raise TypeError("payload must be a PayloadRef")
+    validity = _finite_seconds(
+        result_validity_s,
+        "result_validity_s",
+        positive=True,
+    )
+    now = clock_ns()
+    return TaskEnvelope(
+        task_id=task_id,
+        task_kind=TaskKind.VLM,
+        source_monotonic_ns=now,
+        created_monotonic_ns=now,
+        deadline_monotonic_ns=now + int(validity * 1_000_000_000),
+        state_token=state_token,
+        payload=payload,
+        supersession_key="vlm-latest",
+        metadata={
+            "protocol": "phase1c",
+            "fixed_input": True,
+            "raw_output_recorded": False,
+        },
+    )
+
+
+def _wait_for(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float,
+    description: str,
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        threading.Event().wait(0.01)
+    raise TimeoutError(f"timed out waiting for {description}")
+
+
+def _sleep(seconds: float) -> None:
+    if seconds > 0:
+        threading.Event().wait(seconds)
+
+
+def _final_disposition(snapshot: BrokerSnapshot) -> FinalDisposition:
+    nonzero = [
+        disposition for disposition, count in snapshot.disposition_counts if count > 0
+    ]
+    if len(nonzero) != 1 or snapshot.terminal_admitted_total != 1:
+        raise RuntimeError("VLM slice did not close with one final disposition")
+    return nonzero[0]
+
+
+def run_vlm_slice(
+    spec: VLMSliceSpec,
+    payload: PayloadRef,
+    event_sink: RuntimeEventSink,
+    *,
+    adapter: FixedInputVLMAdapter | None = None,
+    task_id: str = "vlm-001",
+) -> VLMSliceReport:
+    """Run one nominal or invalidated VLM request and close all threads."""
+
+    if not isinstance(spec, VLMSliceSpec):
+        raise TypeError("spec must be a VLMSliceSpec")
+    if not isinstance(payload, PayloadRef):
+        raise TypeError("payload must be a PayloadRef")
+    if not callable(getattr(event_sink, "emit", None)):
+        raise TypeError("event_sink must provide emit(event)")
+    resolved_adapter = adapter or FixedInputVLMAdapter()
+    if not callable(resolved_adapter):
+        raise TypeError("adapter must be callable")
+
+    broker = BoundedTaskBroker(
+        LaneConfig(
+            task_kind=TaskKind.VLM,
+            pending_capacity=1,
+            result_capacity=1,
+            overflow_policy=OverflowPolicy.REJECT_NEW,
+        )
+    )
+    executor = ObservableExecutor(
+        broker,
+        resolved_adapter,
+        event_sink=event_sink,
+        worker_name="phase1-vlm-worker",
+    )
+    probe = PeriodicProbe(
+        period_ns=spec.probe_period_ns,
+        deadline_ns=spec.probe_deadline_ns,
+        event_sink=event_sink,
+        thread_name="phase1-vlm-probe",
+    )
+    task = make_vlm_task(
+        payload,
+        state_token=broker.current_state_token("vlm-slice"),
+        task_id=task_id,
+        result_validity_s=spec.result_validity_s,
+    )
+
+    executor.start()
+    probe.start()
+    shutdown: ExecutorShutdownReport | None = None
+    probe_report: ProbeStopReport | None = None
+    state_advanced = False
+    consumed = False
+    try:
+        _sleep(spec.prelude_s)
+        submission = executor.submit(task)
+        if not submission.admitted:
+            raise RuntimeError("the single VLM request was not admitted")
+
+        if spec.condition is VLMSliceCondition.STALE:
+            if not resolved_adapter.inference_started_event.wait(
+                spec.completion_timeout_s
+            ):
+                raise TimeoutError("VLM inference did not reach its start boundary")
+            executor.advance_state(
+                "vlm-slice",
+                reason="fixed_input_state_change",
+            )
+            state_advanced = True
+
+        _wait_for(
+            lambda: (
+                executor.snapshot().result_pending == 1
+                or executor.snapshot().terminal_admitted_total == 1
+            ),
+            timeout_s=spec.completion_timeout_s,
+            description="the VLM result decision",
+        )
+
+        if spec.condition is VLMSliceCondition.ASYNC:
+            decision = executor.consume_next()
+            if decision is None or not decision.consumed:
+                raise RuntimeError("nominal VLM result was not consumed")
+            consumed = True
+        elif executor.consume_next() is not None:
+            raise RuntimeError("invalidated VLM result entered the result mailbox")
+
+        _sleep(spec.postlude_s)
+        shutdown = executor.shutdown(
+            cancel_live=False,
+            join_timeout_s=spec.join_timeout_s,
+        )
+    finally:
+        if shutdown is None and executor.is_alive:
+            shutdown = executor.shutdown(
+                cancel_live=True,
+                join_timeout_s=spec.join_timeout_s,
+            )
+        probe_report = probe.stop(join_timeout_s=spec.probe_join_timeout_s)
+
+    if shutdown is None or not shutdown.complete:
+        raise RuntimeError("VLM executor did not shut down cleanly")
+    if probe_report is None or not probe_report.joined:
+        raise RuntimeError("VLM periodic probe did not join")
+    adapter_record = resolved_adapter.last_record
+    if adapter_record is None or adapter_record.task_id != task.task_id:
+        raise RuntimeError("VLM adapter did not publish a matching execution record")
+
+    final_snapshot = executor.snapshot()
+    disposition = _final_disposition(final_snapshot)
+    if spec.condition is VLMSliceCondition.ASYNC:
+        if disposition is not FinalDisposition.CONSUMED or not consumed:
+            raise RuntimeError("nominal VLM task did not finish as consumed")
+    else:
+        if disposition is not FinalDisposition.REJECTED_STATE or consumed:
+            raise RuntimeError("stale VLM task escaped state rejection")
+
+    return VLMSliceReport(
+        condition=spec.condition,
+        task_id=task.task_id,
+        state_advanced=state_advanced,
+        consumed=consumed,
+        final_disposition=disposition.value,
+        adapter=adapter_record,
+        shutdown=shutdown,
+        probe=probe_report,
+        final_snapshot=final_snapshot,
+    )

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -1,10 +1,10 @@
 # Jetson Runtime
 
-The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel, which is not yet connected to the robot application or model services.
+The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel. The experiment layer now connects that kernel to the fixed Phase 0 VLM input without changing the robot application.
 
-The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. A portable simulated-condition runner and host-tested Jetson pilot harness are available under `experiments/phase1/`, but the Jetson pilot and application integration remain research work.
+The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. The portable simulated-condition runner and Jetson pilot harness under `experiments/phase1/` have completed one motion-disabled, independently validated simulation pilot. The fixed-input VLM runner is implemented and host-tested; its Jetson execution and application integration remain research work.
 
-> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 的 host-only worker 与周期探针尚未接入真实模型或运动控制。
+> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 已完成固定输入 VLM 接入的主机测试，但尚未进行 Jetson 实机采集，也未接入运动控制。
 
 ## Modules
 
@@ -112,7 +112,7 @@ Audio, ASR text, captured images and communication logs are written beneath `ROB
 ## Baseline limitations
 
 - The orchestration path is blocking and single-process; inference tasks do not have explicit deadlines or cancellation.
-- The Phase 1 host-only kernel is not yet connected to acquisition, inference services, TTS or the synchronous application loop.
+- The Phase 1 VLM experiment uses one fixed file and is not connected to live acquisition, TTS or the synchronous application loop.
 - llama.cpp and Ollama are managed outside the application.
 - The color tracker uses fixed HSV ranges and discrete motion commands tuned on the thesis robot.
 - The Jetson sends speed percentages, while the STM32 applies open-loop PWM rather than closed-loop wheel velocity.


### PR DESCRIPTION
## Summary

This PR advances Phase 1 through two connected increments:

- adds deterministic post-run analysis for the Jetson simulation pilot and checks in a reproducible derived report
- introduces a fixed-C100-input VLM asynchronous vertical slice with lazy model-service initialization
- extends the runtime contract and experiment documentation for execution, observability, validation, and safety behavior

## Runtime behavior

- supports `vlm_async` and `vlm_stale` execution scenarios
- adds Jetson, model-service, and safety preflight checks
- captures continuous `tegrastats` resource telemetry
- writes run artifacts atomically and provides independent summary and validation commands
- prevents stale VLM results from affecting runtime state by recording them as `rejected_state`

## Safety and data handling

- keeps physical motion disabled with `ROBOT_ENABLE_MOTION=0`
- does not modify UART, STM32, or physical-motion paths
- does not persist model-generated text or private local paths
- reports only directly observed behavior and does not claim confirmed GPU inference, model offloading, or model-execution cancellation

## Validation

- Phase 0 tests: 29 passed
- Phase 1 tests: 99 passed
- total automated tests: 128 passed
- Black: 41 Phase 1 Python files checked
- Pyflakes and `compileall`: passed
- Phase 1 JSON Schemas: valid
- public Markdown links: valid
- changed text files: UTF-8, LF, and no BOM