### PR TITLE
feat(phase1): analyze VLM pilot and harden preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository began with my bachelor's thesis on speech interaction and visual perception for a wheeled robot. The thesis system runs fully local speech and vision pipelines on a Jetson Orin Nano, while an STM32F407 executes motion commands and enforces a communication watchdog. The same platform will now be used to study how long-running perception and inference can coexist with predictable control timing.
 
-> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立有界运行时、可观测 worker、周期探针和模拟实验运行器，完成首次 Jetson simulation pilot 及独立验证，并通过固定输入 VLM 接入的主机测试；真实模型实机采集和整机应用适配尚未开始。
+> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立有界运行时、可观测 worker、周期探针和模拟实验运行器，完成 Jetson simulation pilot 和固定输入 VLM correctness pilot；真实模型正式对比实验与整机应用适配尚未开始。
 
 ## Project status
 
@@ -15,7 +15,7 @@ This repository began with my bachelor's thesis on speech interaction and visual
 | Bachelor's thesis software and firmware | Complete and hardware validated |
 | Custom base-driver PCB | Published and tested on the physical robot |
 | Jetson–STM32 command link | Validated with ACK/error responses and a 1.2 s command watchdog |
-| Asynchronous inference runtime | Bounded executor, probe and replay validated by a Jetson simulation pilot; fixed-input VLM runner host-tested, with Jetson execution pending |
+| Asynchronous inference runtime | Bounded executor, probe and replay validated by Jetson simulation and fixed-input VLM correctness pilots; formal comparison pending |
 
 The validated Jetson–STM32 code is preserved at [`v0.1.0-thesis-baseline`](https://github.com/yuzhang-robotics/embodied-robot-heterogeneous-control/tree/v0.1.0-thesis-baseline). The current `main` branch also includes the reviewed hardware documentation and editable PCB export.
 
@@ -68,11 +68,15 @@ simulated-condition runner. A fail-closed Jetson preflight, continuous
 `tegrastats` recorder and pilot-session validator are also implemented. A
 motion-disabled Jetson simulation pilot completed all session Gates; its
 [descriptive report](experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/)
-separates timing-domain isolation from the additional bounded-runtime
-semantics. A fixed-input Moondream/Qwen adapter, single-request nominal/stale
-runner and independent validator are now host-tested, but have not yet been
-executed on the Jetson. Neither milestone authorizes a performance-superiority
-claim. The broader research stage will investigate:
+separates simulated timing behavior from the additional bounded-runtime
+semantics. A fixed-input Moondream/Qwen correctness pilot also completed both
+nominal consumption and old-generation rejection. Its
+[descriptive report](experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/)
+shows that all skipped releases occurred during lazy module import in the
+independent Python probe, so thread-level timing isolation does not generalize
+from the simulated sleep workload. Neither pilot authorizes a
+performance-superiority, hard-real-time or heterogeneous-inference claim. The
+broader research stage will investigate:
 
 - independent acquisition, inference, planning and control workers;
 - timestamped bounded queues, cancellation and stale-result rejection;

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -106,9 +106,12 @@ pilot-session validator have also completed one motion-disabled simulation
 pilot on the Jetson. The independently reconstructed
 [descriptive result](../../experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/)
 validates the evidence chain and runtime semantics, but it is not a real-model
-or formal performance result. The fixed-input VLM adapter and its nominal/stale
-single-request evidence path are host-tested; Jetson execution is the next
-Gate.
+or formal performance result. The fixed-input VLM adapter has since completed
+one nominal/stale correctness pilot on the Jetson. Its independently derived
+[report](../../experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/)
+confirms stale-result rejection while also recording module-import-scale gaps
+in the threaded periodic probe. Process-level isolation or an equivalent
+mitigation must therefore be evaluated before timing isolation is claimed.
 
 ## Evaluation plan
 

--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -4,20 +4,23 @@ This document defines the correctness and safety contract for the first
 asynchronous runtime used by the Octopus robot research platform. The
 host-only model, broker, observable executor, periodic probes, trace replay and
 portable simulation protocol have been implemented. One motion-disabled Jetson
-simulation pilot has validated the protocol and runtime semantics. The first
-fixed-input VLM adapter and runner are host-tested; real-model Jetson execution
-and formal performance behavior remain unvalidated.
+simulation pilot has validated the protocol and runtime semantics. A
+fixed-input VLM correctness pilot has also completed nominal consumption and
+old-generation rejection on the Jetson. Formal performance behavior remains
+unvalidated.
 
 > 中文简介：本文冻结 Phase 1 异步运行时的任务模型、生命周期、队列、取消、结果新鲜度、
 > 快速周期代理和安全边界。host-only worker、周期探针、trace replay 和模拟实验运行器已实现；
-> Jetson simulation pilot 已完成并通过独立验证；固定输入 VLM 接入已通过主机测试，
-> 真实模型实机运行和正式实验仍需按 Gate 逐步完成。
+> Jetson simulation pilot 与固定输入 VLM correctness pilot 已完成并通过独立验证；
+> 正式同步/异步对比实验仍需按 Gate 逐步完成。
 
 ## Status
 
-- Phase: Phase 1C fixed-input VLM implementation; Jetson execution pending
-- Contract status: frozen through one independently validated Jetson simulation
-  pilot
+- Phase: Phase 1C fixed-input VLM pilot analysis and evidence hardening
+- Contract status: frozen through independently validated Jetson simulation
+  and fixed-input VLM correctness pilots
+- VLM-pilot result: `main@aebd1a2`, session
+  `20260830T073825Z_phase1_vlm_pilot`
 - Jetson-pilot result: `main@77138f2`, session `20260828T121142Z_phase1_jetson_pilot`
 - Jetson-pilot harness starting point: `main@844b633`
 - Simulation-runner starting point: `main@4514d97`
@@ -44,12 +47,16 @@ The current implementation includes:
 - fail-closed Jetson preflight, a continuous non-daemon `tegrastats` sampler,
   an immutable pilot matrix and independent session reconstruction;
 - a lazy fixed-input VLM adapter, nominal/stale single-request orchestration,
-  model-service preflight, resource trace and independent run validation.
+  model-service preflight, resource trace and independent run validation;
+- deterministic VLM-pilot reconstruction and fail-closed recording of actual
+  model-service listener bindings for subsequent runs.
 
-The VLM implementation has not yet run on the Jetson and it does not include
-formal performance data. The completed simulation pilot remains descriptive
-protocol evidence and does not authorize an asynchronous-performance,
-hard-real-time or heterogeneous-inference claim.
+The VLM pilot includes no formal performance data. It validates the real-model
+integration and result-freshness path, while its skipped probe releases show
+that the simulated sleep result cannot be generalized to every Python worker
+thread workload. Neither completed pilot authorizes an
+asynchronous-performance, hard-real-time, timing-isolation or
+heterogeneous-inference claim.
 
 ## Research objective
 
@@ -439,7 +446,11 @@ The probe is a software scheduling proxy, not a motor controller.
 Both probe paths and their pure release/tick calculations are implemented. The
 inline path advances on the caller thread and therefore records releases
 skipped while a direct synchronous adapter call owns that thread. The threaded
-path advances independently. Both invoke the same scenario adapter contract.
+path has independent ownership, but it still shares the Python process and GIL.
+The fixed-input VLM pilot consequently recorded skipped releases during lazy
+module import even though inference ran in the worker thread. Thread ownership
+alone is not accepted as evidence of timing isolation. Both paths invoke the
+same scenario adapter contract.
 
 ## Event and replay requirements
 
@@ -657,6 +668,10 @@ direct and bounded-runtime conditions recorded no skipped releases. R4 rejected
 one old-state result, bounded pending and result depth at one, and consumed zero
 stale results.
 
+That result is specific to the simulated adapter, whose service delay releases
+the interpreter. It demonstrates the intended ownership and evidence path but
+does not prove that a Python thread isolates real adapters that hold the GIL.
+
 The public
 [derived report](../../experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/)
 also records the limits discovered by the pilot. It contains one fixed-order
@@ -700,16 +715,44 @@ stdout/stderr.
 Before creating a run directory, preflight requires the existing Jetson safety
 and synchronized-`main` checks plus the fixed input, local-only Ollama and
 llama.cpp endpoints, installed Moondream and Qwen model identities, and the
-Ollama CLI plus OpenCV/Argos dependencies. A completed manifest additionally
-requires resource coverage during the adapter interval, valid replay, exactly one terminal
-disposition, zero stale consumption, a returned model-unload request,
-worker/probe/sampler joins,
-artifact hashes and an independently rebuilt summary.
+Ollama CLI plus OpenCV/Argos dependencies. Preflight schema `0.2.0` queries the
+numeric TCP listeners with `ss`, records only their bound addresses and fails
+if either service has no listener or any wildcard/non-loopback binding. The
+validator retains read support for the first pilot's `0.1.0` record without
+inventing listener evidence that was not archived. A completed manifest
+additionally requires resource coverage during the adapter interval, valid
+replay, exactly one terminal disposition, zero stale consumption, a returned
+model-unload request, worker/probe/sampler joins, artifact hashes and an
+independently rebuilt summary.
 
 The host implementation and fault-injection tests do not count as a real-model
 result. The first Jetson runs remain descriptive correctness evidence. They do
 not measure visual accuracy, compare synchronous and asynchronous performance,
 prove GPU preemption or authorize a heterogeneous-compute performance claim.
+
+### First fixed-input VLM pilot outcome
+
+Session `20260830T073825Z_phase1_vlm_pilot` ran one `vlm_async` request and one
+`vlm_stale` request on `main@aebd1a2`. Both independently validate. The nominal
+result was consumed exactly once; the old-generation result completed as
+`cancel_observed`, was recorded once as `rejected_state`, and was never
+consumed. Both used the Qwen rewrite route, kept raw model text out of the
+artifacts and returned a Moondream unload request without claiming confirmed
+eviction.
+
+The 100 ms probe recorded 85 skipped releases and a 4262.876 ms maximum gap in
+`vlm_async`, then 63 skipped releases and a 2700.375 ms maximum gap in
+`vlm_stale`. Reconstruction assigns every skipped release to the lazy
+`module_import` interval. The real-model pilot therefore passes its lifecycle
+correctness Gates but does not pass a timing-isolation interpretation. A
+process-level worker or an equivalent mitigation must be evaluated before the
+formal protocol is frozen.
+
+The source runs used VLM preflight schema `0.1.0`. The operator bound
+llama.cpp to `127.0.0.1` and checked it before execution, but the archived
+preflight records only the configured loopback request URL. The derived report
+marks actual listener evidence incomplete. New runs use schema `0.2.0` and fail
+closed on the observed bindings.
 
 ## Gates
 
@@ -730,6 +773,7 @@ The fixed-input VLM slice adds these zero-tolerance Gates:
 - Moondream, one translation route, normalization and the unload call close;
 - the artifact records an unload request without claiming confirmed eviction;
 - raw model text and the private input path are absent from public artifacts;
+- model-service TCP listeners are present and bound only to loopback addresses;
 - `vlm_async` consumes exactly one result;
 - `vlm_stale` records exactly one `rejected_state` and zero accepted results;
 - cancellation evidence does not claim backend stop without confirmation;

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -4,13 +4,13 @@ This directory contains the host tests, simulated-condition runner, trace
 recorder, event schema, independent lifecycle replay, run validation, Jetson
 pilot orchestration, deterministic analysis, fixed-input VLM integration and
 descriptive summaries for the Phase 1 asynchronous runtime study. The first
-Jetson simulation pilot is complete. The VLM slice is implemented and
-host-tested, but its Jetson runs and all formal Phase 1 data remain uncollected.
+Jetson simulation pilot and fixed-input VLM correctness pilot are complete.
+Formal synchronous/asynchronous data remain uncollected.
 
 > 中文简介：本目录用于 Phase 1 异步运行时研究。当前已实现 host-only 有界 broker、
 > 单 worker 执行层、100 ms 周期探针、独立 trace replay、模拟条件运行器和 Jetson
-> pilot 证据链，并完成首次 Jetson simulation pilot 及确定性分析；固定输入 VLM
-> 适配器和证据链已通过主机测试，Jetson 实机运行与 Phase 1 正式数据尚未采集。
+> pilot 证据链，并完成 Jetson simulation pilot 与固定输入 VLM correctness pilot；
+> 当前已验证真实模型接入和陈旧结果拒绝，正式对比数据尚未采集。
 
 ## Current status
 
@@ -25,8 +25,9 @@ host-tested, but its Jetson runs and all formal Phase 1 data remain uncollected.
 - Jetson preflight, continuous resource telemetry and pilot runner: implemented
 - Jetson simulation pilot: completed and independently validated
 - Deterministic pilot analysis and public descriptive report: implemented
-- Fixed-input VLM adapter, single-request runner and validator: host-tested;
-  Jetson execution pending
+- Fixed-input VLM adapter, single-request runner and validator: completed one
+  independently validated Jetson correctness pilot
+- Deterministic VLM pilot analysis and listener-binding preflight: implemented
 - Real ASR/LLM slices: not started
 - Formal Phase 1 data: not collected
 - Physical motion and UART: excluded
@@ -200,6 +201,14 @@ does not authorize an asynchronous-performance or hard-real-time claim.
 Condition-level power summaries use instantaneous rail samples; the
 `tegrastats`-reported average is retained only as a session-window diagnostic.
 
+The second public derived result is the
+[`20260830T073825Z` fixed-input VLM pilot](results/20260830T073825Z_phase1_vlm_pilot/).
+Both real-model conditions passed their correctness Gates, but the periodic
+probe recorded 85 and 63 skipped releases respectively. All skipped releases
+were scheduled during lazy module import. The result therefore validates
+nominal consumption and stale-result rejection while explicitly withholding a
+thread-level timing-isolation claim.
+
 ## Fixed-input VLM slice
 
 The first real-workload integration reuses the exact Phase 0 C100 JPEG, the
@@ -222,8 +231,7 @@ reject the completed result. Public artifacts retain only input identity,
 output hash and length, translation route, stage durations and lifecycle
 facts. Model text, prompts and the private input path are not serialized.
 
-After this implementation is merged, run each condition from a clean,
-synchronized Jetson `main` branch:
+Reproduce each condition from a clean, synchronized Jetson `main` branch:
 
 ```bash
 export ROBOT_ENABLE_MOTION=0
@@ -239,13 +247,32 @@ python3 -m experiments.phase1.run_vlm_slice \
 ```
 
 The runner refuses to create a directory unless platform, Git, motion, module,
-fixed-input, dependency, Ollama CLI, Moondream and Qwen checks all pass. Each
-run contains `preflight.json`, the event and resource JSONL traces, `scenario.json`,
+fixed-input, dependency, Ollama CLI, Moondream and Qwen checks all pass. VLM
+preflight schema `0.2.0` also records the TCP listener addresses and rejects a
+service bound to a wildcard or non-loopback address. Each run contains
+`preflight.json`, the event and resource JSONL traces, `scenario.json`,
 `summary.json` and an atomic manifest. Validate either directory again with:
 
 ```bash
 python3 -m experiments.phase1.validate_vlm_slice /path/to/run_dir
 ```
+
+Build deterministic derivatives from a two-condition ignored session with:
+
+```bash
+python3 -m experiments.phase1.analyze_vlm_pilot \
+  /path/to/session_dir \
+  --source-archive-sha256 <archive_sha256> \
+  --json-output /path/to/analysis.json \
+  --markdown-output /path/to/README.md
+```
+
+The first VLM pilot was collected under preflight schema `0.1.0`. Its request
+URLs were loopback addresses, and the operator checked the llama.cpp listener
+before execution, but actual listener bindings were not stored in the archive.
+The public analysis retains that evidence gap rather than converting the
+manual observation into a reproducible claim. The validator remains able to
+read the original schema while new runs fail closed under `0.2.0`.
 
 These two runs establish integration and stale-result correctness only. They
 do not form a balanced synchronous/asynchronous comparison, prove backend
@@ -265,11 +292,14 @@ claim.
    pilot session validation — complete;
 6. run and independently analyze the safe Jetson simulation pilot with
    `ROBOT_ENABLE_MOTION=0` — complete;
-7. implement and host-test the fixed-input VLM slice — complete; Jetson
-   execution pending;
-8. extend the same adapter/runtime boundary to ASR and LLM;
-9. freeze formal thresholds and collect balanced synchronous/asynchronous data;
-10. add an opt-in motion-disabled application slice after the research Gates
+7. implement, run and independently analyze the fixed-input VLM correctness
+   slice — complete;
+8. record actual model-service listener bindings and qualify the simulated
+   thread-isolation result with real-workload evidence — complete;
+9. evaluate process-level isolation, then extend the adapter/runtime boundary
+   to ASR and LLM;
+10. freeze formal thresholds and collect balanced synchronous/asynchronous data;
+11. add an opt-in motion-disabled application slice after the research Gates
    pass.
 
 Contract changes are reviewed before implementation, and the formal protocol
@@ -298,6 +328,7 @@ The reusable, hardware-independent kernel lives under
 
 ```text
 experiments/phase1/
+├── analyze_vlm_pilot.py
 ├── jetson_preflight.py
 ├── jetson_telemetry.py
 ├── manifest.py

--- a/experiments/phase1/analyze_jetson_pilot.py
+++ b/experiments/phase1/analyze_jetson_pilot.py
@@ -852,9 +852,11 @@ def render_markdown(analysis: Mapping[str, object]) -> str:
             "",
             (
                 "The pilot shows that an inline slow call creates a control-proxy "
-                "gap on the same scale as the configured service time. A separate "
-                "thread is sufficient for timing-domain isolation, while the bounded "
-                "runtime adds explicit queue, cancellation and freshness behavior."
+                "gap on the same scale as the configured service time. For this "
+                "simulated delay, a separate thread preserved the probe schedule, "
+                "while the bounded runtime added explicit queue, cancellation and "
+                "freshness behavior. This result does not establish isolation for "
+                "real adapters that hold the Python GIL."
             ),
             "",
             (

--- a/experiments/phase1/analyze_vlm_pilot.py
+++ b/experiments/phase1/analyze_vlm_pilot.py
@@ -1,0 +1,860 @@
+"""Build a deterministic descriptive report from one validated VLM pilot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from experiments.phase1.jetson_telemetry import load_resource_samples
+from experiments.phase1.validate_vlm_slice import validate_vlm_slice_dir
+
+
+ANALYSIS_SCHEMA_VERSION = "0.1.0"
+EXPECTED_CONDITIONS = ("vlm_async", "vlm_stale")
+_EXPECTED_RUN_FILES = {
+    "events.jsonl",
+    "manifest.json",
+    "preflight.json",
+    "resources.jsonl",
+    "scenario.json",
+    "summary.json",
+}
+_STAGE_ORDER = (
+    "input_verify_before",
+    "module_import",
+    "moondream_inference",
+    "qwen_rewrite",
+    "argos_fallback",
+    "output_normalization",
+    "model_unload",
+    "input_verify_after",
+)
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.name} must contain a JSON object")
+    return value
+
+
+def _read_events(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), 1
+    ):
+        value = json.loads(line)
+        if not isinstance(value, dict):
+            raise ValueError(f"{path.name}:{line_number} is not a JSON object")
+        events.append(value)
+    if not events:
+        raise ValueError(f"{path.name} contains no events")
+    return events
+
+
+def _mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _integer(value: object, name: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{name} must be an integer not less than {minimum}")
+    return value
+
+
+def _number(value: object, name: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+    ):
+        raise ValueError(f"{name} must be finite and numeric")
+    return float(value)
+
+
+def _milliseconds(value: object, name: str) -> float:
+    return round(_number(value, name) / 1_000_000.0, 6)
+
+
+def _metric_value(
+    summary: Mapping[str, object],
+    metric: str,
+    field: str,
+) -> float | None:
+    value = summary.get(metric)
+    if value is None:
+        return None
+    record = _mapping(value, f"resource metric {metric}")
+    observed = record.get(field)
+    if observed is None:
+        return None
+    return round(_number(observed, f"resource metric {metric}.{field}"), 6)
+
+
+def _find_run_directories(session_dir: Path) -> dict[str, Path]:
+    observed = sorted(path.name for path in session_dir.iterdir())
+    if observed != sorted(EXPECTED_CONDITIONS) or not all(
+        (session_dir / condition).is_dir() for condition in EXPECTED_CONDITIONS
+    ):
+        raise ValueError(
+            "VLM pilot must contain exactly vlm_async and vlm_stale directories"
+        )
+    runs: dict[str, Path] = {}
+    for condition in EXPECTED_CONDITIONS:
+        candidates = sorted((session_dir / condition).iterdir())
+        if len(candidates) != 1 or not candidates[0].is_dir():
+            raise ValueError(f"{condition} must contain exactly one run directory")
+        runs[condition] = candidates[0]
+    return runs
+
+
+def _disposition_counts(lifecycle: Mapping[str, object]) -> dict[str, int]:
+    items = lifecycle.get("disposition_counts")
+    if not isinstance(items, list):
+        raise ValueError("lifecycle disposition_counts must be a list")
+    result: dict[str, int] = {}
+    for item in items:
+        if not isinstance(item, list) or len(item) != 2 or not isinstance(item[0], str):
+            raise ValueError("lifecycle disposition count is invalid")
+        result[item[0]] = _integer(item[1], "lifecycle disposition count")
+    return result
+
+
+def _stage_records(adapter: Mapping[str, object]) -> list[dict[str, object]]:
+    durations = _mapping(adapter.get("stage_durations_ns"), "adapter stage durations")
+    statuses = _mapping(adapter.get("stage_status"), "adapter stage status")
+    started_ns = _integer(adapter.get("started_monotonic_ns"), "adapter start")
+    cursor = started_ns
+    rows: list[dict[str, object]] = []
+    for stage in _STAGE_ORDER:
+        if stage not in durations:
+            continue
+        duration_ns = _integer(durations.get(stage), f"stage duration {stage}")
+        rows.append(
+            {
+                "stage": stage,
+                "status": statuses.get(stage),
+                "duration_ms": _milliseconds(duration_ns, f"stage duration {stage}"),
+                "start_monotonic_ns": cursor,
+                "finish_monotonic_ns": cursor + duration_ns,
+            }
+        )
+        cursor += duration_ns
+    if not rows:
+        raise ValueError("adapter contains no stage durations")
+    return rows
+
+
+def _skipped_release_attribution(
+    events: Sequence[Mapping[str, object]],
+    stages: Sequence[Mapping[str, object]],
+    expected_total: int,
+) -> dict[str, int]:
+    started = next(
+        (event for event in events if event.get("event") == "probe.started"), None
+    )
+    if started is None:
+        raise ValueError("event trace contains no probe.started event")
+    details = _mapping(started.get("details"), "probe.started details")
+    origin_ns = _integer(details.get("origin_monotonic_ns"), "probe origin")
+    period_ns = _integer(details.get("period_ns"), "probe period", minimum=1)
+    counts: Counter[str] = Counter()
+    observed_total = 0
+    for event in events:
+        if event.get("event") != "probe.skipped":
+            continue
+        skipped = _mapping(event.get("details"), "probe.skipped details")
+        first = _integer(skipped.get("from_index"), "first skipped release")
+        last = _integer(skipped.get("to_index"), "last skipped release")
+        count = _integer(skipped.get("skipped_releases"), "skipped release count")
+        if last - first != count:
+            raise ValueError("probe.skipped index range does not match its count")
+        observed_total += count
+        for tick_index in range(first, last):
+            scheduled_ns = origin_ns + tick_index * period_ns
+            stage_name = "unattributed"
+            for stage in stages:
+                start_ns = _integer(stage.get("start_monotonic_ns"), "stage start")
+                finish_ns = _integer(stage.get("finish_monotonic_ns"), "stage finish")
+                if start_ns <= scheduled_ns < finish_ns:
+                    stage_name = str(stage.get("stage"))
+                    break
+            counts[stage_name] += 1
+    if observed_total != expected_total:
+        raise ValueError("probe skipped-release events do not match the probe report")
+    return {name: counts[name] for name in sorted(counts)}
+
+
+def _probe_record(
+    scenario: Mapping[str, object],
+    events: Sequence[Mapping[str, object]],
+    stages: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    report = _mapping(scenario.get("report"), "scenario report")
+    probe = _mapping(report.get("probe"), "scenario probe report")
+    spec = _mapping(scenario.get("spec"), "scenario spec")
+    ticks = _integer(probe.get("tick_count"), "probe tick count")
+    skipped = _integer(probe.get("skipped_releases"), "probe skipped releases")
+    scheduled = ticks + skipped
+    return {
+        "period_ms": _milliseconds(spec.get("probe_period_ns"), "probe period"),
+        "deadline_ms": _milliseconds(spec.get("probe_deadline_ns"), "probe deadline"),
+        "tick_count": ticks,
+        "skipped_releases": skipped,
+        "scheduled_release_count": scheduled,
+        "skipped_release_rate": round(skipped / scheduled, 9) if scheduled else None,
+        "deadline_miss_count": _integer(
+            probe.get("deadline_miss_count"), "probe deadline misses"
+        ),
+        "max_lateness_ms": _milliseconds(
+            probe.get("max_lateness_ns"), "probe maximum lateness"
+        ),
+        "maximum_observed_gap_ms": _milliseconds(
+            probe.get("max_gap_ns"), "probe maximum gap"
+        ),
+        "joined": probe.get("joined") is True,
+        "error_code": probe.get("error_code"),
+        "skipped_releases_by_adapter_stage": _skipped_release_attribution(
+            events,
+            stages,
+            skipped,
+        ),
+    }
+
+
+def _warning_counts(samples: Sequence[Mapping[str, object]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for sample in samples:
+        warnings = sample.get("parse_warnings")
+        if not isinstance(warnings, list):
+            raise ValueError("resource sample parse_warnings must be a list")
+        if not all(isinstance(item, str) for item in warnings):
+            raise ValueError("resource parse warning must be a string")
+        counts.update(warnings)
+    return {name: counts[name] for name in sorted(counts)}
+
+
+def _resource_record(
+    summary: Mapping[str, object],
+    samples: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    resources = _mapping(summary.get("resources"), "summary resources")
+    description = _mapping(resources.get("summary"), "resource summary")
+    return {
+        "sample_count": _integer(
+            description.get("sample_count"), "resource sample count"
+        ),
+        "inference_interval_sample_count": _integer(
+            resources.get("inference_interval_sample_count"),
+            "inference resource sample count",
+        ),
+        "parse_error_count": _integer(
+            description.get("parse_error_count"), "resource parse error count"
+        ),
+        "parse_warning_counts": _warning_counts(samples),
+        "sample_interval_ms": {
+            field: (
+                round(value / 1_000_000.0, 6)
+                if (value := _metric_value(description, "sample_interval_ns", field))
+                is not None
+                else None
+            )
+            for field in ("mean", "p95", "p99", "max")
+        },
+        "ram_used_mb": {
+            field: _metric_value(description, "ram_used_mb", field)
+            for field in ("mean", "p95", "max")
+        },
+        "gr3d_usage_pct": {
+            field: _metric_value(description, "gr3d_usage_pct", field)
+            for field in ("mean", "p95", "max")
+        },
+        "junction_temperature_c": {
+            field: _metric_value(
+                _mapping(description.get("temperatures_c"), "temperature summary"),
+                "tj",
+                field,
+            )
+            for field in ("mean", "p95", "max")
+        },
+        "vdd_in_instant_mw": {
+            field: _metric_value(
+                _mapping(description.get("power_instant_mw"), "power summary"),
+                "VDD_IN",
+                field,
+            )
+            for field in ("mean", "p95", "max")
+        },
+    }
+
+
+def _listener_evidence(preflight: Mapping[str, object]) -> dict[str, object]:
+    version = preflight.get("vlm_preflight_schema_version")
+    services = _mapping(preflight.get("services"), "preflight services")
+    records: dict[str, object] = {}
+    complete = version == "0.2.0"
+    for name in ("ollama", "qwen"):
+        service = _mapping(services.get(name), f"{name} service")
+        addresses = service.get("listener_addresses")
+        loopback_only = service.get("listener_loopback_only")
+        recorded = (
+            isinstance(addresses, list)
+            and all(isinstance(item, str) for item in addresses)
+            and bool(addresses)
+            and loopback_only is True
+        )
+        records[name] = {
+            "recorded": recorded,
+            "addresses": addresses if recorded else [],
+            "loopback_only": loopback_only if recorded else None,
+        }
+        complete = complete and recorded
+    return {
+        "preflight_schema_version": version,
+        "complete": complete,
+        "services": records,
+    }
+
+
+def _run_record(condition: str, run_dir: Path) -> dict[str, object]:
+    observed_files = {path.name for path in run_dir.iterdir() if path.is_file()}
+    if observed_files != _EXPECTED_RUN_FILES or any(
+        not path.is_file() for path in run_dir.iterdir()
+    ):
+        raise ValueError(f"{condition} run files do not match the evidence contract")
+    errors = validate_vlm_slice_dir(run_dir)
+    if errors:
+        raise ValueError(f"invalid {condition} run: " + "; ".join(errors))
+    manifest = _read_object(run_dir / "manifest.json")
+    preflight = _read_object(run_dir / "preflight.json")
+    scenario = _read_object(run_dir / "scenario.json")
+    summary = _read_object(run_dir / "summary.json")
+    events = _read_events(run_dir / "events.jsonl")
+    samples = load_resource_samples(run_dir / "resources.jsonl")
+    if manifest.get("condition") != condition or summary.get("condition") != condition:
+        raise ValueError(f"{condition} directory contains a different condition")
+    adapter = _mapping(summary.get("adapter"), "summary adapter")
+    lifecycle = _mapping(summary.get("lifecycle"), "summary lifecycle")
+    stages = _stage_records(adapter)
+    started_ns = _integer(adapter.get("started_monotonic_ns"), "adapter start")
+    finished_ns = _integer(adapter.get("finished_monotonic_ns"), "adapter finish")
+    environment = _mapping(manifest.get("environment"), "manifest environment")
+    git = _mapping(environment.get("git"), "manifest Git identity")
+    services = _mapping(preflight.get("services"), "preflight services")
+    ollama = _mapping(services.get("ollama"), "Ollama service")
+    qwen = _mapping(services.get("qwen"), "Qwen service")
+    gates = summary.get("gates")
+    if not isinstance(gates, list) or not all(
+        isinstance(gate, Mapping) for gate in gates
+    ):
+        raise ValueError("summary gates must be a list of objects")
+    return {
+        "condition": condition,
+        "run_id": manifest.get("run_id"),
+        "session_id": manifest.get("session_id"),
+        "source": {
+            "git_commit": git.get("commit"),
+            "git_branch": git.get("branch"),
+            "artifacts": manifest.get("artifacts"),
+        },
+        "input": manifest.get("input"),
+        "services": {
+            "moondream_model": ollama.get("model"),
+            "moondream_digest": ollama.get("model_digest"),
+            "qwen_model_ids": qwen.get("served_model_ids"),
+            "listener_evidence": _listener_evidence(preflight),
+        },
+        "validation": {
+            "manifest_status": manifest.get("status"),
+            "summary_valid": summary.get("valid") is True,
+            "all_gates_passed": all(gate.get("passed") is True for gate in gates),
+            "real_vlm_path_executed": summary.get("real_vlm_path_executed") is True,
+        },
+        "result": {
+            "execution_outcome": adapter.get("execution_outcome"),
+            "translation_route": adapter.get("translation_route"),
+            "disposition_counts": _disposition_counts(lifecycle),
+            "accepted_result_count": _integer(
+                lifecycle.get("accepted_result_count"), "accepted result count"
+            ),
+            "stale_consumed_count": _integer(
+                lifecycle.get("stale_consumed_count"), "stale consumed count"
+            ),
+            "raw_text_recorded": _mapping(adapter.get("output"), "adapter output").get(
+                "raw_text_recorded"
+            ),
+            "model_unload": adapter.get("model_residency"),
+            "cancellation": adapter.get("cancellation"),
+        },
+        "timing": {
+            "adapter_total_ms": _milliseconds(
+                finished_ns - started_ns, "adapter total duration"
+            ),
+            "stages": [
+                {
+                    "stage": stage["stage"],
+                    "status": stage["status"],
+                    "duration_ms": stage["duration_ms"],
+                }
+                for stage in stages
+            ],
+            "probe": _probe_record(scenario, events, stages),
+        },
+        "resources": _resource_record(summary, samples),
+    }
+
+
+def _same_value(runs: Sequence[Mapping[str, object]], path: Sequence[str]) -> object:
+    values: list[object] = []
+    for run in runs:
+        current: object = run
+        for key in path:
+            current = _mapping(current, ".".join(path)).get(key)
+        values.append(current)
+    if any(value != values[0] for value in values[1:]):
+        raise ValueError(f"runs disagree on {'.'.join(path)}")
+    return values[0]
+
+
+def analyze_vlm_pilot_dir(
+    session_dir: Path | str,
+    *,
+    source_archive_sha256: str | None = None,
+) -> dict[str, object]:
+    """Validate and reconstruct one two-condition real-model VLM pilot."""
+
+    directory = Path(session_dir).resolve()
+    if not directory.is_dir():
+        raise ValueError("VLM pilot session directory does not exist")
+    normalized_hash: str | None = None
+    if source_archive_sha256 is not None:
+        normalized_hash = source_archive_sha256.lower()
+        if _SHA256_RE.fullmatch(normalized_hash) is None:
+            raise ValueError("source_archive_sha256 must contain 64 hexadecimal digits")
+    run_dirs = _find_run_directories(directory)
+    runs = [
+        _run_record(condition, run_dirs[condition]) for condition in EXPECTED_CONDITIONS
+    ]
+    session_id = _same_value(runs, ("session_id",))
+    if session_id != directory.name:
+        raise ValueError("run session_id does not match the session directory")
+    git_commit = _same_value(runs, ("source", "git_commit"))
+    git_branch = _same_value(runs, ("source", "git_branch"))
+    input_identity = _same_value(runs, ("input",))
+    moondream_digest = _same_value(runs, ("services", "moondream_digest"))
+    qwen_models = _same_value(runs, ("services", "qwen_model_ids"))
+
+    async_run, stale_run = runs
+    correctness_observed = (
+        async_run["result"]["disposition_counts"] == {"consumed": 1}
+        and async_run["result"]["accepted_result_count"] == 1
+        and stale_run["result"]["disposition_counts"] == {"rejected_state": 1}
+        and stale_run["result"]["accepted_result_count"] == 0
+        and all(run["result"]["stale_consumed_count"] == 0 for run in runs)
+    )
+    listener_complete = all(
+        run["services"]["listener_evidence"]["complete"] is True for run in runs
+    )
+    skipped_total = sum(run["timing"]["probe"]["skipped_releases"] for run in runs)
+    limitations = [
+        "single_run_per_condition",
+        "fixed_condition_order",
+        "no_real_workload_synchronous_condition",
+        "formal_thresholds_not_frozen",
+        "model_unload_not_independently_confirmed",
+        "resource_activity_not_attributed_to_a_model_or_processor",
+    ]
+    if not listener_complete:
+        limitations.append("listener_binding_evidence_not_recorded")
+    if skipped_total:
+        limitations.append("probe_skipped_releases_observed")
+    if all(
+        run["resources"]["parse_warning_counts"].get("emc_missing", 0)
+        == run["resources"]["sample_count"]
+        for run in runs
+    ):
+        limitations.append("emc_unavailable")
+
+    return {
+        "analysis_schema_version": ANALYSIS_SCHEMA_VERSION,
+        "analysis_kind": "phase1_fixed_input_vlm_pilot",
+        "session_id": session_id,
+        "source": {
+            "git_commit": git_commit,
+            "git_branch": git_branch,
+            "source_archive_sha256": normalized_hash,
+            "run_artifacts": {
+                run["condition"]: run["source"]["artifacts"] for run in runs
+            },
+        },
+        "identity": {
+            "input": input_identity,
+            "moondream_digest": moondream_digest,
+            "qwen_model_ids": qwen_models,
+        },
+        "claim_boundary": {
+            "design_role": "correctness_pilot",
+            "descriptive_only": True,
+            "real_workload_integration_observed": all(
+                run["validation"]["real_vlm_path_executed"] is True for run in runs
+            ),
+            "stale_result_rejection_observed": correctness_observed,
+            "timing_domain_isolation_claim_permitted": False,
+            "asynchronous_performance_superiority_claim_permitted": False,
+            "hard_real_time_claim_permitted": False,
+            "heterogeneous_inference_claim_permitted": False,
+            "condition_resource_attribution_permitted": False,
+        },
+        "validation": {
+            "run_count": len(runs),
+            "all_runs_valid": all(
+                run["validation"]["summary_valid"] is True
+                and run["validation"]["all_gates_passed"] is True
+                for run in runs
+            ),
+            "correctness_observed": correctness_observed,
+            "listener_binding_evidence_complete": listener_complete,
+        },
+        "runs": runs,
+        "data_quality": {
+            "total_probe_skipped_releases": skipped_total,
+            "limitations": limitations,
+        },
+    }
+
+
+def _format_number(value: object, digits: int = 3) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (int, float)):
+        return f"{value:.{digits}f}" if isinstance(value, float) else str(value)
+    return str(value)
+
+
+def _stage_duration(run: Mapping[str, object], name: str) -> object:
+    timing = _mapping(run.get("timing"), "run timing")
+    stages = timing.get("stages")
+    if not isinstance(stages, list):
+        raise ValueError("run timing stages must be a list")
+    for stage in stages:
+        if isinstance(stage, Mapping) and stage.get("stage") == name:
+            return stage.get("duration_ms")
+    return None
+
+
+def _render_dispositions(value: object) -> str:
+    record = _mapping(value, "disposition counts")
+    return ", ".join(f"{name}={record[name]}" for name in sorted(record))
+
+
+def render_markdown(analysis: Mapping[str, object]) -> str:
+    """Render the machine-readable analysis without adding new claims."""
+
+    source = _mapping(analysis.get("source"), "analysis source")
+    identity = _mapping(analysis.get("identity"), "analysis identity")
+    validation = _mapping(analysis.get("validation"), "analysis validation")
+    quality = _mapping(analysis.get("data_quality"), "analysis data quality")
+    runs_value = analysis.get("runs")
+    if not isinstance(runs_value, list) or not all(
+        isinstance(run, Mapping) for run in runs_value
+    ):
+        raise ValueError("analysis runs must be a list of objects")
+    runs: list[Mapping[str, object]] = list(runs_value)
+    input_identity = _mapping(identity.get("input"), "analysis input identity")
+    qwen_ids = identity.get("qwen_model_ids")
+    lines = [
+        "# Phase 1 Fixed-input VLM Pilot",
+        "",
+        (
+            "This report records one motion-disabled correctness pilot on the Jetson "
+            "Orin Nano. It validates real-model integration and stale-result rejection; "
+            "it is not a synchronous/asynchronous performance comparison."
+        ),
+        "",
+        "## Evidence boundary",
+        "",
+        "- Workload: one fixed Phase 0 C100 image per condition.",
+        "- Conditions: one `vlm_async` run followed by one `vlm_stale` run.",
+        "- Model path: Ollama/Moondream description followed by llama.cpp/Qwen rewriting.",
+        "- Physical motion and UART access: disabled.",
+        "- Permitted interpretation: integration and lifecycle correctness evidence only.",
+        (
+            "- Not permitted: asynchronous superiority, hard-real-time, timing-isolation "
+            "or heterogeneous-inference claims."
+        ),
+        "",
+        "## Provenance",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Session | `{analysis.get('session_id')}` |",
+        f"| Source commit | `{source.get('git_commit')}` |",
+        f"| Source branch | `{source.get('git_branch')}` |",
+        f"| Transfer archive SHA-256 | `{source.get('source_archive_sha256')}` |",
+        f"| Independently valid runs | {_format_number(validation.get('all_runs_valid'))} |",
+        "",
+        "Machine-readable derived data: [`analysis.json`](analysis.json).",
+        "",
+        "## Frozen identities",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Input SHA-256 | `{input_identity.get('sha256')}` |",
+        f"| Input size | {_format_number(input_identity.get('size_bytes'))} bytes |",
+        f"| Moondream digest | `{identity.get('moondream_digest')}` |",
+        f"| Qwen model | `{', '.join(qwen_ids) if isinstance(qwen_ids, list) else qwen_ids}` |",
+        "",
+        "## Correctness results",
+        "",
+        "| Condition | Execution | Route | Disposition | Accepted | Stale consumed | Gates |",
+        "| --- | --- | --- | --- | ---: | ---: | --- |",
+    ]
+    for run in runs:
+        result = _mapping(run.get("result"), "run result")
+        run_validation = _mapping(run.get("validation"), "run validation")
+        lines.append(
+            "| `{condition}` | `{outcome}` | `{route}` | {dispositions} | {accepted} | "
+            "{stale} | {gates} |".format(
+                condition=run.get("condition"),
+                outcome=result.get("execution_outcome"),
+                route=result.get("translation_route"),
+                dispositions=_render_dispositions(result.get("disposition_counts")),
+                accepted=_format_number(result.get("accepted_result_count")),
+                stale=_format_number(result.get("stale_consumed_count")),
+                gates=(
+                    "pass" if run_validation.get("all_gates_passed") is True else "fail"
+                ),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            (
+                "The nominal result was consumed once. After the state generation "
+                "advanced, the stale result completed but was rejected before consumption. "
+                "Backend stop remains unconfirmed by design."
+            ),
+            "",
+            "## Pipeline timing",
+            "",
+            "| Condition | Adapter total (ms) | Module import | Moondream | Qwen | Unload |",
+            "| --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        timing = _mapping(run.get("timing"), "run timing")
+        lines.append(
+            "| `{condition}` | {total} | {module} | {moondream} | {qwen} | {unload} |".format(
+                condition=run.get("condition"),
+                total=_format_number(timing.get("adapter_total_ms")),
+                module=_format_number(_stage_duration(run, "module_import")),
+                moondream=_format_number(_stage_duration(run, "moondream_inference")),
+                qwen=_format_number(_stage_duration(run, "qwen_rewrite")),
+                unload=_format_number(_stage_duration(run, "model_unload")),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "These single, fixed-order observations are descriptive and are not compared inferentially.",
+            "",
+            "## Periodic-probe observations",
+            "",
+            (
+                "The probe used a 100 ms absolute schedule. Skipped releases are "
+                "reported separately from callbacks that started after their deadline."
+            ),
+            "",
+            "| Condition | Ticks | Skipped | Skip rate (%) | Deadline misses | Max lateness (ms) | Max gap (ms) |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        probe = _mapping(
+            _mapping(run.get("timing"), "run timing").get("probe"), "run probe"
+        )
+        lines.append(
+            "| `{condition}` | {ticks} | {skipped} | {rate} | {misses} | {lateness} | {gap} |".format(
+                condition=run.get("condition"),
+                ticks=_format_number(probe.get("tick_count")),
+                skipped=_format_number(probe.get("skipped_releases")),
+                rate=_format_number(
+                    (
+                        100.0 * probe["skipped_release_rate"]
+                        if probe.get("skipped_release_rate") is not None
+                        else None
+                    )
+                ),
+                misses=_format_number(probe.get("deadline_miss_count")),
+                lateness=_format_number(probe.get("max_lateness_ms")),
+                gap=_format_number(probe.get("maximum_observed_gap_ms")),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "Skipped-release attribution from scheduled timestamps:",
+            "",
+            "| Condition | Adapter stage | Skipped releases |",
+            "| --- | --- | ---: |",
+        ]
+    )
+    for run in runs:
+        probe = _mapping(
+            _mapping(run.get("timing"), "run timing").get("probe"), "run probe"
+        )
+        attribution = _mapping(
+            probe.get("skipped_releases_by_adapter_stage"), "skip attribution"
+        )
+        for stage, count in attribution.items():
+            lines.append(
+                f"| `{run.get('condition')}` | `{stage}` | {_format_number(count)} |"
+            )
+    lines.extend(
+        [
+            "",
+            (
+                "Both runs missed scheduled releases during lazy module import. The "
+                "simulated sleep pilot therefore does not establish that a Python worker "
+                "thread isolates every real workload. Process-level isolation or an "
+                "equivalent mitigation must be evaluated before a timing-isolation claim."
+            ),
+            "",
+            "## Resource observations",
+            "",
+            "| Condition | Samples | Covered | RAM mean/max (MB) | GR3D mean/max (%) | Tj max (C) | VDD_IN mean/max (mW) |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        resources = _mapping(run.get("resources"), "run resources")
+        ram = _mapping(resources.get("ram_used_mb"), "RAM summary")
+        gr3d = _mapping(resources.get("gr3d_usage_pct"), "GR3D summary")
+        temperature = _mapping(
+            resources.get("junction_temperature_c"), "temperature summary"
+        )
+        power = _mapping(resources.get("vdd_in_instant_mw"), "power summary")
+        lines.append(
+            "| `{condition}` | {samples} | {covered} | {ram_mean}/{ram_max} | "
+            "{gpu_mean}/{gpu_max} | {temperature} | {power_mean}/{power_max} |".format(
+                condition=run.get("condition"),
+                samples=_format_number(resources.get("sample_count")),
+                covered=_format_number(
+                    resources.get("inference_interval_sample_count")
+                ),
+                ram_mean=_format_number(ram.get("mean")),
+                ram_max=_format_number(ram.get("max")),
+                gpu_mean=_format_number(gr3d.get("mean")),
+                gpu_max=_format_number(gr3d.get("max")),
+                temperature=_format_number(temperature.get("max")),
+                power_mean=_format_number(power.get("mean")),
+                power_max=_format_number(power.get("max")),
+            )
+        )
+    limitations = quality.get("limitations")
+    if not isinstance(limitations, list):
+        raise ValueError("analysis limitations must be a list")
+    lines.extend(["", "## Evidence gaps", ""])
+    lines.extend(f"- `{item}`" for item in limitations)
+    lines.extend(
+        [
+            "",
+            (
+                "The source runs used VLM preflight schema 0.1.0, which recorded a "
+                "loopback request URL but not the TCP listener addresses. The operator "
+                "verified loopback binding before execution, but that observation is not "
+                "contained in the archived artifacts and is not elevated into a reproducible claim."
+            ),
+            "",
+            (
+                "GR3D activity confirms only that the device reported GPU activity during "
+                "the run window. The trace does not attribute activity to Moondream, Qwen "
+                "or a particular processor, so it does not authorize a heterogeneous-inference claim."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _refuse_output_inside_session(output: Path | None, session_dir: Path) -> None:
+    if output is None:
+        return
+    try:
+        output.resolve().relative_to(session_dir.resolve())
+    except ValueError:
+        return
+    raise ValueError("analysis output must not be written inside the source session")
+
+
+def _require_distinct_outputs(
+    json_output: Path | None,
+    markdown_output: Path | None,
+) -> None:
+    if (
+        json_output is not None
+        and markdown_output is not None
+        and json_output.resolve() == markdown_output.resolve()
+    ):
+        raise ValueError("JSON and Markdown outputs must use distinct paths")
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(text, encoding="utf-8", newline="\n")
+    os.replace(temporary, path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("session_dir", type=Path)
+    parser.add_argument("--source-archive-sha256")
+    parser.add_argument("--json-output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    session_dir = args.session_dir.resolve()
+    try:
+        _refuse_output_inside_session(args.json_output, session_dir)
+        _refuse_output_inside_session(args.markdown_output, session_dir)
+        _require_distinct_outputs(args.json_output, args.markdown_output)
+        analysis = analyze_vlm_pilot_dir(
+            session_dir,
+            source_archive_sha256=args.source_archive_sha256,
+        )
+        json_text = json.dumps(
+            analysis,
+            ensure_ascii=False,
+            indent=2,
+            allow_nan=False,
+        )
+        if args.json_output is not None:
+            _write_text_atomic(args.json_output, json_text + "\n")
+        else:
+            print(json_text)
+        if args.markdown_output is not None:
+            _write_text_atomic(args.markdown_output, render_markdown(analysis) + "\n")
+    except (OSError, TypeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/README.md
+++ b/experiments/phase1/results/20260828T121142Z_phase1_jetson_pilot/README.md
@@ -124,6 +124,6 @@ The screen sums per-core usage percentages and marks sustained intervals at or a
 
 ## Interpretation
 
-The pilot shows that an inline slow call creates a control-proxy gap on the same scale as the configured service time. A separate thread is sufficient for timing-domain isolation, while the bounded runtime adds explicit queue, cancellation and freshness behavior.
+The pilot shows that an inline slow call creates a control-proxy gap on the same scale as the configured service time. For this simulated delay, a separate thread preserved the probe schedule, while the bounded runtime added explicit queue, cancellation and freshness behavior. This result does not establish isolation for real adapters that hold the Python GIL.
 
 Resource differences between conditions are not attributed to the runtime because the matrix has one fixed-order repetition and the CPU screen crosses condition boundaries. The simulated adapter also does not exercise a heterogeneous inference workload. A fixed-input VLM slice and a balanced repeated protocol are required before those questions can be tested.

--- a/experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/README.md
+++ b/experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/README.md
@@ -1,0 +1,92 @@
+# Phase 1 Fixed-input VLM Pilot
+
+This report records one motion-disabled correctness pilot on the Jetson Orin Nano. It validates real-model integration and stale-result rejection; it is not a synchronous/asynchronous performance comparison.
+
+## Evidence boundary
+
+- Workload: one fixed Phase 0 C100 image per condition.
+- Conditions: one `vlm_async` run followed by one `vlm_stale` run.
+- Model path: Ollama/Moondream description followed by llama.cpp/Qwen rewriting.
+- Physical motion and UART access: disabled.
+- Permitted interpretation: integration and lifecycle correctness evidence only.
+- Not permitted: asynchronous superiority, hard-real-time, timing-isolation or heterogeneous-inference claims.
+
+## Provenance
+
+| Field | Value |
+| --- | --- |
+| Session | `20260830T073825Z_phase1_vlm_pilot` |
+| Source commit | `aebd1a22f8d9a9bfce1cd8dfd2f089e1cc48a204` |
+| Source branch | `main` |
+| Transfer archive SHA-256 | `01869a420203929bc895c589082ec1d60244b2ba2ec8865fc6249bfaf07cae23` |
+| Independently valid runs | yes |
+
+Machine-readable derived data: [`analysis.json`](analysis.json).
+
+## Frozen identities
+
+| Field | Value |
+| --- | --- |
+| Input SHA-256 | `607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7` |
+| Input size | 9009 bytes |
+| Moondream digest | `55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b` |
+| Qwen model | `qwen2.5-1.5b-instruct-q4_k_m.gguf` |
+
+## Correctness results
+
+| Condition | Execution | Route | Disposition | Accepted | Stale consumed | Gates |
+| --- | --- | --- | --- | ---: | ---: | --- |
+| `vlm_async` | `ok` | `qwen` | consumed=1 | 1 | 0 | pass |
+| `vlm_stale` | `cancel_observed` | `qwen` | rejected_state=1 | 0 | 0 | pass |
+
+The nominal result was consumed once. After the state generation advanced, the stale result completed but was rejected before consumption. Backend stop remains unconfirmed by design.
+
+## Pipeline timing
+
+| Condition | Adapter total (ms) | Module import | Moondream | Qwen | Unload |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `vlm_async` | 79757.102 | 18886.883 | 39249.051 | 21057.203 | 559.293 |
+| `vlm_stale` | 61776.670 | 15130.227 | 27933.338 | 18367.115 | 342.301 |
+
+These single, fixed-order observations are descriptive and are not compared inferentially.
+
+## Periodic-probe observations
+
+The probe used a 100 ms absolute schedule. Skipped releases are reported separately from callbacks that started after their deadline.
+
+| Condition | Ticks | Skipped | Skip rate (%) | Deadline misses | Max lateness (ms) | Max gap (ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `vlm_async` | 733 | 85 | 10.391 | 0 | 88.396 | 4262.876 |
+| `vlm_stale` | 575 | 63 | 9.875 | 0 | 93.881 | 2700.375 |
+
+Skipped-release attribution from scheduled timestamps:
+
+| Condition | Adapter stage | Skipped releases |
+| --- | --- | ---: |
+| `vlm_async` | `module_import` | 85 |
+| `vlm_stale` | `module_import` | 63 |
+
+Both runs missed scheduled releases during lazy module import. The simulated sleep pilot therefore does not establish that a Python worker thread isolates every real workload. Process-level isolation or an equivalent mitigation must be evaluated before a timing-isolation claim.
+
+## Resource observations
+
+| Condition | Samples | Covered | RAM mean/max (MB) | GR3D mean/max (%) | Tj max (C) | VDD_IN mean/max (mW) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `vlm_async` | 398 | 388 | 5344.666/6366.000 | 4.131/99.000 | 54.343 | 5778.158/16242.000 |
+| `vlm_stale` | 310 | 300 | 4978.861/5990.000 | 6.129/99.000 | 54.343 | 5962.639/16803.000 |
+
+## Evidence gaps
+
+- `single_run_per_condition`
+- `fixed_condition_order`
+- `no_real_workload_synchronous_condition`
+- `formal_thresholds_not_frozen`
+- `model_unload_not_independently_confirmed`
+- `resource_activity_not_attributed_to_a_model_or_processor`
+- `listener_binding_evidence_not_recorded`
+- `probe_skipped_releases_observed`
+- `emc_unavailable`
+
+The source runs used VLM preflight schema 0.1.0, which recorded a loopback request URL but not the TCP listener addresses. The operator verified loopback binding before execution, but that observation is not contained in the archived artifacts and is not elevated into a reproducible claim.
+
+GR3D activity confirms only that the device reported GPU activity during the run window. The trace does not attribute activity to Moondream, Qwen or a particular processor, so it does not authorize a heterogeneous-inference claim.

--- a/experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/analysis.json
+++ b/experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/analysis.json
@@ -1,0 +1,453 @@
+{
+  "analysis_schema_version": "0.1.0",
+  "analysis_kind": "phase1_fixed_input_vlm_pilot",
+  "session_id": "20260830T073825Z_phase1_vlm_pilot",
+  "source": {
+    "git_commit": "aebd1a22f8d9a9bfce1cd8dfd2f089e1cc48a204",
+    "git_branch": "main",
+    "source_archive_sha256": "01869a420203929bc895c589082ec1d60244b2ba2ec8865fc6249bfaf07cae23",
+    "run_artifacts": {
+      "vlm_async": {
+        "preflight.json": {
+          "size_bytes": 7291,
+          "sha256": "e01a7fdf6fb0ae2159babe8202d39f32ef3cbbd692bc34b3a7f96409dd209dcb"
+        },
+        "events.jsonl": {
+          "size_bytes": 429013,
+          "sha256": "ee6fff9a27069c09b699f04ed30212d6b6c11421a01d90d025ce80fb1899a2c7"
+        },
+        "resources.jsonl": {
+          "size_bytes": 523446,
+          "sha256": "15272b532b80b04ff9631839cd63f53ad35ac11f6a48a35e6ff126d3ce2c7847"
+        },
+        "scenario.json": {
+          "size_bytes": 2996,
+          "sha256": "3c15292ddd44ce7a14c6d7d2428b17d084eee2ef3c576ebe272d5aa8aa6fddba"
+        },
+        "summary.json": {
+          "size_bytes": 13850,
+          "sha256": "b706ed47d3b8fbe6f412948e46f41837b1eee81853c39158077c428333f7fc41"
+        }
+      },
+      "vlm_stale": {
+        "preflight.json": {
+          "size_bytes": 7291,
+          "sha256": "9bb70b515fc7f865034ff49aeab15697b071f384e6eae6a873fba3f9632b81f5"
+        },
+        "events.jsonl": {
+          "size_bytes": 337944,
+          "sha256": "8de5f22cad87d73f4047ccc877a4975000afe07689ad93eb1c33a5cc5c2e23ae"
+        },
+        "resources.jsonl": {
+          "size_bytes": 408804,
+          "sha256": "182371e7a4095fd66e058b599a372b64a730f7f172ebcf3f91b22f2fe0b7c3c9"
+        },
+        "scenario.json": {
+          "size_bytes": 3015,
+          "sha256": "b995065f996f85574640041378a8d9eedf827fdedff7a8dcccfdaab47ee76c2b"
+        },
+        "summary.json": {
+          "size_bytes": 13915,
+          "sha256": "35a5b66c928491993eef1a2a515b54ae1f7fd8d11ea90f8e4163b9b5a03a6ba2"
+        }
+      }
+    }
+  },
+  "identity": {
+    "input": {
+      "sha256": "607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7",
+      "size_bytes": 9009,
+      "media_type": "image/jpeg",
+      "path_recorded": false
+    },
+    "moondream_digest": "55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b",
+    "qwen_model_ids": [
+      "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+    ]
+  },
+  "claim_boundary": {
+    "design_role": "correctness_pilot",
+    "descriptive_only": true,
+    "real_workload_integration_observed": true,
+    "stale_result_rejection_observed": true,
+    "timing_domain_isolation_claim_permitted": false,
+    "asynchronous_performance_superiority_claim_permitted": false,
+    "hard_real_time_claim_permitted": false,
+    "heterogeneous_inference_claim_permitted": false,
+    "condition_resource_attribution_permitted": false
+  },
+  "validation": {
+    "run_count": 2,
+    "all_runs_valid": true,
+    "correctness_observed": true,
+    "listener_binding_evidence_complete": false
+  },
+  "runs": [
+    {
+      "condition": "vlm_async",
+      "run_id": "20260830T073825Z_phase1_vlm_async_vlm_001",
+      "session_id": "20260830T073825Z_phase1_vlm_pilot",
+      "source": {
+        "git_commit": "aebd1a22f8d9a9bfce1cd8dfd2f089e1cc48a204",
+        "git_branch": "main",
+        "artifacts": {
+          "preflight.json": {
+            "size_bytes": 7291,
+            "sha256": "e01a7fdf6fb0ae2159babe8202d39f32ef3cbbd692bc34b3a7f96409dd209dcb"
+          },
+          "events.jsonl": {
+            "size_bytes": 429013,
+            "sha256": "ee6fff9a27069c09b699f04ed30212d6b6c11421a01d90d025ce80fb1899a2c7"
+          },
+          "resources.jsonl": {
+            "size_bytes": 523446,
+            "sha256": "15272b532b80b04ff9631839cd63f53ad35ac11f6a48a35e6ff126d3ce2c7847"
+          },
+          "scenario.json": {
+            "size_bytes": 2996,
+            "sha256": "3c15292ddd44ce7a14c6d7d2428b17d084eee2ef3c576ebe272d5aa8aa6fddba"
+          },
+          "summary.json": {
+            "size_bytes": 13850,
+            "sha256": "b706ed47d3b8fbe6f412948e46f41837b1eee81853c39158077c428333f7fc41"
+          }
+        }
+      },
+      "input": {
+        "sha256": "607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7",
+        "size_bytes": 9009,
+        "media_type": "image/jpeg",
+        "path_recorded": false
+      },
+      "services": {
+        "moondream_model": "moondream",
+        "moondream_digest": "55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b",
+        "qwen_model_ids": [
+          "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+        ],
+        "listener_evidence": {
+          "preflight_schema_version": "0.1.0",
+          "complete": false,
+          "services": {
+            "ollama": {
+              "recorded": false,
+              "addresses": [],
+              "loopback_only": null
+            },
+            "qwen": {
+              "recorded": false,
+              "addresses": [],
+              "loopback_only": null
+            }
+          }
+        }
+      },
+      "validation": {
+        "manifest_status": "completed",
+        "summary_valid": true,
+        "all_gates_passed": true,
+        "real_vlm_path_executed": true
+      },
+      "result": {
+        "execution_outcome": "ok",
+        "translation_route": "qwen",
+        "disposition_counts": {
+          "consumed": 1
+        },
+        "accepted_result_count": 1,
+        "stale_consumed_count": 0,
+        "raw_text_recorded": false,
+        "model_unload": {
+          "unload_requested": true,
+          "unload_confirmed": null
+        },
+        "cancellation": {
+          "requested": false,
+          "worker_observed": false,
+          "client_wait_stopped": false,
+          "backend_stop_confirmed": null
+        }
+      },
+      "timing": {
+        "adapter_total_ms": 79757.102262,
+        "stages": [
+          {
+            "stage": "input_verify_before",
+            "status": "ok",
+            "duration_ms": 0.578042
+          },
+          {
+            "stage": "module_import",
+            "status": "ok",
+            "duration_ms": 18886.883332
+          },
+          {
+            "stage": "moondream_inference",
+            "status": "ok",
+            "duration_ms": 39249.050942
+          },
+          {
+            "stage": "qwen_rewrite",
+            "status": "ok",
+            "duration_ms": 21057.203005
+          },
+          {
+            "stage": "output_normalization",
+            "status": "ok",
+            "duration_ms": 1.483271
+          },
+          {
+            "stage": "model_unload",
+            "status": "ok",
+            "duration_ms": 559.293335
+          },
+          {
+            "stage": "input_verify_after",
+            "status": "ok",
+            "duration_ms": 1.920188
+          }
+        ],
+        "probe": {
+          "period_ms": 100.0,
+          "deadline_ms": 100.0,
+          "tick_count": 733,
+          "skipped_releases": 85,
+          "scheduled_release_count": 818,
+          "skipped_release_rate": 0.10391198,
+          "deadline_miss_count": 0,
+          "max_lateness_ms": 88.396307,
+          "maximum_observed_gap_ms": 4262.87556,
+          "joined": true,
+          "error_code": null,
+          "skipped_releases_by_adapter_stage": {
+            "module_import": 85
+          }
+        }
+      },
+      "resources": {
+        "sample_count": 398,
+        "inference_interval_sample_count": 388,
+        "parse_error_count": 0,
+        "parse_warning_counts": {
+          "emc_missing": 398
+        },
+        "sample_interval_ms": {
+          "mean": 205.982982,
+          "p95": 209.259719,
+          "p99": 777.851783,
+          "max": 4247.173457
+        },
+        "ram_used_mb": {
+          "mean": 5344.665829,
+          "p95": 6357.0,
+          "max": 6366.0
+        },
+        "gr3d_usage_pct": {
+          "mean": 4.130653,
+          "p95": 17.0,
+          "max": 99.0
+        },
+        "junction_temperature_c": {
+          "mean": 52.05656,
+          "p95": 52.531,
+          "max": 54.343
+        },
+        "vdd_in_instant_mw": {
+          "mean": 5778.158291,
+          "p95": 8213.0,
+          "max": 16242.0
+        }
+      }
+    },
+    {
+      "condition": "vlm_stale",
+      "run_id": "20260830T074339Z_phase1_vlm_stale_vlm_001",
+      "session_id": "20260830T073825Z_phase1_vlm_pilot",
+      "source": {
+        "git_commit": "aebd1a22f8d9a9bfce1cd8dfd2f089e1cc48a204",
+        "git_branch": "main",
+        "artifacts": {
+          "preflight.json": {
+            "size_bytes": 7291,
+            "sha256": "9bb70b515fc7f865034ff49aeab15697b071f384e6eae6a873fba3f9632b81f5"
+          },
+          "events.jsonl": {
+            "size_bytes": 337944,
+            "sha256": "8de5f22cad87d73f4047ccc877a4975000afe07689ad93eb1c33a5cc5c2e23ae"
+          },
+          "resources.jsonl": {
+            "size_bytes": 408804,
+            "sha256": "182371e7a4095fd66e058b599a372b64a730f7f172ebcf3f91b22f2fe0b7c3c9"
+          },
+          "scenario.json": {
+            "size_bytes": 3015,
+            "sha256": "b995065f996f85574640041378a8d9eedf827fdedff7a8dcccfdaab47ee76c2b"
+          },
+          "summary.json": {
+            "size_bytes": 13915,
+            "sha256": "35a5b66c928491993eef1a2a515b54ae1f7fd8d11ea90f8e4163b9b5a03a6ba2"
+          }
+        }
+      },
+      "input": {
+        "sha256": "607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7",
+        "size_bytes": 9009,
+        "media_type": "image/jpeg",
+        "path_recorded": false
+      },
+      "services": {
+        "moondream_model": "moondream",
+        "moondream_digest": "55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b",
+        "qwen_model_ids": [
+          "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+        ],
+        "listener_evidence": {
+          "preflight_schema_version": "0.1.0",
+          "complete": false,
+          "services": {
+            "ollama": {
+              "recorded": false,
+              "addresses": [],
+              "loopback_only": null
+            },
+            "qwen": {
+              "recorded": false,
+              "addresses": [],
+              "loopback_only": null
+            }
+          }
+        }
+      },
+      "validation": {
+        "manifest_status": "completed",
+        "summary_valid": true,
+        "all_gates_passed": true,
+        "real_vlm_path_executed": true
+      },
+      "result": {
+        "execution_outcome": "cancel_observed",
+        "translation_route": "qwen",
+        "disposition_counts": {
+          "rejected_state": 1
+        },
+        "accepted_result_count": 0,
+        "stale_consumed_count": 0,
+        "raw_text_recorded": false,
+        "model_unload": {
+          "unload_requested": true,
+          "unload_confirmed": null
+        },
+        "cancellation": {
+          "requested": true,
+          "worker_observed": true,
+          "client_wait_stopped": false,
+          "backend_stop_confirmed": null
+        }
+      },
+      "timing": {
+        "adapter_total_ms": 61776.669919,
+        "stages": [
+          {
+            "stage": "input_verify_before",
+            "status": "ok",
+            "duration_ms": 0.579519
+          },
+          {
+            "stage": "module_import",
+            "status": "ok",
+            "duration_ms": 15130.22681
+          },
+          {
+            "stage": "moondream_inference",
+            "status": "ok",
+            "duration_ms": 27933.337664
+          },
+          {
+            "stage": "qwen_rewrite",
+            "status": "ok",
+            "duration_ms": 18367.114679
+          },
+          {
+            "stage": "output_normalization",
+            "status": "ok",
+            "duration_ms": 0.043714
+          },
+          {
+            "stage": "model_unload",
+            "status": "ok",
+            "duration_ms": 342.30135
+          },
+          {
+            "stage": "input_verify_after",
+            "status": "ok",
+            "duration_ms": 2.002445
+          }
+        ],
+        "probe": {
+          "period_ms": 100.0,
+          "deadline_ms": 100.0,
+          "tick_count": 575,
+          "skipped_releases": 63,
+          "scheduled_release_count": 638,
+          "skipped_release_rate": 0.098746082,
+          "deadline_miss_count": 0,
+          "max_lateness_ms": 93.880989,
+          "maximum_observed_gap_ms": 2700.37549,
+          "joined": true,
+          "error_code": null,
+          "skipped_releases_by_adapter_stage": {
+            "module_import": 63
+          }
+        }
+      },
+      "resources": {
+        "sample_count": 310,
+        "inference_interval_sample_count": 300,
+        "parse_error_count": 0,
+        "parse_warning_counts": {
+          "emc_missing": 310
+        },
+        "sample_interval_ms": {
+          "mean": 205.874002,
+          "p95": 207.500801,
+          "p99": 545.871255,
+          "max": 2698.625859
+        },
+        "ram_used_mb": {
+          "mean": 4978.86129,
+          "p95": 5928.0,
+          "max": 5990.0
+        },
+        "gr3d_usage_pct": {
+          "mean": 6.129032,
+          "p95": 62.0,
+          "max": 99.0
+        },
+        "junction_temperature_c": {
+          "mean": 52.134081,
+          "p95": 52.625,
+          "max": 54.343
+        },
+        "vdd_in_instant_mw": {
+          "mean": 5962.63871,
+          "p95": 8451.0,
+          "max": 16803.0
+        }
+      }
+    }
+  ],
+  "data_quality": {
+    "total_probe_skipped_releases": 148,
+    "limitations": [
+      "single_run_per_condition",
+      "fixed_condition_order",
+      "no_real_workload_synchronous_condition",
+      "formal_thresholds_not_frozen",
+      "model_unload_not_independently_confirmed",
+      "resource_activity_not_attributed_to_a_model_or_processor",
+      "listener_binding_evidence_not_recorded",
+      "probe_skipped_releases_observed",
+      "emc_unavailable"
+    ]
+  }
+}

--- a/experiments/phase1/tests/test_jetson_pilot_analysis.py
+++ b/experiments/phase1/tests/test_jetson_pilot_analysis.py
@@ -240,6 +240,7 @@ class JetsonPilotAnalysisTests(unittest.TestCase):
         report = render_markdown(analysis)
         self.assertIn("not a formal performance comparison", report)
         self.assertIn("does not exercise a heterogeneous inference workload", report)
+        self.assertIn("does not establish isolation for real adapters", report)
         self.assertNotIn("statistically significant", report)
 
 

--- a/experiments/phase1/tests/test_vlm_pilot_analysis.py
+++ b/experiments/phase1/tests/test_vlm_pilot_analysis.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from experiments.phase1.analyze_vlm_pilot import (
+    analyze_vlm_pilot_dir,
+    main,
+    render_markdown,
+)
+
+
+SESSION_ID = "20260830T073825Z_phase1_vlm_pilot"
+ARCHIVE_SHA256 = "1" * 64
+
+
+def _resource_description() -> dict[str, object]:
+    metric = {
+        "count": 1,
+        "min": 1.0,
+        "mean": 2.0,
+        "median": 2.0,
+        "p50": 2.0,
+        "p95": 3.0,
+        "p99": 3.0,
+        "max": 4.0,
+    }
+    return {
+        "sample_count": 1,
+        "parse_error_count": 0,
+        "sample_interval_ns": None,
+        "ram_used_mb": metric,
+        "gr3d_usage_pct": metric,
+        "temperatures_c": {"tj": metric},
+        "power_instant_mw": {"VDD_IN": metric},
+    }
+
+
+def _write_run(session: Path, condition: str, commit: str = "a" * 40) -> Path:
+    run_id = f"20260830T000000Z_phase1_{condition}_vlm_001"
+    run_dir = session / condition / run_id
+    run_dir.mkdir(parents=True)
+    disposition = "consumed" if condition == "vlm_async" else "rejected_state"
+    outcome = "ok" if condition == "vlm_async" else "cancel_observed"
+    accepted = int(condition == "vlm_async")
+    durations = {
+        "input_verify_before": 10_000_000,
+        "module_import": 300_000_000,
+        "moondream_inference": 200_000_000,
+        "qwen_rewrite": 100_000_000,
+        "output_normalization": 10_000_000,
+        "model_unload": 10_000_000,
+        "input_verify_after": 10_000_000,
+    }
+    status = {name: "ok" for name in durations}
+    started_ns = 1_000_000_000
+    finished_ns = started_ns + sum(durations.values())
+    manifest = {
+        "run_id": run_id,
+        "session_id": SESSION_ID,
+        "condition": condition,
+        "status": "completed",
+        "environment": {
+            "git": {"commit": commit, "branch": "main"},
+        },
+        "input": {
+            "sha256": "6" * 64,
+            "size_bytes": 9009,
+            "media_type": "image/jpeg",
+            "path_recorded": False,
+        },
+        "artifacts": {"summary.json": {"sha256": "7" * 64, "size_bytes": 1}},
+    }
+    preflight = {
+        "vlm_preflight_schema_version": "0.1.0",
+        "services": {
+            "ollama": {"model": "moondream", "model_digest": "5" * 64},
+            "qwen": {"served_model_ids": ["qwen.gguf"]},
+        },
+    }
+    scenario = {
+        "spec": {"probe_period_ns": 100_000_000, "probe_deadline_ns": 100_000_000},
+        "report": {
+            "probe": {
+                "tick_count": 10,
+                "skipped_releases": 2,
+                "deadline_miss_count": 0,
+                "max_lateness_ns": 5_000_000,
+                "max_gap_ns": 300_000_000,
+                "joined": True,
+                "error_code": None,
+            }
+        },
+    }
+    summary = {
+        "condition": condition,
+        "valid": True,
+        "real_vlm_path_executed": True,
+        "adapter": {
+            "started_monotonic_ns": started_ns,
+            "finished_monotonic_ns": finished_ns,
+            "execution_outcome": outcome,
+            "translation_route": "qwen",
+            "stage_durations_ns": durations,
+            "stage_status": status,
+            "output": {"raw_text_recorded": False},
+            "model_residency": {"unload_requested": True, "unload_confirmed": None},
+            "cancellation": {
+                "requested": condition == "vlm_stale",
+                "worker_observed": condition == "vlm_stale",
+                "backend_stop_confirmed": None,
+            },
+        },
+        "lifecycle": {
+            "disposition_counts": [[disposition, 1]],
+            "accepted_result_count": accepted,
+            "stale_consumed_count": 0,
+        },
+        "resources": {
+            "inference_interval_sample_count": 1,
+            "summary": _resource_description(),
+        },
+        "gates": [{"name": "test", "passed": True}],
+    }
+    events = [
+        {
+            "event": "probe.started",
+            "details": {
+                "origin_monotonic_ns": 900_000_000,
+                "period_ns": 100_000_000,
+            },
+        },
+        {
+            "event": "probe.skipped",
+            "details": {
+                "from_index": 2,
+                "to_index": 4,
+                "skipped_releases": 2,
+            },
+        },
+    ]
+    resource = {"parse_warnings": ["emc_missing"]}
+    for name, value in (
+        ("manifest.json", manifest),
+        ("preflight.json", preflight),
+        ("scenario.json", scenario),
+        ("summary.json", summary),
+    ):
+        (run_dir / name).write_text(json.dumps(value) + "\n", encoding="utf-8")
+    (run_dir / "events.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+    (run_dir / "resources.jsonl").write_text(
+        json.dumps(resource) + "\n",
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def make_session(root: Path) -> Path:
+    session = root / SESSION_ID
+    _write_run(session, "vlm_async")
+    _write_run(session, "vlm_stale")
+    return session
+
+
+class VLMPilotAnalysisTests(unittest.TestCase):
+    def test_analysis_separates_correctness_from_timing_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = make_session(Path(temp_dir))
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                analysis = analyze_vlm_pilot_dir(
+                    session,
+                    source_archive_sha256=ARCHIVE_SHA256,
+                )
+
+        self.assertTrue(analysis["validation"]["all_runs_valid"])
+        self.assertTrue(analysis["validation"]["correctness_observed"])
+        self.assertFalse(analysis["validation"]["listener_binding_evidence_complete"])
+        self.assertFalse(
+            analysis["claim_boundary"]["timing_domain_isolation_claim_permitted"]
+        )
+        self.assertEqual(analysis["data_quality"]["total_probe_skipped_releases"], 4)
+        for run in analysis["runs"]:
+            self.assertEqual(
+                run["timing"]["probe"]["skipped_releases_by_adapter_stage"],
+                {"module_import": 2},
+            )
+
+    def test_cli_writes_deterministic_outputs_outside_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            session = make_session(root / "raw")
+            json_path = root / "published" / "analysis.json"
+            markdown_path = root / "published" / "README.md"
+            arguments = [
+                str(session),
+                "--source-archive-sha256",
+                ARCHIVE_SHA256,
+                "--json-output",
+                str(json_path),
+                "--markdown-output",
+                str(markdown_path),
+            ]
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                first_result = main(arguments)
+                first_json = json_path.read_text(encoding="utf-8")
+                first_markdown = markdown_path.read_text(encoding="utf-8")
+                second_result = main(arguments)
+                second_json = json_path.read_text(encoding="utf-8")
+                second_markdown = markdown_path.read_text(encoding="utf-8")
+                temporary_files = list(root.rglob("*.tmp"))
+
+        self.assertEqual(first_result, 0)
+        self.assertEqual(second_result, 0)
+        self.assertEqual(first_json, second_json)
+        self.assertEqual(first_markdown, second_markdown)
+        self.assertNotIn(str(session), first_json)
+        self.assertIn("# Phase 1 Fixed-input VLM Pilot", first_markdown)
+        self.assertIn(
+            "missed scheduled releases during lazy module import", first_markdown
+        )
+        self.assertNotIn("performance improvement", first_markdown)
+        self.assertFalse(temporary_files)
+
+    def test_analysis_rejects_mismatched_source_and_session_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            session = make_session(root)
+            stale_dir = next((session / "vlm_stale").iterdir())
+            manifest_path = stale_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["environment"]["git"]["commit"] = "b" * 40
+            manifest_path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                with self.assertRaisesRegex(ValueError, "runs disagree"):
+                    analyze_vlm_pilot_dir(session)
+                stderr = StringIO()
+                with redirect_stderr(stderr):
+                    result = main(
+                        [
+                            str(session),
+                            "--json-output",
+                            str(session / "analysis.json"),
+                        ]
+                    )
+
+        self.assertEqual(result, 1)
+        self.assertIn("must not be written inside", stderr.getvalue())
+
+    def test_analysis_rejects_extra_source_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = make_session(Path(temp_dir))
+            (session / "notes.txt").write_text("unexpected\n", encoding="utf-8")
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                with self.assertRaisesRegex(ValueError, "must contain exactly"):
+                    analyze_vlm_pilot_dir(session)
+
+    def test_markdown_preserves_claim_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = make_session(Path(temp_dir))
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                analysis = analyze_vlm_pilot_dir(session)
+
+        report = render_markdown(analysis)
+        self.assertIn("not a synchronous/asynchronous performance comparison", report)
+        self.assertIn("does not authorize a heterogeneous-inference claim", report)
+        self.assertNotIn("hard real-time guarantee", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_vlm_runner.py
+++ b/experiments/phase1/tests/test_vlm_runner.py
@@ -16,10 +16,16 @@ from experiments.phase1.run_vlm_slice import build_parser, run_once
 from experiments.phase1.tests.test_jetson_pilot import clean_environment
 from experiments.phase1.tests.test_jetson_telemetry import sampler_command
 from experiments.phase1.validate_vlm_slice import validate_vlm_slice_dir
-from experiments.phase1.vlm_adapter import FixedInputVLMAdapter, VLMPipeline
+from experiments.phase1.vlm_adapter import (
+    FixedInputVLMAdapter,
+    VLMPipeline,
+    fixed_c100_payload,
+)
 from experiments.phase1.vlm_preflight import (
     build_vlm_preflight,
+    probe_tcp_listener,
     probe_vlm_services,
+    vlm_preflight_errors,
 )
 from experiments.phase1.vlm_slice import VLMSliceCondition
 
@@ -36,6 +42,9 @@ def service_status() -> dict[str, object]:
             "model": "moondream",
             "model_present": True,
             "model_digest": "a" * 64,
+            "listener_addresses": ["127.0.0.1"],
+            "listener_loopback_only": True,
+            "listener_error_code": None,
             "error_code": None,
         },
         "qwen": {
@@ -44,6 +53,9 @@ def service_status() -> dict[str, object]:
             "model": "qwen",
             "model_present": True,
             "served_model_ids": ["qwen2.5-1.5b-instruct-q4_k_m.gguf"],
+            "listener_addresses": ["127.0.0.1"],
+            "listener_loopback_only": True,
+            "listener_error_code": None,
             "error_code": None,
         },
         "python_dependencies": {"argostranslate": True, "cv2": True},
@@ -155,10 +167,20 @@ class VLMRunnerTests(unittest.TestCase):
         )
 
     def test_local_service_probe_records_identity_without_endpoint_text(self) -> None:
+        listener_ports: list[int] = []
+
         def query(url: str) -> dict[str, object]:
             if url.endswith("/tags"):
                 return {"models": [{"name": "moondream:latest", "digest": "b" * 64}]}
             return {"data": [{"id": "qwen"}]}
+
+        def listener_probe(port: int) -> dict[str, object]:
+            listener_ports.append(port)
+            return {
+                "addresses": ["127.0.0.1"],
+                "loopback_only": True,
+                "error_code": None,
+            }
 
         with patch.dict(
             os.environ,
@@ -167,19 +189,65 @@ class VLMRunnerTests(unittest.TestCase):
                 "ROBOT_LLAMA_API_URL": ("http://127.0.0.1:8080/v1/chat/completions"),
             },
         ):
-            status = probe_vlm_services(query=query)
+            status = probe_vlm_services(query=query, listener_probe=listener_probe)
+        self.assertEqual(listener_ports, [11434, 8080])
         self.assertTrue(status["ollama"]["endpoint_local"])
+        self.assertTrue(status["ollama"]["listener_loopback_only"])
         self.assertTrue(status["ollama"]["model_present"])
         self.assertEqual(status["ollama"]["model_digest"], "b" * 64)
         self.assertTrue(status["qwen"]["model_present"])
+        self.assertTrue(status["qwen"]["listener_loopback_only"])
         self.assertEqual(status["qwen"]["served_model_ids"], ["qwen"])
         self.assertNotIn("endpoint", status["ollama"])
 
+    def test_listener_probe_distinguishes_loopback_and_wildcard_bindings(self) -> None:
+        loopback = probe_tcp_listener(
+            8080,
+            snapshotter=lambda _command: {
+                "returncode": 0,
+                "output": "LISTEN 0 512 127.0.0.1:8080 0.0.0.0:*",
+                "error_code": None,
+            },
+        )
+        wildcard = probe_tcp_listener(
+            8080,
+            snapshotter=lambda _command: {
+                "returncode": 0,
+                "output": "LISTEN 0 512 0.0.0.0:8080 0.0.0.0:*",
+                "error_code": None,
+            },
+        )
+        dual_stack = probe_tcp_listener(
+            8080,
+            snapshotter=lambda _command: {
+                "returncode": 0,
+                "output": "\n".join(
+                    (
+                        "LISTEN 0 512 127.0.0.1:8080 0.0.0.0:*",
+                        "LISTEN 0 512 [::1]:8080 [::]:*",
+                    )
+                ),
+                "error_code": None,
+            },
+        )
+
+        self.assertEqual(loopback["addresses"], ["127.0.0.1"])
+        self.assertTrue(loopback["loopback_only"])
+        self.assertEqual(wildcard["addresses"], ["0.0.0.0"])
+        self.assertFalse(wildcard["loopback_only"])
+        self.assertEqual(dual_stack["addresses"], ["127.0.0.1", "::1"])
+        self.assertTrue(dual_stack["loopback_only"])
+
     def test_nonlocal_service_configuration_is_not_contacted(self) -> None:
         requested_urls: list[str] = []
+        requested_listener_ports: list[int] = []
 
         def query(url: str) -> dict[str, object]:
             requested_urls.append(url)
+            return {}
+
+        def listener_probe(port: int) -> dict[str, object]:
+            requested_listener_ports.append(port)
             return {}
 
         with (
@@ -201,10 +269,49 @@ class VLMRunnerTests(unittest.TestCase):
                 "http://192.0.2.2:8080/v1/chat/completions",
             ),
         ):
-            status = probe_vlm_services(query=query)
+            status = probe_vlm_services(query=query, listener_probe=listener_probe)
         self.assertEqual(requested_urls, [])
+        self.assertEqual(requested_listener_ports, [])
         self.assertEqual(status["ollama"]["error_code"], "nonlocal_endpoint")
         self.assertEqual(status["qwen"]["error_code"], "nonlocal_endpoint")
+
+    def test_preflight_rejects_wildcard_listener_and_accepts_legacy_record(
+        self,
+    ) -> None:
+        services = service_status()
+        services["qwen"]["listener_addresses"] = ["0.0.0.0"]
+        services["qwen"]["listener_loopback_only"] = False
+        current = build_vlm_preflight(
+            REPO_ROOT,
+            input_payload=fixed_c100_payload(self.input_path),
+            base_preflight=base_preflight(),
+            services=services,
+        )
+        self.assertFalse(current["eligible"])
+        self.assertTrue(
+            any(
+                "qwen_listener_loopback_only" in error
+                for error in vlm_preflight_errors(current)
+            )
+        )
+
+        legacy = self.preflight_builder(
+            REPO_ROOT,
+            input_payload=fixed_c100_payload(self.input_path),
+            expected_branch="main",
+        )
+        legacy["vlm_preflight_schema_version"] = "0.1.0"
+        legacy["checks"] = [
+            check
+            for check in legacy["checks"]
+            if check["name"]
+            not in {
+                "ollama_listener_loopback_only",
+                "qwen_listener_loopback_only",
+            }
+        ]
+        legacy["eligible"] = True
+        self.assertEqual(vlm_preflight_errors(legacy), [])
 
     def test_failed_preflight_creates_no_run_directory(self) -> None:
         def failed_builder(_root, *, input_payload, expected_branch):

--- a/experiments/phase1/vlm_preflight.py
+++ b/experiments/phase1/vlm_preflight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import ipaddress
 import json
 import shutil
 import urllib.parse
@@ -14,6 +15,7 @@ from experiments.phase1.jetson_preflight import (
     build_jetson_preflight,
     preflight_errors,
 )
+from experiments.phase1.manifest import command_snapshot
 from experiments.phase1.vlm_adapter import (
     C100_INPUT_MEDIA_TYPE,
     C100_INPUT_SHA256,
@@ -22,9 +24,9 @@ from experiments.phase1.vlm_adapter import (
 from jetson.phase1_runtime import PayloadRef
 
 
-VLM_PREFLIGHT_SCHEMA_VERSION = "0.1.0"
+VLM_PREFLIGHT_SCHEMA_VERSION = "0.2.0"
 _LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
-_REQUIRED_CHECKS = {
+_REQUIRED_CHECKS_V0_1 = {
     "fixed_input_identity",
     "python_dependencies_available",
     "ollama_endpoint_local",
@@ -34,6 +36,14 @@ _REQUIRED_CHECKS = {
     "qwen_endpoint_local",
     "qwen_service_reachable",
     "qwen_model_present",
+}
+_REQUIRED_CHECKS_BY_VERSION = {
+    "0.1.0": _REQUIRED_CHECKS_V0_1,
+    "0.2.0": _REQUIRED_CHECKS_V0_1
+    | {
+        "ollama_listener_loopback_only",
+        "qwen_listener_loopback_only",
+    },
 }
 
 
@@ -59,9 +69,92 @@ def _llama_models_url(api_url: str) -> str:
     )
 
 
+def _endpoint_port(url: str) -> int:
+    parts = urllib.parse.urlsplit(url)
+    if parts.port is not None:
+        return parts.port
+    return 443 if parts.scheme == "https" else 80
+
+
+def _listener_host(local_address: str, port: int) -> str | None:
+    token = local_address.strip()
+    if token.startswith("["):
+        closing = token.rfind("]")
+        if closing < 0 or token[closing + 1 :] != f":{port}":
+            return None
+        return token[1:closing].split("%", 1)[0]
+    try:
+        host, service = token.rsplit(":", 1)
+    except ValueError:
+        return None
+    if service != str(port):
+        return None
+    return host.split("%", 1)[0]
+
+
+def _is_loopback_address(address: str) -> bool:
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    if parsed.is_loopback:
+        return True
+    mapped = getattr(parsed, "ipv4_mapped", None)
+    return mapped is not None and mapped.is_loopback
+
+
+def probe_tcp_listener(
+    port: int,
+    *,
+    snapshotter: Callable[[list[str]], Mapping[str, object]] = command_snapshot,
+) -> dict[str, object]:
+    """Record the bound addresses for one TCP port without process details."""
+
+    if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
+        raise ValueError("port must be an integer from 1 to 65535")
+    snapshot = snapshotter(["ss", "-H", "-ltn"])
+    returncode = snapshot.get("returncode")
+    error_code = snapshot.get("error_code")
+    output = snapshot.get("output")
+    if returncode != 0 or error_code is not None or not isinstance(output, str):
+        return {
+            "addresses": [],
+            "loopback_only": False,
+            "error_code": str(error_code or "listener_probe_failed"),
+        }
+
+    addresses: set[str] = set()
+    unparsed_match = False
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) < 4:
+            continue
+        local_address = fields[3]
+        if not local_address.endswith(f":{port}"):
+            continue
+        host = _listener_host(local_address, port)
+        if host is None:
+            unparsed_match = True
+        else:
+            addresses.add(host)
+    ordered = sorted(addresses)
+    listener_found = bool(ordered) or unparsed_match
+    loopback_only = (
+        bool(ordered)
+        and not unparsed_match
+        and all(_is_loopback_address(address) for address in ordered)
+    )
+    return {
+        "addresses": ordered,
+        "loopback_only": loopback_only,
+        "error_code": None if listener_found else "listener_not_found",
+    }
+
+
 def probe_vlm_services(
     *,
     query: Callable[[str], dict[str, object]] = _read_json,
+    listener_probe: Callable[[int], Mapping[str, object]] = probe_tcp_listener,
 ) -> dict[str, object]:
     """Probe local model services without importing the VLM implementation."""
 
@@ -73,11 +166,18 @@ def probe_vlm_services(
         "model": VLM_MODEL,
         "model_present": False,
         "model_digest": None,
+        "listener_addresses": [],
+        "listener_loopback_only": False,
+        "listener_error_code": "not_probed",
         "error_code": None,
     }
     if ollama["endpoint_local"] is not True:
         ollama["error_code"] = "nonlocal_endpoint"
     else:
+        listener = listener_probe(_endpoint_port(OLLAMA_CHAT_URL))
+        ollama["listener_addresses"] = list(listener.get("addresses", []))
+        ollama["listener_loopback_only"] = listener.get("loopback_only") is True
+        ollama["listener_error_code"] = listener.get("error_code")
         try:
             models = query(OLLAMA_CHAT_URL.rsplit("/", 1)[0] + "/tags").get(
                 "models", []
@@ -108,11 +208,18 @@ def probe_vlm_services(
         "model": "qwen",
         "model_present": False,
         "served_model_ids": [],
+        "listener_addresses": [],
+        "listener_loopback_only": False,
+        "listener_error_code": "not_probed",
         "error_code": None,
     }
     if qwen["endpoint_local"] is not True:
         qwen["error_code"] = "nonlocal_endpoint"
     else:
+        listener = listener_probe(_endpoint_port(LLAMA_API_URL))
+        qwen["listener_addresses"] = list(listener.get("addresses", []))
+        qwen["listener_loopback_only"] = listener.get("loopback_only") is True
+        qwen["listener_error_code"] = listener.get("error_code")
         try:
             models = query(_llama_models_url(LLAMA_API_URL)).get("data", [])
             if not isinstance(models, list):
@@ -216,6 +323,15 @@ def build_vlm_preflight(
             requirement="the Ollama endpoint is loopback-only",
         ),
         _check(
+            "ollama_listener_loopback_only",
+            ollama_record.get("listener_loopback_only") is True,
+            observed={
+                "addresses": ollama_record.get("listener_addresses"),
+                "error_code": ollama_record.get("listener_error_code"),
+            },
+            requirement="the Ollama TCP listener binds only loopback addresses",
+        ),
+        _check(
             "ollama_cli_available",
             ollama_cli_available is True,
             observed=ollama_cli_available,
@@ -245,6 +361,15 @@ def build_vlm_preflight(
             qwen_record.get("endpoint_local") is True,
             observed=qwen_record.get("endpoint_local"),
             requirement="the Qwen rewrite endpoint is loopback-only",
+        ),
+        _check(
+            "qwen_listener_loopback_only",
+            qwen_record.get("listener_loopback_only") is True,
+            observed={
+                "addresses": qwen_record.get("listener_addresses"),
+                "error_code": qwen_record.get("listener_error_code"),
+            },
+            requirement="the Qwen TCP listener binds only loopback addresses",
         ),
         _check(
             "qwen_service_reachable",
@@ -281,7 +406,9 @@ def build_vlm_preflight(
 
 def vlm_preflight_errors(preflight: Mapping[str, object]) -> list[str]:
     errors: list[str] = []
-    if preflight.get("vlm_preflight_schema_version") != VLM_PREFLIGHT_SCHEMA_VERSION:
+    schema_version = preflight.get("vlm_preflight_schema_version")
+    required_checks = _REQUIRED_CHECKS_BY_VERSION.get(str(schema_version))
+    if required_checks is None:
         errors.append("unsupported VLM preflight schema version")
     base = preflight.get("base")
     if not isinstance(base, Mapping):
@@ -304,7 +431,7 @@ def vlm_preflight_errors(preflight: Mapping[str, object]) -> list[str]:
             check_by_name[name] = item
             if item.get("required") is not True or item.get("passed") is not True:
                 errors.append(f"VLM preflight check failed: {name}")
-    if set(check_by_name) != _REQUIRED_CHECKS:
+    if required_checks is not None and set(check_by_name) != required_checks:
         errors.append("VLM preflight check set is incomplete or unsupported")
 
     input_identity = preflight.get("input")

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -2,9 +2,9 @@
 
 The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel. The experiment layer now connects that kernel to the fixed Phase 0 VLM input without changing the robot application.
 
-The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. The portable simulated-condition runner and Jetson pilot harness under `experiments/phase1/` have completed one motion-disabled, independently validated simulation pilot. The fixed-input VLM runner is implemented and host-tested; its Jetson execution and application integration remain research work.
+The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. The experiment harness under `experiments/phase1/` has completed one motion-disabled simulation pilot and one fixed-input VLM correctness pilot on the Jetson. The real-model pilot validated nominal consumption and stale-result rejection, but also recorded skipped probe releases during lazy Python module import; formal comparison and application integration remain research work.
 
-> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 已完成固定输入 VLM 接入的主机测试，但尚未进行 Jetson 实机采集，也未接入运动控制。
+> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 已完成固定输入 VLM 的 Jetson correctness pilot，但正式对比实验与运动控制接入尚未开始。
 
 ## Modules
 
@@ -63,9 +63,12 @@ The application expects two services to be started separately:
 | llama.cpp | `http://127.0.0.1:8080/v1/chat/completions` | Qwen dialogue and Chinese scene-description rewriting |
 | Ollama | `http://127.0.0.1:11434/api/chat` | Moondream image description |
 
-The exact llama.cpp launch flags depend on the local model and build. Confirm both services before starting the robot application:
+The exact llama.cpp launch flags depend on the local model and build. Bind both
+services to loopback rather than a wildcard interface. Confirm the listeners
+and model identities before starting the robot application:
 
 ```bash
+ss -ltnp | grep -E ':(8080|11434)'
 curl --max-time 5 http://127.0.0.1:8080/v1/models
 curl --max-time 5 http://127.0.0.1:11434/api/tags
 ```


### PR DESCRIPTION
## Summary

- add deterministic analysis for the Jetson VLM pilot session
- publish derived evidence for the `vlm_async` and `vlm_stale` correctness paths
- harden VLM preflight checks using observed TCP listener bindings
- preserve validation compatibility with the earlier preflight schema
- qualify timing-isolation claims using evidence from the real-model runs

## Experimental results

Both VLM lifecycle paths completed and passed validation:

- `vlm_async`: one request was accepted and consumed exactly once
- `vlm_stale`: the stale result was rejected with no accepted or consumed result
- both runs used the fixed Phase 0 input and completed without recording raw model output
- all lifecycle, cancellation, thread-closure and resource-trace gates passed

The real-model runs also exposed a limitation that was not visible in the simulated workload:

- `vlm_async`: 85 skipped control releases, with a maximum gap of 4262.876 ms
- `vlm_stale`: 63 skipped control releases, with a maximum gap of 2700.375 ms
- all 148 skipped releases were scheduled during lazy module import

These results support the lifecycle-correctness claim, but they do not support thread-level timing isolation for the current real VLM adapter. Process-level workload isolation is the next architecture step to evaluate.

## Preflight hardening

The VLM preflight schema is updated to `0.2.0`.

The preflight now:

- inspects actual TCP listeners through `ss -H -ltn`
- requires the Qwen service to be bound exclusively to loopback
- rejects wildcard and non-loopback listener bindings
- retains compatibility when validating pilot artifacts produced with schema `0.1.0`

## Evidence boundaries

- only deterministic derived reports are committed
- raw Jetson run artifacts remain outside version control
- no formal performance threshold is claimed
- GPU activity is not attributed to a specific model or processor
- heterogeneous-inference and model-unload claims remain bounded by the available evidence

## Validation

- Phase 0 tests: 29 passed
- Phase 1 tests: 106 passed
- total: 135 passed
- formatting, static analysis and compilation checks passed
- both archived VLM runs validate as `VALID`
- published derivatives regenerate byte-for-byte from the archived evidence