### PR TITLE
feat(phase1): add process-isolated VLM execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository began with my bachelor's thesis on speech interaction and visual perception for a wheeled robot. The thesis system runs fully local speech and vision pipelines on a Jetson Orin Nano, while an STM32F407 executes motion commands and enforces a communication watchdog. The same platform will now be used to study how long-running perception and inference can coexist with predictable control timing.
 
-> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立有界运行时、可观测 worker、周期探针和模拟实验运行器，完成 Jetson simulation pilot 和固定输入 VLM correctness pilot；真实模型正式对比实验与整机应用适配尚未开始。
+> 中文简介：本仓库记录“章鱼号”轮式机器人的本科毕设基线，并在同一平台上继续研究异构计算架构下的异步推理、实时控制与系统评测。当前版本已经完成 Jetson、STM32 和自制底层驱动板的整机验证；Phase 1 已建立有界运行时、可观测 worker、周期探针和模拟实验运行器，完成 Jetson simulation pilot 和固定输入 VLM correctness pilot，并开始对真实 VLM 适配器进行进程级隔离；正式对比实验与整机应用适配尚未开始。
 
 ## Project status
 
@@ -15,7 +15,7 @@ This repository began with my bachelor's thesis on speech interaction and visual
 | Bachelor's thesis software and firmware | Complete and hardware validated |
 | Custom base-driver PCB | Published and tested on the physical robot |
 | Jetson–STM32 command link | Validated with ACK/error responses and a 1.2 s command watchdog |
-| Asynchronous inference runtime | Bounded executor, probe and replay validated by Jetson simulation and fixed-input VLM correctness pilots; formal comparison pending |
+| Asynchronous inference runtime | Bounded executor, probe and replay validated by Jetson simulation and fixed-input VLM correctness pilots; spawned VLM adapter host-tested, Jetson process pilot pending |
 
 The validated Jetson–STM32 code is preserved at [`v0.1.0-thesis-baseline`](https://github.com/yuzhang-robotics/embodied-robot-heterogeneous-control/tree/v0.1.0-thesis-baseline). The current `main` branch also includes the reviewed hardware documentation and editable PCB export.
 
@@ -74,7 +74,11 @@ nominal consumption and old-generation rejection. Its
 [descriptive report](experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/)
 shows that all skipped releases occurred during lazy module import in the
 independent Python probe, so thread-level timing isolation does not generalize
-from the simulated sleep workload. Neither pilot authorizes a
+from the simulated sleep workload. A spawned-process VLM adapter now keeps the
+broker, freshness checks and periodic probe in the parent process while moving
+the lazy adapter path behind bounded IPC. Its lifecycle, cancellation, crash,
+timeout and child-reaping paths are host-tested; it has not yet produced a
+Jetson result. Neither completed pilot authorizes a
 performance-superiority, hard-real-time or heterogeneous-inference claim. The
 broader research stage will investigate:
 
@@ -98,7 +102,7 @@ These are research objectives, not claims about the current implementation. The 
 | [`docs/hardware/`](docs/hardware/) | Physical platform, wiring, pin assignments, power and safety notes |
 | [`docs/architecture/`](docs/architecture/) | Current timing model and the boundary of the planned asynchronous architecture |
 | [`experiments/phase0/`](experiments/phase0/) | Synchronous fixed-input measurement, validation and formal analysis tools |
-| [`experiments/phase1/`](experiments/phase1/) | Host tests, simulation and fixed-input VLM runners, Jetson pilot, deterministic analysis, trace schemas and validation |
+| [`experiments/phase1/`](experiments/phase1/) | Host tests, simulation and thread/process fixed-input VLM runners, Jetson pilots, deterministic analysis, trace schemas and validation |
 
 ## Reproducing the baseline
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -110,8 +110,10 @@ or formal performance result. The fixed-input VLM adapter has since completed
 one nominal/stale correctness pilot on the Jetson. Its independently derived
 [report](../../experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/)
 confirms stale-result rejection while also recording module-import-scale gaps
-in the threaded periodic probe. Process-level isolation or an equivalent
-mitigation must therefore be evaluated before timing isolation is claimed.
+in the threaded periodic probe. The next implementation moves the VLM adapter
+call into a spawned child process while the broker, freshness authority and
+periodic probe remain in the parent. This path is host-tested but has not yet
+been evaluated on the Jetson, so timing isolation is still not claimed.
 
 ## Evaluation plan
 

--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -6,21 +6,23 @@ host-only model, broker, observable executor, periodic probes, trace replay and
 portable simulation protocol have been implemented. One motion-disabled Jetson
 simulation pilot has validated the protocol and runtime semantics. A
 fixed-input VLM correctness pilot has also completed nominal consumption and
-old-generation rejection on the Jetson. Formal performance behavior remains
-unvalidated.
+old-generation rejection on the Jetson. A spawned-process VLM adapter and its
+evidence Gates are host-tested, but no process-isolated Jetson result has been
+collected. Formal performance behavior remains unvalidated.
 
 > 中文简介：本文冻结 Phase 1 异步运行时的任务模型、生命周期、队列、取消、结果新鲜度、
 > 快速周期代理和安全边界。host-only worker、周期探针、trace replay 和模拟实验运行器已实现；
 > Jetson simulation pilot 与固定输入 VLM correctness pilot 已完成并通过独立验证；
-> 正式同步/异步对比实验仍需按 Gate 逐步完成。
+> VLM 进程隔离路径已完成 host-only 测试，尚待 Jetson pilot；正式同步/异步对比实验仍需按 Gate 逐步完成。
 
 ## Status
 
-- Phase: Phase 1C fixed-input VLM pilot analysis and evidence hardening
+- Phase: Phase 1C process-isolated VLM pilot preparation
 - Contract status: frozen through independently validated Jetson simulation
   and fixed-input VLM correctness pilots
 - VLM-pilot result: `main@aebd1a2`, session
   `20260830T073825Z_phase1_vlm_pilot`
+- VLM-pilot public analysis: `main@95a839d`
 - Jetson-pilot result: `main@77138f2`, session `20260828T121142Z_phase1_jetson_pilot`
 - Jetson-pilot harness starting point: `main@844b633`
 - Simulation-runner starting point: `main@4514d97`
@@ -49,7 +51,9 @@ The current implementation includes:
 - a lazy fixed-input VLM adapter, nominal/stale single-request orchestration,
   model-service preflight, resource trace and independent run validation;
 - deterministic VLM-pilot reconstruction and fail-closed recording of actual
-  model-service listener bindings for subsequent runs.
+  model-service listener bindings for subsequent runs;
+- a per-request spawned-process VLM supervisor, bounded IPC, explicit process
+  cleanup facts and independently rebuilt process Gates.
 
 The VLM pilot includes no formal performance data. It validates the real-model
 integration and result-freshness path, while its skipped probe releases show
@@ -452,6 +456,54 @@ module import even though inference ran in the worker thread. Thread ownership
 alone is not accepted as evidence of timing isolation. Both paths invoke the
 same scenario adapter contract.
 
+## Process-isolated VLM boundary
+
+The first mitigation keeps task admission, queue ownership, state generations,
+result validation, event recording and the periodic probe in the parent
+process. Only the fixed-input VLM adapter invocation moves into one child
+created with the `spawn` start method. `fork` is excluded because the parent is
+already multithreaded and may have initialized library state that is unsafe to
+inherit.
+
+The parent remains the only lifecycle authority. The child cannot mutate the
+broker, consume a result, advance state or emit a final disposition. It receives
+one immutable task descriptor through a private pipe and returns only the
+existing bounded result and adapter records. Application messages are encoded
+as JSON with a 65,536-byte maximum. The fixed input path is needed inside that
+private message but remains excluded from the scenario, summary and process
+artifacts. Model text, prompts, stdout, stderr and exception tracebacks do not
+cross the evidence boundary.
+
+One process is created per request in this initial correctness experiment. This
+keeps ownership and cleanup observable without introducing a persistent worker
+pool or model concurrency. The supervisor records the spawn request, child
+start, inference-start signal, completion receipt, join, exit code and any
+forced termination. Every successful invocation must close the protocol, exit
+with code zero and be reaped without `terminate`. An EOF, malformed message,
+unexpected child exit or execution timeout becomes a bounded adapter error;
+the parent still reaps or terminates the child within finite budgets.
+
+Cancellation is forwarded through a process-safe event. For `vlm_stale`, the
+parent advances the generation only after receiving the child inference-start
+signal. The child may later report that it observed cancellation, but the
+broker still owns the `rejected_state` decision. Terminating or reaping the
+Python child proves only the local worker-process fact. It does not prove that
+Ollama, llama.cpp or GPU work stopped, so `backend_stop_confirmed` remains
+unknown unless a separate backend acknowledgement is introduced.
+
+The process runner adds `adapter_isolation=spawned_process`, a distinct run ID
+and `process.json`. The latter is rebuilt from the supervisor facts in
+`scenario.json` and fails closed unless spawn ownership, protocol completion,
+boundary order, cancellation forwarding and normal child reaping all pass.
+The original thread mode remains the default and the first VLM pilot remains
+valid under its earlier artifact contract.
+
+Host fault-injection covers nominal completion, state invalidation, child-side
+execution errors, abrupt exit and timeout termination. These tests validate
+the boundary implementation, not Jetson scheduling behavior. A motion-disabled
+real-model pilot is required before deciding whether this mitigation removes
+the module-import-scale probe gaps.
+
 ## Event and replay requirements
 
 Phase 1 creates a new event schema and run root. Phase 0 schema version `0.1.0`
@@ -778,6 +830,17 @@ The fixed-input VLM slice adds these zero-tolerance Gates:
 - `vlm_stale` records exactly one `rejected_state` and zero accepted results;
 - cancellation evidence does not claim backend stop without confirmation;
 - at least one valid resource sample falls inside the adapter interval.
+
+The process-isolated variant additionally requires:
+
+- the adapter uses `spawn` and records one positive child process identity;
+- the bounded process protocol completes without an error;
+- spawn, child start, inference start, completion and join boundaries are
+  present and ordered;
+- `vlm_stale` forwards cancellation after inference starts, while `vlm_async`
+  forwards none;
+- the child exits with code zero and is reaped without forced termination;
+- process cleanup is not represented as confirmed model-backend cancellation.
 
 Numerical jitter and non-inferiority thresholds will be frozen during the next
 protocol review and before formal data. The current 300 ms unchanged-command

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -5,12 +5,14 @@ recorder, event schema, independent lifecycle replay, run validation, Jetson
 pilot orchestration, deterministic analysis, fixed-input VLM integration and
 descriptive summaries for the Phase 1 asynchronous runtime study. The first
 Jetson simulation pilot and fixed-input VLM correctness pilot are complete.
-Formal synchronous/asynchronous data remain uncollected.
+A spawned-process VLM adapter and evidence path are host-tested; their Jetson
+pilot and all formal synchronous/asynchronous data remain uncollected.
 
 > 中文简介：本目录用于 Phase 1 异步运行时研究。当前已实现 host-only 有界 broker、
 > 单 worker 执行层、100 ms 周期探针、独立 trace replay、模拟条件运行器和 Jetson
 > pilot 证据链，并完成 Jetson simulation pilot 与固定输入 VLM correctness pilot；
-> 当前已验证真实模型接入和陈旧结果拒绝，正式对比数据尚未采集。
+> 当前已验证真实模型接入和陈旧结果拒绝，VLM 进程隔离路径已完成 host-only 测试、尚待
+> Jetson pilot，正式对比数据尚未采集。
 
 ## Current status
 
@@ -28,6 +30,8 @@ Formal synchronous/asynchronous data remain uncollected.
 - Fixed-input VLM adapter, single-request runner and validator: completed one
   independently validated Jetson correctness pilot
 - Deterministic VLM pilot analysis and listener-binding preflight: implemented
+- Spawned-process VLM adapter, cleanup evidence and runner mode: host-tested;
+  Jetson process pilot not yet run
 - Real ASR/LLM slices: not started
 - Formal Phase 1 data: not collected
 - Physical motion and UART: excluded
@@ -279,6 +283,49 @@ do not form a balanced synchronous/asynchronous comparison, prove backend
 preemption, measure visual accuracy or authorize a heterogeneous-performance
 claim.
 
+### Spawned-process VLM variant
+
+The process-isolated variant keeps the broker, state generations, result
+freshness checks, event recorder and periodic probe in the parent process. It
+moves only the lazy VLM adapter call into one child created with `spawn`. The
+child receives one task through bounded private IPC and returns the same
+hash-only result and stage facts as the thread adapter. It cannot mutate the
+broker or choose a final disposition.
+
+Each process run adds a distinct condition directory and `process.json`. The
+process summary is independently rebuilt from supervisor facts in
+`scenario.json` and requires a complete protocol, ordered boundaries, correct
+cancellation forwarding, exit code zero and a normally reaped child. A forced
+child termination is recorded separately and never becomes a claim that the
+Ollama backend stopped inference.
+
+After this implementation is merged and the Jetson is synchronized to that
+`main` commit, the two motion-disabled pilot conditions can be run with:
+
+```bash
+export ROBOT_ENABLE_MOTION=0
+python3 -m experiments.phase1.run_vlm_slice \
+  --condition vlm_async \
+  --adapter-isolation spawned_process \
+  --process-execution-timeout-s 600 \
+  --completion-timeout-s 720 \
+  --session-id 20260830T000000Z_phase1_vlm_process_pilot \
+  --repetition 1
+
+python3 -m experiments.phase1.run_vlm_slice \
+  --condition vlm_stale \
+  --adapter-isolation spawned_process \
+  --process-execution-timeout-s 600 \
+  --completion-timeout-s 720 \
+  --session-id 20260830T000000Z_phase1_vlm_process_pilot \
+  --repetition 1
+```
+
+These commands are a correctness and timing-isolation pilot, not a formal
+thread/process comparison. The two earlier thread runs remain unchanged and
+valid. Process-level timing behavior is not claimed until the new Jetson
+artifacts are collected and independently analyzed.
+
 ## Planned implementation order
 
 1. freeze the task, result, lifecycle, queue, cancellation, and freshness
@@ -296,8 +343,9 @@ claim.
    slice — complete;
 8. record actual model-service listener bindings and qualify the simulated
    thread-isolation result with real-workload evidence — complete;
-9. evaluate process-level isolation, then extend the adapter/runtime boundary
-   to ASR and LLM;
+9. implement and host-test process-level VLM isolation — complete; run and
+   independently analyze its Jetson pilot, then extend the adapter/runtime
+   boundary to ASR and LLM;
 10. freeze formal thresholds and collect balanced synchronous/asynchronous data;
 11. add an opt-in motion-disabled application slice after the research Gates
    pass.
@@ -341,6 +389,7 @@ experiments/phase1/
 │   └── resource.schema.json
 ├── simulation.py
 ├── summarize_run.py
+├── summarize_vlm_process_slice.py
 ├── summarize_vlm_slice.py
 ├── tests/
 ├── telemetry.py
@@ -349,6 +398,7 @@ experiments/phase1/
 ├── validate_vlm_slice.py
 ├── vlm_adapter.py
 ├── vlm_preflight.py
+├── vlm_process_adapter.py
 ├── vlm_slice.py
 ├── replay_lifecycle.py
 └── README.md

--- a/experiments/phase1/run_vlm_slice.py
+++ b/experiments/phase1/run_vlm_slice.py
@@ -22,12 +22,17 @@ from experiments.phase1.manifest import (
     write_json_atomic,
 )
 from experiments.phase1.summarize_vlm_slice import build_vlm_summary
+from experiments.phase1.summarize_vlm_process_slice import (
+    VLM_PROCESS_ISOLATION,
+    build_vlm_process_summary,
+)
 from experiments.phase1.telemetry import EventRecorder, SCHEMA_VERSION
 from experiments.phase1.vlm_adapter import FixedInputVLMAdapter, fixed_c100_payload
 from experiments.phase1.vlm_preflight import (
     build_vlm_preflight,
     vlm_preflight_errors,
 )
+from experiments.phase1.vlm_process_adapter import ProcessIsolatedVLMAdapter
 from experiments.phase1.vlm_slice import (
     VLMSliceCondition,
     VLMSliceSpec,
@@ -44,6 +49,7 @@ DEFAULT_INPUT = (
 )
 DEFAULT_OUTPUT_ROOT = Path(__file__).resolve().parents[1] / "runs" / "phase1-vlm-slice"
 _SESSION_ID_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z_phase1_vlm_[a-z][a-z0-9_-]{0,31}$")
+THREAD_ISOLATION = "thread"
 
 
 class VLMRunError(RuntimeError):
@@ -54,6 +60,7 @@ def make_vlm_run_id(
     condition: VLMSliceCondition,
     repetition: int,
     *,
+    adapter_isolation: str = THREAD_ISOLATION,
     now: datetime | None = None,
 ) -> str:
     if not isinstance(condition, VLMSliceCondition):
@@ -64,11 +71,16 @@ def make_vlm_run_id(
         or not 0 <= repetition <= 999
     ):
         raise ValueError("repetition must be an integer from 0 to 999")
+    if adapter_isolation not in {THREAD_ISOLATION, VLM_PROCESS_ISOLATION}:
+        raise ValueError("adapter_isolation must be thread or spawned_process")
     current = now or datetime.now(timezone.utc)
     if current.tzinfo is None:
         raise ValueError("now must be timezone-aware")
     stamp = current.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    return f"{stamp}_phase1_{condition.value}_vlm_{repetition:03d}"
+    condition_label = condition.value
+    if adapter_isolation == VLM_PROCESS_ISOLATION:
+        condition_label = condition_label.replace("vlm_", "vlm_process_", 1)
+    return f"{stamp}_phase1_{condition_label}_vlm_{repetition:03d}"
 
 
 def make_vlm_session_id(now: datetime | None = None) -> str:
@@ -153,7 +165,7 @@ def run_once(
     repo_root: Path | str | None = None,
     preflight_builder: Callable[..., dict[str, object]] | None = None,
     sampler_factory: Callable[..., TegrastatsSampler] | None = None,
-    adapter_factory: Callable[[], FixedInputVLMAdapter] | None = None,
+    adapter_factory: Callable[[], object] | None = None,
 ) -> Path:
     """Execute one preflighted VLM request and independently validate it."""
 
@@ -163,6 +175,16 @@ def run_once(
         else Path(__file__).resolve().parents[2]
     )
     condition = VLMSliceCondition(args.condition)
+    adapter_isolation = args.adapter_isolation
+    if adapter_isolation not in {THREAD_ISOLATION, VLM_PROCESS_ISOLATION}:
+        raise VLMRunError("unsupported VLM adapter isolation")
+    if (
+        adapter_isolation == VLM_PROCESS_ISOLATION
+        and args.process_execution_timeout_s >= args.completion_timeout_s
+    ):
+        raise VLMRunError(
+            "process execution timeout must be below the slice completion timeout"
+        )
     session_id = _validate_session_id(args.session_id or make_vlm_session_id())
     injected_components = [
         name
@@ -175,7 +197,6 @@ def run_once(
     ]
     resolved_preflight_builder = preflight_builder or build_vlm_preflight
     resolved_sampler_factory = sampler_factory or TegrastatsSampler
-    resolved_adapter_factory = adapter_factory or FixedInputVLMAdapter
     safety = require_motion_disabled()
     payload = fixed_c100_payload(args.input)
     preflight = resolved_preflight_builder(
@@ -188,8 +209,17 @@ def run_once(
         raise VLMRunError("VLM preflight failed: " + "; ".join(failed_checks))
 
     output_root = _resolve_output_root(Path(args.output_root), root)
-    run_id = make_vlm_run_id(condition, args.repetition)
-    run_dir = output_root / session_id / condition.value / run_id
+    run_id = make_vlm_run_id(
+        condition,
+        args.repetition,
+        adapter_isolation=adapter_isolation,
+    )
+    condition_label = (
+        condition.value
+        if adapter_isolation == THREAD_ISOLATION
+        else condition.value.replace("vlm_", "vlm_process_", 1)
+    )
+    run_dir = output_root / session_id / condition_label / run_id
     if run_dir.exists():
         raise FileExistsError(f"refusing to overwrite VLM run: {run_dir}")
     run_dir.mkdir(parents=True)
@@ -208,14 +238,21 @@ def run_once(
         probe_period_ns=int(args.probe_period_ms * 1_000_000),
         probe_deadline_ns=int(args.probe_deadline_ms * 1_000_000),
     )
+    spec_record = spec.to_dict()
+    spec_record["adapter_isolation"] = adapter_isolation
     environment = collect_environment(root)
     manifest: dict[str, object] = {
         "manifest_schema_version": MANIFEST_SCHEMA_VERSION,
         "event_schema_version": SCHEMA_VERSION,
-        "artifact_kind": "phase1_fixed_input_vlm_run",
+        "artifact_kind": (
+            "phase1_fixed_input_vlm_run"
+            if adapter_isolation == THREAD_ISOLATION
+            else "phase1_fixed_input_vlm_process_run"
+        ),
         "run_id": run_id,
         "session_id": session_id,
         "condition": condition.value,
+        "adapter_isolation": adapter_isolation,
         "trace_profile": "runtime_threaded_probe",
         "status": "running",
         "created_at": utc_now_iso(),
@@ -252,7 +289,7 @@ def run_once(
             "unload_confirmation": "not_available",
             "raw_output_recorded": False,
         },
-        "spec": spec.to_dict(),
+        "spec": spec_record,
         "resource_interval_ms": args.resource_interval_ms,
         "resource_sampler_report": None,
         "artifacts": {},
@@ -267,11 +304,22 @@ def run_once(
         sampler = resolved_sampler_factory(run_dir, args.resource_interval_ms)
         sampler.start(first_sample_timeout_s=args.resource_first_sample_timeout_s)
         recorder = EventRecorder(run_dir, run_id)
+        if adapter_factory is not None:
+            adapter = adapter_factory()
+        elif adapter_isolation == VLM_PROCESS_ISOLATION:
+            adapter = ProcessIsolatedVLMAdapter(
+                execution_timeout_s=args.process_execution_timeout_s,
+                poll_interval_s=args.process_poll_interval_s,
+                join_timeout_s=args.process_join_timeout_s,
+                terminate_join_timeout_s=args.process_terminate_timeout_s,
+            )
+        else:
+            adapter = FixedInputVLMAdapter()
         report = run_vlm_slice(
             spec,
             payload,
             recorder,
-            adapter=resolved_adapter_factory(),
+            adapter=adapter,
         )
         recorder.close()
         recorder = None
@@ -280,14 +328,32 @@ def run_once(
         if not sampler_report.successful:
             raise VLMRunError("tegrastats did not produce a valid closed trace")
 
-        scenario = {"spec": spec.to_dict(), "report": report.to_dict()}
+        scenario: dict[str, object] = {
+            "spec": spec_record,
+            "report": report.to_dict(),
+        }
+        process_summary: dict[str, object] | None = None
+        if adapter_isolation == VLM_PROCESS_ISOLATION:
+            process_report = getattr(adapter, "last_process_report", None)
+            if process_report is None or not callable(
+                getattr(process_report, "to_dict", None)
+            ):
+                raise VLMRunError("process adapter did not publish supervisor facts")
+            process_record = process_report.to_dict()
+            scenario["process"] = process_record
+            process_summary = build_vlm_process_summary(
+                process_record,
+                condition=condition,
+            )
+            if process_summary.get("valid") is not True:
+                raise VLMRunError("one or more VLM process Gates failed")
         scenario_path = run_dir / "scenario.json"
         write_json_atomic(scenario_path, scenario)
         samples = load_resource_samples(run_dir / "resources.jsonl")
         summary = build_vlm_summary(
             run_dir / "events.jsonl",
             condition=condition,
-            spec=spec.to_dict(),
+            spec=spec_record,
             report=report.to_dict(),
             resource_samples=samples,
             sampler_report=sampler_report.to_dict(),
@@ -298,15 +364,20 @@ def run_once(
         if summary.get("valid") is not True:
             raise VLMRunError("one or more VLM slice Gates failed")
 
+        if process_summary is not None:
+            write_json_atomic(run_dir / "process.json", process_summary)
+
+        artifact_names = [
+            "preflight.json",
+            "events.jsonl",
+            "resources.jsonl",
+            "scenario.json",
+            "summary.json",
+        ]
+        if process_summary is not None:
+            artifact_names.append("process.json")
         manifest["artifacts"] = {
-            name: _artifact_identity(run_dir / name)
-            for name in (
-                "preflight.json",
-                "events.jsonl",
-                "resources.jsonl",
-                "scenario.json",
-                "summary.json",
-            )
+            name: _artifact_identity(run_dir / name) for name in artifact_names
         }
         manifest["status"] = "completed"
         manifest["completed_at"] = utc_now_iso()
@@ -358,6 +429,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--probe-deadline-ms", type=float, default=100.0)
     parser.add_argument("--resource-interval-ms", type=int, default=200)
     parser.add_argument("--resource-first-sample-timeout-s", type=float, default=5.0)
+    parser.add_argument(
+        "--adapter-isolation",
+        choices=(THREAD_ISOLATION, VLM_PROCESS_ISOLATION),
+        default=THREAD_ISOLATION,
+    )
+    parser.add_argument("--process-execution-timeout-s", type=float, default=600.0)
+    parser.add_argument("--process-poll-interval-s", type=float, default=0.02)
+    parser.add_argument("--process-join-timeout-s", type=float, default=5.0)
+    parser.add_argument("--process-terminate-timeout-s", type=float, default=5.0)
     return parser
 
 

--- a/experiments/phase1/summarize_vlm_process_slice.py
+++ b/experiments/phase1/summarize_vlm_process_slice.py
@@ -1,0 +1,156 @@
+"""Deterministic process-boundary Gates for one fixed-input VLM run."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from experiments.phase1.vlm_process_adapter import PROCESS_PROTOCOL_VERSION
+from experiments.phase1.vlm_slice import VLMSliceCondition
+
+
+VLM_PROCESS_SUMMARY_SCHEMA_VERSION = "0.1.0"
+VLM_PROCESS_ISOLATION = "spawned_process"
+
+
+def _gate(
+    name: str,
+    passed: bool,
+    *,
+    observed: object,
+    requirement: str,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "passed": passed,
+        "observed": observed,
+        "requirement": requirement,
+    }
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def build_vlm_process_summary(
+    process_report: Mapping[str, object],
+    *,
+    condition: VLMSliceCondition,
+) -> dict[str, object]:
+    """Rebuild process ownership and cleanup Gates from serialized facts."""
+
+    if not isinstance(process_report, Mapping):
+        raise TypeError("process_report must be a mapping")
+    if not isinstance(condition, VLMSliceCondition):
+        raise TypeError("condition must be a VLMSliceCondition")
+
+    process_id = _integer(process_report.get("process_id"))
+    spawn_ns = _integer(process_report.get("spawn_requested_monotonic_ns"))
+    child_started_ns = _integer(process_report.get("child_started_monotonic_ns"))
+    inference_started_ns = _integer(
+        process_report.get("inference_started_monotonic_ns")
+    )
+    completion_ns = _integer(process_report.get("completion_received_monotonic_ns"))
+    joined_ns = _integer(process_report.get("joined_monotonic_ns"))
+    expected_cancellation = condition is VLMSliceCondition.STALE
+    cancellation_forwarded = process_report.get("cancellation_forwarded")
+    cancellation_ns = _integer(
+        process_report.get("cancellation_forwarded_monotonic_ns")
+    )
+
+    gates = [
+        _gate(
+            "spawned_process",
+            process_report.get("start_method") == "spawn"
+            and process_id is not None
+            and process_id > 0,
+            observed={
+                "start_method": process_report.get("start_method"),
+                "process_id_present": process_id is not None,
+            },
+            requirement="the VLM adapter executes in one spawned child process",
+        ),
+        _gate(
+            "bounded_protocol",
+            process_report.get("protocol_version") == PROCESS_PROTOCOL_VERSION
+            and process_report.get("protocol_complete") is True
+            and process_report.get("error_code") is None,
+            observed={
+                "protocol_version": process_report.get("protocol_version"),
+                "protocol_complete": process_report.get("protocol_complete"),
+                "error_code": process_report.get("error_code"),
+            },
+            requirement="the bounded child protocol closes without an error",
+        ),
+        _gate(
+            "process_reaped",
+            process_report.get("exit_code") == 0
+            and process_report.get("terminate_requested") is False
+            and process_report.get("terminate_confirmed") is False,
+            observed={
+                "exit_code": process_report.get("exit_code"),
+                "terminate_requested": process_report.get("terminate_requested"),
+                "terminate_confirmed": process_report.get("terminate_confirmed"),
+            },
+            requirement="the child exits normally and is reaped without termination",
+        ),
+        _gate(
+            "boundary_order",
+            all(
+                value is not None
+                for value in (
+                    spawn_ns,
+                    child_started_ns,
+                    inference_started_ns,
+                    completion_ns,
+                    joined_ns,
+                )
+            )
+            and spawn_ns <= child_started_ns <= inference_started_ns
+            and inference_started_ns <= completion_ns <= joined_ns,
+            observed={
+                "spawn_requested_monotonic_ns": spawn_ns,
+                "child_started_monotonic_ns": child_started_ns,
+                "inference_started_monotonic_ns": inference_started_ns,
+                "completion_received_monotonic_ns": completion_ns,
+                "joined_monotonic_ns": joined_ns,
+            },
+            requirement="spawn, inference, completion and join boundaries are ordered",
+        ),
+        _gate(
+            "cancellation_forwarding",
+            cancellation_forwarded is expected_cancellation
+            and (
+                cancellation_ns is not None
+                if expected_cancellation
+                else cancellation_ns is None
+            )
+            and (
+                not expected_cancellation
+                or (
+                    inference_started_ns is not None
+                    and completion_ns is not None
+                    and inference_started_ns <= cancellation_ns <= completion_ns
+                )
+            ),
+            observed={
+                "expected": expected_cancellation,
+                "forwarded": cancellation_forwarded,
+                "forwarded_monotonic_ns": cancellation_ns,
+            },
+            requirement=(
+                "state invalidation is forwarded to the child"
+                if expected_cancellation
+                else "the nominal request forwards no cancellation"
+            ),
+        ),
+    ]
+    return {
+        "vlm_process_summary_schema_version": (VLM_PROCESS_SUMMARY_SCHEMA_VERSION),
+        "adapter_isolation": VLM_PROCESS_ISOLATION,
+        "condition": condition.value,
+        "valid": all(gate["passed"] for gate in gates),
+        "process": dict(process_report),
+        "gates": gates,
+    }

--- a/experiments/phase1/tests/test_vlm_process_adapter.py
+++ b/experiments/phase1/tests/test_vlm_process_adapter.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import multiprocessing
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+from experiments.phase1.vlm_process_adapter import ProcessIsolatedVLMAdapter
+from experiments.phase1.telemetry import EventRecorder
+from experiments.phase1.vlm_slice import (
+    VLMSliceCondition,
+    VLMSliceSpec,
+    run_vlm_slice,
+)
+from jetson.phase1_runtime import (
+    CancellationToken,
+    ClaimedTask,
+    ExecutionOutcome,
+    PayloadRef,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+)
+
+
+FIXTURE_FACTORY = "experiments.phase1.tests.vlm_process_fixture:FixtureVLMAdapter"
+ABRUPT_FACTORY = "experiments.phase1.tests.vlm_process_fixture:AbruptExitVLMAdapter"
+UNRESPONSIVE_FACTORY = (
+    "experiments.phase1.tests.vlm_process_fixture:UnresponsiveVLMAdapter"
+)
+ERROR_FACTORY = "experiments.phase1.tests.vlm_process_fixture:ErrorVLMAdapter"
+
+
+class ProcessIsolatedVLMAdapterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.input_path = Path(self.temporary.name) / "fixed.jpg"
+        self.input_path.write_bytes(b"fixed process input")
+
+    def claimed(self, token: CancellationToken | None = None) -> ClaimedTask:
+        digest = hashlib.sha256(self.input_path.read_bytes()).hexdigest()
+        now = time.monotonic_ns()
+        task = TaskEnvelope(
+            task_id="vlm-process-test",
+            task_kind=TaskKind.VLM,
+            source_monotonic_ns=now,
+            created_monotonic_ns=now,
+            deadline_monotonic_ns=now + 10_000_000_000,
+            state_token=StateToken("vlm-process-test", 0),
+            payload=PayloadRef(
+                ref=str(self.input_path),
+                sha256=digest,
+                size_bytes=self.input_path.stat().st_size,
+                media_type="image/jpeg",
+            ),
+        )
+        return ClaimedTask(
+            task=task,
+            cancellation_token=token or CancellationToken(),
+            started_monotonic_ns=now,
+        )
+
+    def test_module_import_does_not_start_or_load_device_paths(self) -> None:
+        code = (
+            "import sys\n"
+            "import experiments.phase1.vlm_process_adapter\n"
+            "assert 'jetson.vision_vlm' not in sys.modules\n"
+            "assert 'jetson.app' not in sys.modules\n"
+            "assert 'jetson.robot_comm' not in sys.modules\n"
+            "assert not __import__('multiprocessing').active_children()\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=Path(__file__).resolve().parents[3],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=5,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+
+    def test_spawned_worker_returns_bounded_result_and_is_reaped(self) -> None:
+        adapter = ProcessIsolatedVLMAdapter(
+            factory_ref=FIXTURE_FACTORY,
+            execution_timeout_s=5.0,
+        )
+        result = adapter(self.claimed())
+        record = adapter.last_record
+        report = adapter.last_process_report
+
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.OK)
+        self.assertIsNotNone(record)
+        self.assertIsNotNone(report)
+        assert record is not None
+        assert report is not None
+        self.assertEqual(report.start_method, "spawn")
+        self.assertTrue(report.protocol_complete)
+        self.assertEqual(report.exit_code, 0)
+        self.assertFalse(report.terminate_requested)
+        self.assertFalse(report.terminate_confirmed)
+        self.assertIsNone(report.error_code)
+        self.assertIsNotNone(report.child_started_monotonic_ns)
+        self.assertIsNotNone(report.inference_started_monotonic_ns)
+        serialized = json.dumps(
+            {
+                "record": record.to_dict(),
+                "process": report.to_dict(),
+            }
+        )
+        self.assertNotIn(str(self.input_path), serialized)
+        self.assertNotIn("bounded fixture output", serialized)
+
+    def test_cancellation_is_forwarded_without_backend_stop_claim(self) -> None:
+        token = CancellationToken()
+        adapter = ProcessIsolatedVLMAdapter(
+            factory_ref=FIXTURE_FACTORY,
+            execution_timeout_s=5.0,
+        )
+        results = []
+        worker = threading.Thread(
+            target=lambda: results.append(adapter(self.claimed(token)))
+        )
+        worker.start()
+        self.assertTrue(adapter.inference_started_event.wait(3.0))
+        token.request("state_changed", time.monotonic_ns())
+        worker.join(5.0)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(results[0].execution_outcome, ExecutionOutcome.CANCEL_OBSERVED)
+        self.assertTrue(results[0].cancellation_report.worker_observed)
+        self.assertIsNone(results[0].cancellation_report.backend_stop_confirmed)
+        report = adapter.last_process_report
+        self.assertIsNotNone(report)
+        assert report is not None
+        self.assertTrue(report.cancellation_forwarded)
+        self.assertFalse(report.terminate_requested)
+        self.assertEqual(report.exit_code, 0)
+
+    def test_abrupt_child_exit_returns_error_and_records_exit_code(self) -> None:
+        adapter = ProcessIsolatedVLMAdapter(
+            factory_ref=ABRUPT_FACTORY,
+            execution_timeout_s=5.0,
+        )
+        result = adapter(self.claimed())
+        report = adapter.last_process_report
+
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.ERROR)
+        self.assertEqual(result.error_code, "process_worker_exit")
+        self.assertIsNotNone(report)
+        assert report is not None
+        self.assertEqual(report.exit_code, 17)
+        self.assertFalse(report.protocol_complete)
+        self.assertEqual(report.error_code, "process_worker_exit")
+
+    def test_child_error_result_preserves_empty_output(self) -> None:
+        adapter = ProcessIsolatedVLMAdapter(
+            factory_ref=ERROR_FACTORY,
+            execution_timeout_s=5.0,
+        )
+        result = adapter(self.claimed())
+        record = adapter.last_record
+        report = adapter.last_process_report
+
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.ERROR)
+        self.assertEqual(result.error_code, "fixture_failure")
+        self.assertIsNone(result.output_sha256)
+        self.assertIsNotNone(record)
+        self.assertIsNotNone(report)
+        assert record is not None
+        assert report is not None
+        self.assertIsNone(record.output_sha256)
+        self.assertTrue(report.protocol_complete)
+        self.assertEqual(report.exit_code, 0)
+
+    def test_unresponsive_child_is_terminated_and_reaped(self) -> None:
+        adapter = ProcessIsolatedVLMAdapter(
+            factory_ref=UNRESPONSIVE_FACTORY,
+            execution_timeout_s=0.1,
+            join_timeout_s=0.1,
+            terminate_join_timeout_s=1.0,
+        )
+        result = adapter(self.claimed())
+        report = adapter.last_process_report
+
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.TIMEOUT)
+        self.assertEqual(result.error_code, "process_worker_timeout")
+        self.assertIsNotNone(report)
+        assert report is not None
+        self.assertTrue(report.terminate_requested)
+        self.assertTrue(report.terminate_confirmed)
+        self.assertIsNotNone(report.exit_code)
+        self.assertFalse(report.protocol_complete)
+
+    def test_only_spawn_start_method_is_accepted(self) -> None:
+        with self.assertRaisesRegex(ValueError, "start_method must be spawn"):
+            ProcessIsolatedVLMAdapter(
+                factory_ref=FIXTURE_FACTORY,
+                start_method="fork",
+            )
+
+    def test_existing_slice_owns_lifecycle_around_process_adapter(self) -> None:
+        baseline_children = {child.pid for child in multiprocessing.active_children()}
+        adapter = ProcessIsolatedVLMAdapter(
+            factory_ref=FIXTURE_FACTORY,
+            execution_timeout_s=5.0,
+        )
+        claimed = self.claimed()
+        spec = VLMSliceSpec(
+            condition=VLMSliceCondition.STALE,
+            result_validity_s=5.0,
+            completion_timeout_s=3.0,
+            join_timeout_s=3.0,
+            probe_join_timeout_s=1.0,
+            prelude_s=0.005,
+            postlude_s=0.005,
+            probe_period_ns=5_000_000,
+            probe_deadline_ns=10_000_000,
+        )
+        run_id = "20260830T160000Z_phase1_vlm_process_vlm_001"
+        with EventRecorder(Path(self.temporary.name) / "run", run_id) as sink:
+            report = run_vlm_slice(
+                spec,
+                claimed.task.payload,
+                sink,
+                adapter=adapter,
+                task_id="vlm-process-slice",
+            )
+
+        remaining_children = {child.pid for child in multiprocessing.active_children()}
+        self.assertEqual(remaining_children, baseline_children)
+        self.assertEqual(report.final_disposition, "rejected_state")
+        self.assertFalse(report.consumed)
+        self.assertTrue(report.adapter.worker_observed_cancellation)
+        process_report = adapter.last_process_report
+        self.assertIsNotNone(process_report)
+        assert process_report is not None
+        self.assertTrue(process_report.protocol_complete)
+        self.assertEqual(process_report.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/phase1/tests/test_vlm_runner.py
+++ b/experiments/phase1/tests/test_vlm_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import multiprocessing
 import os
 import tempfile
 import threading
@@ -13,6 +14,7 @@ from experiments.phase1.jetson_preflight import build_jetson_preflight
 from experiments.phase1.jetson_telemetry import TegrastatsSampler
 from experiments.phase1.manifest import sha256_file
 from experiments.phase1.run_vlm_slice import build_parser, run_once
+from experiments.phase1.summarize_vlm_process_slice import VLM_PROCESS_ISOLATION
 from experiments.phase1.tests.test_jetson_pilot import clean_environment
 from experiments.phase1.tests.test_jetson_telemetry import sampler_command
 from experiments.phase1.validate_vlm_slice import validate_vlm_slice_dir
@@ -27,11 +29,15 @@ from experiments.phase1.vlm_preflight import (
     probe_vlm_services,
     vlm_preflight_errors,
 )
+from experiments.phase1.vlm_process_adapter import ProcessIsolatedVLMAdapter
 from experiments.phase1.vlm_slice import VLMSliceCondition
 
 
 SESSION_ID = "20260828T170000Z_phase1_vlm_test"
 REPO_ROOT = Path(__file__).resolve().parents[3]
+PROCESS_FIXTURE_FACTORY = (
+    "experiments.phase1.tests.vlm_process_fixture:FixtureVLMAdapter"
+)
 
 
 def service_status() -> dict[str, object]:
@@ -132,6 +138,15 @@ class VLMRunnerTests(unittest.TestCase):
             ]
         )
 
+    def process_args(self, condition: VLMSliceCondition):
+        args = self.args(condition)
+        args.adapter_isolation = VLM_PROCESS_ISOLATION
+        args.result_validity_s = 5.0
+        args.completion_timeout_s = 3.0
+        args.join_timeout_s = 3.0
+        args.process_execution_timeout_s = 2.0
+        return args
+
     def preflight_builder(self, _root, *, input_payload, expected_branch):
         self.assertEqual(expected_branch, "main")
         return build_vlm_preflight(
@@ -164,6 +179,13 @@ class VLMRunnerTests(unittest.TestCase):
                 normalize_output=lambda chinese, _english: chinese + "。",
                 unload_model=lambda: None,
             )
+        )
+
+    @staticmethod
+    def process_adapter_factory() -> ProcessIsolatedVLMAdapter:
+        return ProcessIsolatedVLMAdapter(
+            factory_ref=PROCESS_FIXTURE_FACTORY,
+            execution_timeout_s=2.0,
         )
 
     def test_local_service_probe_records_identity_without_endpoint_text(self) -> None:
@@ -400,6 +422,112 @@ class VLMRunnerTests(unittest.TestCase):
         self.assertEqual(stale_summary["lifecycle"]["accepted_result_count"], 0)
         remaining_threads = {thread.name for thread in threading.enumerate()}
         self.assertEqual(remaining_threads, baseline_threads)
+
+    def test_process_conditions_add_independently_validated_cleanup_evidence(
+        self,
+    ) -> None:
+        baseline_children = {child.pid for child in multiprocessing.active_children()}
+        with (
+            patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}),
+            patch(
+                "experiments.phase1.run_vlm_slice.collect_environment",
+                return_value=clean_environment(),
+            ),
+        ):
+            run_dirs = [
+                run_once(
+                    self.process_args(condition),
+                    repo_root=REPO_ROOT,
+                    preflight_builder=self.preflight_builder,
+                    sampler_factory=self.sampler_factory,
+                    adapter_factory=self.process_adapter_factory,
+                )
+                for condition in VLMSliceCondition
+            ]
+
+        for run_dir, condition in zip(run_dirs, VLMSliceCondition):
+            with self.subTest(condition=condition.value):
+                self.assertEqual(validate_vlm_slice_dir(run_dir), [])
+                manifest = json.loads(
+                    (run_dir / "manifest.json").read_text(encoding="utf-8")
+                )
+                process = json.loads(
+                    (run_dir / "process.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(
+                    manifest["artifact_kind"],
+                    "phase1_fixed_input_vlm_process_run",
+                )
+                self.assertEqual(manifest["adapter_isolation"], VLM_PROCESS_ISOLATION)
+                self.assertIn("process.json", manifest["artifacts"])
+                self.assertTrue(process["valid"])
+                self.assertTrue(all(gate["passed"] for gate in process["gates"]))
+                self.assertEqual(process["process"]["exit_code"], 0)
+                self.assertFalse(process["process"]["terminate_requested"])
+                combined = "\n".join(
+                    (run_dir / name).read_text(encoding="utf-8")
+                    for name in (
+                        "manifest.json",
+                        "scenario.json",
+                        "summary.json",
+                        "process.json",
+                    )
+                )
+                self.assertNotIn(str(self.input_path), combined)
+                self.assertNotIn("bounded fixture output", combined)
+
+        remaining_children = {child.pid for child in multiprocessing.active_children()}
+        self.assertEqual(remaining_children, baseline_children)
+
+    def test_process_timeout_budget_is_rejected_before_output_creation(self) -> None:
+        args = self.process_args(VLMSliceCondition.ASYNC)
+        args.process_execution_timeout_s = args.completion_timeout_s
+        with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+            with self.assertRaisesRegex(RuntimeError, "process execution timeout"):
+                run_once(
+                    args,
+                    repo_root=REPO_ROOT,
+                    preflight_builder=self.preflight_builder,
+                    sampler_factory=self.sampler_factory,
+                    adapter_factory=self.process_adapter_factory,
+                )
+        self.assertFalse((self.root / "runs" / SESSION_ID).exists())
+
+    def test_process_validator_rebuilds_hash_consistent_summary(self) -> None:
+        with (
+            patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}),
+            patch(
+                "experiments.phase1.run_vlm_slice.collect_environment",
+                return_value=clean_environment(),
+            ),
+        ):
+            run_dir = run_once(
+                self.process_args(VLMSliceCondition.ASYNC),
+                repo_root=REPO_ROOT,
+                preflight_builder=self.preflight_builder,
+                sampler_factory=self.sampler_factory,
+                adapter_factory=self.process_adapter_factory,
+            )
+        process_path = run_dir / "process.json"
+        process = json.loads(process_path.read_text(encoding="utf-8"))
+        process["process"]["exit_code"] = 9
+        process_path.write_text(
+            json.dumps(process, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        manifest_path = run_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["artifacts"]["process.json"] = {
+            "size_bytes": process_path.stat().st_size,
+            "sha256": sha256_file(process_path),
+        }
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+        errors = validate_vlm_slice_dir(run_dir)
+        self.assertTrue(any("independently rebuilt Gates" in error for error in errors))
 
     def test_validator_rebuilds_summary_after_hash_consistent_tampering(self) -> None:
         with (

--- a/experiments/phase1/tests/vlm_process_fixture.py
+++ b/experiments/phase1/tests/vlm_process_fixture.py
@@ -1,0 +1,150 @@
+"""Spawn-safe fixture adapters for process-boundary tests."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+import time
+
+from experiments.phase1.vlm_adapter import VLMExecutionRecord
+from jetson.phase1_runtime import (
+    CancellationReport,
+    ClaimedTask,
+    ExecutionOutcome,
+    ResultEnvelope,
+)
+
+
+class FixtureVLMAdapter:
+    def __init__(self) -> None:
+        self.inference_started_event = threading.Event()
+        self.last_record: VLMExecutionRecord | None = None
+
+    def __call__(self, claimed: ClaimedTask) -> ResultEnvelope:
+        self.inference_started_event.set()
+        deadline = time.monotonic() + 0.25
+        while time.monotonic() < deadline:
+            if claimed.cancellation_token.is_requested():
+                break
+            time.sleep(0.005)
+        requested = claimed.cancellation_token.is_requested()
+        outcome = ExecutionOutcome.CANCEL_OBSERVED if requested else ExecutionOutcome.OK
+        output = hashlib.sha256(b"bounded fixture output").hexdigest()
+        finished = time.monotonic_ns()
+        cancellation = CancellationReport(
+            requested=requested,
+            worker_observed=requested,
+            backend_stop_confirmed=None,
+        )
+        result = ResultEnvelope(
+            task_id=claimed.task.task_id,
+            task_kind=claimed.task.task_kind,
+            state_token=claimed.task.state_token,
+            source_monotonic_ns=claimed.task.source_monotonic_ns,
+            deadline_monotonic_ns=claimed.task.deadline_monotonic_ns,
+            input_sha256=claimed.task.payload.sha256,
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=outcome,
+            output_sha256=output,
+            output_length=22,
+            cancellation_report=cancellation,
+        )
+        self.last_record = VLMExecutionRecord(
+            task_id=claimed.task.task_id,
+            worker_thread_id=threading.get_ident(),
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=outcome.value,
+            error_code=None,
+            input_sha256=claimed.task.payload.sha256,
+            input_size_bytes=claimed.task.payload.size_bytes,
+            output_sha256=output,
+            output_length=22,
+            translation_route="qwen",
+            model_unload_requested=True,
+            model_unload_confirmed=None,
+            stage_durations_ns={
+                "input_verify_before": 1,
+                "module_import": 1,
+                "moondream_inference": 1,
+                "qwen_rewrite": 1,
+                "output_normalization": 1,
+                "model_unload": 1,
+                "input_verify_after": 1,
+            },
+            stage_status={
+                "input_verify_before": "ok",
+                "module_import": "ok",
+                "moondream_inference": "ok",
+                "qwen_rewrite": "ok",
+                "output_normalization": "ok",
+                "model_unload": "ok",
+                "input_verify_after": "ok",
+            },
+            cancellation_requested=requested,
+            worker_observed_cancellation=requested,
+            backend_stop_confirmed=None,
+        )
+        return result
+
+
+class AbruptExitVLMAdapter:
+    def __init__(self) -> None:
+        self.inference_started_event = threading.Event()
+        self.last_record = None
+
+    def __call__(self, _claimed: ClaimedTask) -> ResultEnvelope:
+        self.inference_started_event.set()
+        os._exit(17)
+
+
+class ErrorVLMAdapter(FixtureVLMAdapter):
+    def __call__(self, claimed: ClaimedTask) -> ResultEnvelope:
+        self.inference_started_event.set()
+        finished = time.monotonic_ns()
+        result = ResultEnvelope(
+            task_id=claimed.task.task_id,
+            task_kind=claimed.task.task_kind,
+            state_token=claimed.task.state_token,
+            source_monotonic_ns=claimed.task.source_monotonic_ns,
+            deadline_monotonic_ns=claimed.task.deadline_monotonic_ns,
+            input_sha256=claimed.task.payload.sha256,
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=ExecutionOutcome.ERROR,
+            error_code="fixture_failure",
+        )
+        self.last_record = VLMExecutionRecord(
+            task_id=claimed.task.task_id,
+            worker_thread_id=threading.get_ident(),
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=ExecutionOutcome.ERROR.value,
+            error_code="fixture_failure",
+            input_sha256=claimed.task.payload.sha256,
+            input_size_bytes=claimed.task.payload.size_bytes,
+            output_sha256=None,
+            output_length=None,
+            translation_route=None,
+            model_unload_requested=False,
+            model_unload_confirmed=None,
+            stage_durations_ns={"module_import": 1},
+            stage_status={"module_import": "error"},
+            cancellation_requested=False,
+            worker_observed_cancellation=False,
+            backend_stop_confirmed=None,
+        )
+        return result
+
+
+class UnresponsiveVLMAdapter:
+    def __init__(self) -> None:
+        self.inference_started_event = threading.Event()
+        self.last_record = None
+
+    def __call__(self, _claimed: ClaimedTask) -> ResultEnvelope:
+        self.inference_started_event.set()
+        while True:
+            time.sleep(1.0)

--- a/experiments/phase1/validate_vlm_slice.py
+++ b/experiments/phase1/validate_vlm_slice.py
@@ -16,6 +16,11 @@ from experiments.phase1.summarize_vlm_slice import (
     VLM_SUMMARY_SCHEMA_VERSION,
     build_vlm_summary,
 )
+from experiments.phase1.summarize_vlm_process_slice import (
+    VLM_PROCESS_ISOLATION,
+    VLM_PROCESS_SUMMARY_SCHEMA_VERSION,
+    build_vlm_process_summary,
+)
 from experiments.phase1.telemetry import SCHEMA_VERSION as EVENT_SCHEMA_VERSION
 from experiments.phase1.vlm_adapter import (
     C100_INPUT_MEDIA_TYPE,
@@ -61,6 +66,24 @@ _ADAPTER_KEYS = {
     "stage_status",
     "cancellation",
 }
+_PROCESS_REPORT_KEYS = {
+    "protocol_version",
+    "start_method",
+    "process_name",
+    "process_id",
+    "spawn_requested_monotonic_ns",
+    "child_started_monotonic_ns",
+    "inference_started_monotonic_ns",
+    "completion_received_monotonic_ns",
+    "joined_monotonic_ns",
+    "exit_code",
+    "cancellation_forwarded",
+    "cancellation_forwarded_monotonic_ns",
+    "terminate_requested",
+    "terminate_confirmed",
+    "protocol_complete",
+    "error_code",
+}
 
 
 def _read_object(path: Path, errors: list[str]) -> dict[str, Any]:
@@ -83,11 +106,13 @@ def _check_artifacts(
     directory: Path,
     artifacts: object,
     errors: list[str],
+    *,
+    required_files: tuple[str, ...] = REQUIRED_FILES,
 ) -> None:
     if not isinstance(artifacts, Mapping):
         errors.append("manifest artifact identities are missing")
         return
-    expected = set(REQUIRED_FILES) - {"manifest.json"}
+    expected = set(required_files) - {"manifest.json"}
     if set(artifacts) != expected:
         errors.append("manifest artifact identity set is incomplete or unsupported")
     for name in sorted(expected):
@@ -120,6 +145,21 @@ def validate_vlm_slice_dir(run_dir: Path | str) -> list[str]:
     if errors:
         return errors
 
+    artifact_kind = manifest.get("artifact_kind")
+    process_isolated = artifact_kind == "phase1_fixed_input_vlm_process_run"
+    required_files = (
+        REQUIRED_FILES + ("process.json",) if process_isolated else REQUIRED_FILES
+    )
+    process_summary: dict[str, Any] = {}
+    if process_isolated:
+        process_path = directory / "process.json"
+        if not process_path.is_file():
+            errors.append("missing file: process.json")
+        else:
+            process_summary = _read_object(process_path, errors)
+    if errors:
+        return errors
+
     run_id = manifest.get("run_id")
     if not isinstance(run_id, str) or run_id != directory.name:
         errors.append("manifest run_id does not match the run directory")
@@ -127,8 +167,17 @@ def validate_vlm_slice_dir(run_dir: Path | str) -> list[str]:
         errors.append("unsupported manifest schema version")
     if manifest.get("event_schema_version") != EVENT_SCHEMA_VERSION:
         errors.append("unsupported event schema version")
-    if manifest.get("artifact_kind") != "phase1_fixed_input_vlm_run":
+    if artifact_kind not in {
+        "phase1_fixed_input_vlm_run",
+        "phase1_fixed_input_vlm_process_run",
+    }:
         errors.append("manifest artifact kind is not a fixed-input VLM run")
+    adapter_isolation = manifest.get("adapter_isolation")
+    if process_isolated:
+        if adapter_isolation != VLM_PROCESS_ISOLATION:
+            errors.append("manifest process adapter isolation is inconsistent")
+    elif adapter_isolation not in {None, "thread"}:
+        errors.append("manifest thread adapter isolation is inconsistent")
     if manifest.get("trace_profile") != "runtime_threaded_probe":
         errors.append("manifest trace profile is not runtime_threaded_probe")
     if manifest.get("status") != "completed":
@@ -245,6 +294,7 @@ def validate_vlm_slice_dir(run_dir: Path | str) -> list[str]:
         return errors
     spec = manifest.get("spec")
     report = scenario.get("report")
+    process_report = scenario.get("process")
     if spec != scenario.get("spec"):
         errors.append("manifest and scenario specifications differ")
     if not isinstance(spec, Mapping):
@@ -255,6 +305,20 @@ def validate_vlm_slice_dir(run_dir: Path | str) -> list[str]:
         or spec.get("request_count") != 1
     ):
         errors.append("manifest VLM specification is inconsistent")
+    elif process_isolated and spec.get("adapter_isolation") != VLM_PROCESS_ISOLATION:
+        errors.append("process specification isolation is inconsistent")
+    elif not process_isolated and spec.get("adapter_isolation") not in {
+        None,
+        "thread",
+    }:
+        errors.append("thread specification isolation is inconsistent")
+    if process_isolated:
+        if not isinstance(process_report, Mapping):
+            errors.append("scenario process report is missing")
+        elif set(process_report) != _PROCESS_REPORT_KEYS:
+            errors.append("scenario process report fields are unsupported")
+    elif process_report is not None:
+        errors.append("thread scenario unexpectedly contains a process report")
     if not isinstance(report, Mapping):
         errors.append("scenario VLM report is missing")
     elif report.get("condition") != condition.value:
@@ -295,7 +359,12 @@ def validate_vlm_slice_dir(run_dir: Path | str) -> list[str]:
             }:
                 errors.append("scenario model-residency fields are unsupported")
 
-    _check_artifacts(directory, manifest.get("artifacts"), errors)
+    _check_artifacts(
+        directory,
+        manifest.get("artifacts"),
+        errors,
+        required_files=required_files,
+    )
     try:
         samples = load_resource_samples(directory / "resources.jsonl")
     except (OSError, UnicodeError, ValueError) as exc:
@@ -345,6 +414,42 @@ def validate_vlm_slice_dir(run_dir: Path | str) -> list[str]:
         for gate in gates
     ):
         errors.append("one or more VLM summary Gates failed")
+
+    if process_isolated:
+        if (
+            process_summary.get("vlm_process_summary_schema_version")
+            != VLM_PROCESS_SUMMARY_SCHEMA_VERSION
+        ):
+            errors.append("unsupported VLM process summary schema version")
+        if process_summary.get("adapter_isolation") != VLM_PROCESS_ISOLATION:
+            errors.append("process summary isolation is inconsistent")
+        if process_summary.get("condition") != condition.value:
+            errors.append("process summary condition is inconsistent")
+        if process_summary.get("valid") is not True:
+            errors.append("process summary Gates did not all pass")
+        process_gates = process_summary.get("gates")
+        if not isinstance(process_gates, list) or not process_gates:
+            errors.append("process summary contains no Gates")
+        elif any(
+            not isinstance(gate, Mapping) or gate.get("passed") is not True
+            for gate in process_gates
+        ):
+            errors.append("one or more process summary Gates failed")
+        if isinstance(process_report, Mapping):
+            try:
+                rebuilt_process = build_vlm_process_summary(
+                    process_report,
+                    condition=condition,
+                )
+            except (TypeError, ValueError) as exc:
+                errors.append(
+                    "process summary rebuild failed: " f"{type(exc).__name__}: {exc}"
+                )
+            else:
+                if process_summary != _json_value(rebuilt_process):
+                    errors.append(
+                        "process summary does not match independently rebuilt Gates"
+                    )
 
     if isinstance(spec, Mapping) and isinstance(report, Mapping) and samples:
         try:

--- a/experiments/phase1/vlm_process_adapter.py
+++ b/experiments/phase1/vlm_process_adapter.py
@@ -1,0 +1,874 @@
+"""Process-isolated execution boundary for the fixed-input VLM adapter."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import multiprocessing
+import re
+import threading
+import time
+from dataclasses import dataclass, replace
+from multiprocessing.connection import Connection
+from typing import Callable, Mapping
+
+from jetson.phase1_runtime import (
+    CancellationReport,
+    ClaimedTask,
+    ExecutionOutcome,
+    PayloadRef,
+    ResultEnvelope,
+    StateToken,
+    TaskEnvelope,
+    TaskKind,
+)
+
+from .vlm_adapter import VLMExecutionRecord
+
+
+PROCESS_PROTOCOL_VERSION = "0.1.0"
+DEFAULT_FACTORY_REF = "experiments.phase1.vlm_adapter:FixedInputVLMAdapter"
+MAX_PROCESS_MESSAGE_BYTES = 65_536
+
+_FACTORY_REF_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*:[a-zA-Z_][a-zA-Z0-9_.]*$")
+_ERROR_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_RECORD_KEYS = {
+    "task_id",
+    "worker_thread_id",
+    "started_monotonic_ns",
+    "finished_monotonic_ns",
+    "duration_ns",
+    "execution_outcome",
+    "error_code",
+    "input",
+    "output",
+    "translation_route",
+    "model_residency",
+    "stage_durations_ns",
+    "stage_status",
+    "cancellation",
+}
+
+
+class VLMProcessProtocolError(RuntimeError):
+    """The child process violated the bounded VLM message protocol."""
+
+
+class _VLMProcessConnectionClosed(VLMProcessProtocolError):
+    pass
+
+
+def _finite_positive_seconds(value: object, name: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError(f"{name} must be a finite positive number")
+    return float(value)
+
+
+def _bounded_error_code(prefix: str, value: object) -> str:
+    raw = f"{prefix}_{value}".lower()
+    normalized = "".join(character if character.isalnum() else "_" for character in raw)
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return (normalized or "process_worker_error")[:64]
+
+
+def _encode_message(message: Mapping[str, object]) -> bytes:
+    try:
+        encoded = json.dumps(
+            dict(message),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise VLMProcessProtocolError("process_message_not_json") from exc
+    if len(encoded) > MAX_PROCESS_MESSAGE_BYTES:
+        raise VLMProcessProtocolError("process_message_too_large")
+    return encoded
+
+
+def _send_message(
+    connection: Connection,
+    message: Mapping[str, object],
+    *,
+    lock: threading.Lock | None = None,
+) -> None:
+    encoded = _encode_message(message)
+    if lock is None:
+        connection.send_bytes(encoded)
+        return
+    with lock:
+        connection.send_bytes(encoded)
+
+
+def _receive_message(connection: Connection) -> dict[str, object]:
+    try:
+        encoded = connection.recv_bytes(MAX_PROCESS_MESSAGE_BYTES)
+    except (EOFError, OSError) as exc:
+        raise _VLMProcessConnectionClosed("process_connection_closed") from exc
+    try:
+        value = json.loads(encoded.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise VLMProcessProtocolError("process_message_invalid") from exc
+    if not isinstance(value, dict):
+        raise VLMProcessProtocolError("process_message_not_object")
+    return value
+
+
+def _serialize_claimed(claimed: ClaimedTask) -> dict[str, object]:
+    task = claimed.task
+    return {
+        "task": {
+            "task_id": task.task_id,
+            "task_kind": task.task_kind.value,
+            "source_monotonic_ns": task.source_monotonic_ns,
+            "created_monotonic_ns": task.created_monotonic_ns,
+            "deadline_monotonic_ns": task.deadline_monotonic_ns,
+            "state_token": {
+                "scope_id": task.state_token.scope_id,
+                "generation": task.state_token.generation,
+            },
+            "payload": {
+                "ref": task.payload.ref,
+                "sha256": task.payload.sha256,
+                "size_bytes": task.payload.size_bytes,
+                "media_type": task.payload.media_type,
+            },
+            "parent_task_id": task.parent_task_id,
+            "supersession_key": task.supersession_key,
+            "metadata": dict(task.metadata),
+        },
+        "started_monotonic_ns": claimed.started_monotonic_ns,
+    }
+
+
+class _ProcessCancellationToken:
+    def __init__(self, event: object) -> None:
+        self._event = event
+
+    def is_requested(self) -> bool:
+        return bool(self._event.is_set())
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return bool(self._event.wait(timeout))
+
+
+def _mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise VLMProcessProtocolError(f"{name}_not_object")
+    return value
+
+
+def _require_keys(
+    value: Mapping[str, object],
+    expected: set[str],
+    name: str,
+) -> None:
+    if set(value) != expected:
+        raise VLMProcessProtocolError(f"{name}_fields_invalid")
+
+
+def _non_negative_integer(value: object, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise VLMProcessProtocolError(f"{name}_invalid")
+    return value
+
+
+def _deserialize_claimed(
+    value: object,
+    cancellation_event: object,
+) -> ClaimedTask:
+    claimed = _mapping(value, "claimed")
+    if set(claimed) != {"task", "started_monotonic_ns"}:
+        raise VLMProcessProtocolError("claimed_fields_invalid")
+    task_value = _mapping(claimed["task"], "task")
+    if set(task_value) != {
+        "task_id",
+        "task_kind",
+        "source_monotonic_ns",
+        "created_monotonic_ns",
+        "deadline_monotonic_ns",
+        "state_token",
+        "payload",
+        "parent_task_id",
+        "supersession_key",
+        "metadata",
+    }:
+        raise VLMProcessProtocolError("task_fields_invalid")
+    state_value = _mapping(task_value["state_token"], "state_token")
+    payload_value = _mapping(task_value["payload"], "payload")
+    metadata = _mapping(task_value["metadata"], "metadata")
+    _require_keys(state_value, {"scope_id", "generation"}, "state_token")
+    _require_keys(
+        payload_value,
+        {"ref", "sha256", "size_bytes", "media_type"},
+        "payload",
+    )
+    task = TaskEnvelope(
+        task_id=task_value["task_id"],
+        task_kind=TaskKind(task_value["task_kind"]),
+        source_monotonic_ns=task_value["source_monotonic_ns"],
+        created_monotonic_ns=task_value["created_monotonic_ns"],
+        deadline_monotonic_ns=task_value["deadline_monotonic_ns"],
+        state_token=StateToken(
+            scope_id=state_value["scope_id"],
+            generation=state_value["generation"],
+        ),
+        payload=PayloadRef(
+            ref=payload_value["ref"],
+            sha256=payload_value["sha256"],
+            size_bytes=payload_value["size_bytes"],
+            media_type=payload_value["media_type"],
+        ),
+        parent_task_id=task_value["parent_task_id"],
+        supersession_key=task_value["supersession_key"],
+        metadata=dict(metadata),
+    )
+    return ClaimedTask(
+        task=task,
+        cancellation_token=_ProcessCancellationToken(cancellation_event),
+        started_monotonic_ns=claimed["started_monotonic_ns"],
+    )
+
+
+def _serialize_result(result: ResultEnvelope) -> dict[str, object]:
+    if result.output_ref is not None:
+        raise VLMProcessProtocolError("process_output_ref_forbidden")
+    cancellation = result.cancellation_report
+    return {
+        "task_id": result.task_id,
+        "task_kind": result.task_kind.value,
+        "state_token": {
+            "scope_id": result.state_token.scope_id,
+            "generation": result.state_token.generation,
+        },
+        "source_monotonic_ns": result.source_monotonic_ns,
+        "deadline_monotonic_ns": result.deadline_monotonic_ns,
+        "input_sha256": result.input_sha256,
+        "started_monotonic_ns": result.started_monotonic_ns,
+        "finished_monotonic_ns": result.finished_monotonic_ns,
+        "execution_outcome": result.execution_outcome.value,
+        "output_sha256": result.output_sha256,
+        "output_length": result.output_length,
+        "error_code": result.error_code,
+        "cancellation": {
+            "requested": cancellation.requested,
+            "client_wait_stopped": cancellation.client_wait_stopped,
+            "worker_observed": cancellation.worker_observed,
+            "backend_stop_confirmed": cancellation.backend_stop_confirmed,
+        },
+    }
+
+
+def _deserialize_result(value: object) -> ResultEnvelope:
+    result = _mapping(value, "result")
+    expected = {
+        "task_id",
+        "task_kind",
+        "state_token",
+        "source_monotonic_ns",
+        "deadline_monotonic_ns",
+        "input_sha256",
+        "started_monotonic_ns",
+        "finished_monotonic_ns",
+        "execution_outcome",
+        "output_sha256",
+        "output_length",
+        "error_code",
+        "cancellation",
+    }
+    if set(result) != expected:
+        raise VLMProcessProtocolError("result_fields_invalid")
+    state = _mapping(result["state_token"], "result_state_token")
+    cancellation = _mapping(result["cancellation"], "result_cancellation")
+    _require_keys(state, {"scope_id", "generation"}, "result_state_token")
+    _require_keys(
+        cancellation,
+        {
+            "requested",
+            "client_wait_stopped",
+            "worker_observed",
+            "backend_stop_confirmed",
+        },
+        "result_cancellation",
+    )
+    return ResultEnvelope(
+        task_id=result["task_id"],
+        task_kind=TaskKind(result["task_kind"]),
+        state_token=StateToken(
+            scope_id=state["scope_id"],
+            generation=state["generation"],
+        ),
+        source_monotonic_ns=result["source_monotonic_ns"],
+        deadline_monotonic_ns=result["deadline_monotonic_ns"],
+        input_sha256=result["input_sha256"],
+        started_monotonic_ns=result["started_monotonic_ns"],
+        finished_monotonic_ns=result["finished_monotonic_ns"],
+        execution_outcome=ExecutionOutcome(result["execution_outcome"]),
+        output_sha256=result["output_sha256"],
+        output_length=result["output_length"],
+        error_code=result["error_code"],
+        cancellation_report=CancellationReport(
+            requested=cancellation["requested"],
+            client_wait_stopped=cancellation["client_wait_stopped"],
+            worker_observed=cancellation["worker_observed"],
+            backend_stop_confirmed=cancellation["backend_stop_confirmed"],
+        ),
+    )
+
+
+def _deserialize_record(value: object) -> VLMExecutionRecord:
+    record = _mapping(value, "record")
+    if set(record) != _RECORD_KEYS:
+        raise VLMProcessProtocolError("record_fields_invalid")
+    input_value = _mapping(record["input"], "record_input")
+    output_raw = record["output"]
+    output_value = None if output_raw is None else _mapping(output_raw, "record_output")
+    residency = _mapping(record["model_residency"], "record_residency")
+    cancellation = _mapping(record["cancellation"], "record_cancellation")
+    durations = _mapping(record["stage_durations_ns"], "record_durations")
+    statuses = _mapping(record["stage_status"], "record_statuses")
+    _require_keys(
+        input_value,
+        {"sha256", "size_bytes", "media_type"},
+        "record_input",
+    )
+    if output_value is not None:
+        _require_keys(
+            output_value,
+            {"sha256", "length", "raw_text_recorded"},
+            "record_output",
+        )
+        if output_value["raw_text_recorded"] is not False:
+            raise VLMProcessProtocolError("record_output_not_private")
+    _require_keys(
+        residency,
+        {"unload_requested", "unload_confirmed"},
+        "record_residency",
+    )
+    _require_keys(
+        cancellation,
+        {
+            "requested",
+            "worker_observed",
+            "client_wait_stopped",
+            "backend_stop_confirmed",
+        },
+        "record_cancellation",
+    )
+    if any(
+        not isinstance(name, str)
+        or isinstance(duration, bool)
+        or not isinstance(duration, int)
+        or duration < 0
+        for name, duration in durations.items()
+    ):
+        raise VLMProcessProtocolError("record_durations_invalid")
+    if any(
+        not isinstance(name, str) or status not in {"ok", "error"}
+        for name, status in statuses.items()
+    ):
+        raise VLMProcessProtocolError("record_statuses_invalid")
+    return VLMExecutionRecord(
+        task_id=record["task_id"],
+        worker_thread_id=record["worker_thread_id"],
+        started_monotonic_ns=record["started_monotonic_ns"],
+        finished_monotonic_ns=record["finished_monotonic_ns"],
+        execution_outcome=record["execution_outcome"],
+        error_code=record["error_code"],
+        input_sha256=input_value["sha256"],
+        input_size_bytes=input_value["size_bytes"],
+        output_sha256=None if output_value is None else output_value["sha256"],
+        output_length=None if output_value is None else output_value["length"],
+        translation_route=record["translation_route"],
+        model_unload_requested=residency["unload_requested"],
+        model_unload_confirmed=residency["unload_confirmed"],
+        stage_durations_ns=dict(durations),
+        stage_status=dict(statuses),
+        cancellation_requested=cancellation["requested"],
+        worker_observed_cancellation=cancellation["worker_observed"],
+        backend_stop_confirmed=cancellation["backend_stop_confirmed"],
+    )
+
+
+def _decode_worker_message(
+    message: Mapping[str, object],
+) -> tuple[str, object]:
+    message_type = message.get("type")
+    if message_type == "worker_started":
+        _require_keys(
+            message,
+            {"type", "protocol_version", "monotonic_ns"},
+            "worker_started",
+        )
+        if message.get("protocol_version") != PROCESS_PROTOCOL_VERSION:
+            raise VLMProcessProtocolError("process_protocol_version_mismatch")
+        return message_type, _non_negative_integer(
+            message.get("monotonic_ns"),
+            "worker_started_time",
+        )
+    if message_type == "inference_started":
+        _require_keys(
+            message,
+            {"type", "monotonic_ns"},
+            "inference_started",
+        )
+        return message_type, _non_negative_integer(
+            message.get("monotonic_ns"),
+            "inference_started_time",
+        )
+    if message_type == "completed":
+        _require_keys(
+            message,
+            {"type", "result", "record", "monotonic_ns"},
+            "completed",
+        )
+        _non_negative_integer(message.get("monotonic_ns"), "completed_time")
+        return message_type, (
+            _deserialize_result(message.get("result")),
+            _deserialize_record(message.get("record")),
+        )
+    if message_type == "failed":
+        _require_keys(
+            message,
+            {"type", "error_code", "monotonic_ns"},
+            "failed",
+        )
+        _non_negative_integer(message.get("monotonic_ns"), "failed_time")
+        error_code = message.get("error_code")
+        if not isinstance(error_code, str) or not _ERROR_CODE_RE.fullmatch(error_code):
+            raise VLMProcessProtocolError("failed_error_code_invalid")
+        return message_type, error_code
+    raise VLMProcessProtocolError("process_message_type_invalid")
+
+
+def _resolve_factory(reference: object) -> Callable[[], object]:
+    if not isinstance(reference, str) or not _FACTORY_REF_RE.fullmatch(reference):
+        raise VLMProcessProtocolError("factory_ref_invalid")
+    module_name, attribute_path = reference.split(":", 1)
+    value: object = importlib.import_module(module_name)
+    for attribute in attribute_path.split("."):
+        value = getattr(value, attribute)
+    if not callable(value):
+        raise VLMProcessProtocolError("factory_not_callable")
+    return value
+
+
+def _process_worker_main(
+    connection: Connection,
+    cancellation_event: object,
+) -> None:
+    send_lock = threading.Lock()
+    monitor_stop = threading.Event()
+    monitor: threading.Thread | None = None
+    try:
+        _send_message(
+            connection,
+            {
+                "type": "worker_started",
+                "protocol_version": PROCESS_PROTOCOL_VERSION,
+                "monotonic_ns": time.monotonic_ns(),
+            },
+            lock=send_lock,
+        )
+        message = _receive_message(connection)
+        if set(message) != {
+            "type",
+            "protocol_version",
+            "factory_ref",
+            "claimed",
+        }:
+            raise VLMProcessProtocolError("start_fields_invalid")
+        if message["type"] != "start":
+            raise VLMProcessProtocolError("start_message_missing")
+        if message["protocol_version"] != PROCESS_PROTOCOL_VERSION:
+            raise VLMProcessProtocolError("process_protocol_version_mismatch")
+        claimed = _deserialize_claimed(message["claimed"], cancellation_event)
+        factory = _resolve_factory(message["factory_ref"])
+        adapter = factory()
+        inference_event = getattr(adapter, "inference_started_event", None)
+        if not callable(getattr(inference_event, "wait", None)):
+            raise VLMProcessProtocolError("inference_signal_missing")
+
+        def publish_inference_start() -> None:
+            while not monitor_stop.is_set():
+                if inference_event.wait(0.02):
+                    _send_message(
+                        connection,
+                        {
+                            "type": "inference_started",
+                            "monotonic_ns": time.monotonic_ns(),
+                        },
+                        lock=send_lock,
+                    )
+                    return
+
+        monitor = threading.Thread(
+            target=publish_inference_start,
+            name="phase1-vlm-process-signal",
+        )
+        monitor.start()
+        result = adapter(claimed)
+        record = getattr(adapter, "last_record", None)
+        if not isinstance(result, ResultEnvelope):
+            raise VLMProcessProtocolError("child_result_invalid")
+        if not isinstance(record, VLMExecutionRecord):
+            raise VLMProcessProtocolError("child_record_missing")
+        _send_message(
+            connection,
+            {
+                "type": "completed",
+                "result": _serialize_result(result),
+                "record": record.to_dict(),
+                "monotonic_ns": time.monotonic_ns(),
+            },
+            lock=send_lock,
+        )
+    except BaseException as exc:
+        try:
+            _send_message(
+                connection,
+                {
+                    "type": "failed",
+                    "error_code": _bounded_error_code(
+                        "process_worker", type(exc).__name__
+                    ),
+                    "monotonic_ns": time.monotonic_ns(),
+                },
+                lock=send_lock,
+            )
+        except BaseException:
+            pass
+    finally:
+        monitor_stop.set()
+        if monitor is not None:
+            monitor.join(0.2)
+        connection.close()
+
+
+@dataclass(frozen=True, slots=True)
+class VLMProcessReport:
+    """Bounded supervisor facts for one child-process invocation."""
+
+    protocol_version: str
+    start_method: str
+    process_name: str
+    process_id: int | None
+    spawn_requested_monotonic_ns: int
+    child_started_monotonic_ns: int | None
+    inference_started_monotonic_ns: int | None
+    completion_received_monotonic_ns: int | None
+    joined_monotonic_ns: int
+    exit_code: int | None
+    cancellation_forwarded: bool
+    cancellation_forwarded_monotonic_ns: int | None
+    terminate_requested: bool
+    terminate_confirmed: bool
+    protocol_complete: bool
+    error_code: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "protocol_version": self.protocol_version,
+            "start_method": self.start_method,
+            "process_name": self.process_name,
+            "process_id": self.process_id,
+            "spawn_requested_monotonic_ns": self.spawn_requested_monotonic_ns,
+            "child_started_monotonic_ns": self.child_started_monotonic_ns,
+            "inference_started_monotonic_ns": self.inference_started_monotonic_ns,
+            "completion_received_monotonic_ns": (self.completion_received_monotonic_ns),
+            "joined_monotonic_ns": self.joined_monotonic_ns,
+            "exit_code": self.exit_code,
+            "cancellation_forwarded": self.cancellation_forwarded,
+            "cancellation_forwarded_monotonic_ns": (
+                self.cancellation_forwarded_monotonic_ns
+            ),
+            "terminate_requested": self.terminate_requested,
+            "terminate_confirmed": self.terminate_confirmed,
+            "protocol_complete": self.protocol_complete,
+            "error_code": self.error_code,
+        }
+
+
+class ProcessIsolatedVLMAdapter:
+    """Supervise one fixed-input VLM invocation in a spawned process."""
+
+    def __init__(
+        self,
+        *,
+        factory_ref: str = DEFAULT_FACTORY_REF,
+        execution_timeout_s: float = 720.0,
+        poll_interval_s: float = 0.02,
+        join_timeout_s: float = 5.0,
+        terminate_join_timeout_s: float = 5.0,
+        start_method: str = "spawn",
+        clock_ns: Callable[[], int] = time.monotonic_ns,
+    ) -> None:
+        if not isinstance(factory_ref, str) or not _FACTORY_REF_RE.fullmatch(
+            factory_ref
+        ):
+            raise ValueError("factory_ref must be a module:attribute reference")
+        for name, value in (
+            ("execution_timeout_s", execution_timeout_s),
+            ("poll_interval_s", poll_interval_s),
+            ("join_timeout_s", join_timeout_s),
+            ("terminate_join_timeout_s", terminate_join_timeout_s),
+        ):
+            _finite_positive_seconds(value, name)
+        if start_method != "spawn":
+            raise ValueError("start_method must be spawn")
+        if not callable(clock_ns):
+            raise TypeError("clock_ns must be callable")
+        self._factory_ref = factory_ref
+        self._execution_timeout_s = float(execution_timeout_s)
+        self._poll_interval_s = float(poll_interval_s)
+        self._join_timeout_s = float(join_timeout_s)
+        self._terminate_join_timeout_s = float(terminate_join_timeout_s)
+        self._start_method = start_method
+        self._clock_ns = clock_ns
+        self._invocation_lock = threading.Lock()
+        self._record_lock = threading.Lock()
+        self._last_record: VLMExecutionRecord | None = None
+        self._last_process_report: VLMProcessReport | None = None
+        self.inference_started_event = threading.Event()
+
+    @property
+    def last_record(self) -> VLMExecutionRecord | None:
+        with self._record_lock:
+            return self._last_record
+
+    @property
+    def last_process_report(self) -> VLMProcessReport | None:
+        with self._record_lock:
+            return self._last_process_report
+
+    def _publish(
+        self,
+        record: VLMExecutionRecord,
+        process_report: VLMProcessReport,
+    ) -> None:
+        with self._record_lock:
+            self._last_record = record
+            self._last_process_report = process_report
+
+    def _failure_result(
+        self,
+        claimed: ClaimedTask,
+        *,
+        outcome: ExecutionOutcome,
+        error_code: str,
+    ) -> tuple[ResultEnvelope, VLMExecutionRecord]:
+        finished = max(claimed.started_monotonic_ns, self._clock_ns())
+        requested = claimed.cancellation_token.is_requested()
+        cancellation = CancellationReport(
+            requested=requested,
+            client_wait_stopped=False,
+            worker_observed=requested,
+            backend_stop_confirmed=None,
+        )
+        result = ResultEnvelope(
+            task_id=claimed.task.task_id,
+            task_kind=claimed.task.task_kind,
+            state_token=claimed.task.state_token,
+            source_monotonic_ns=claimed.task.source_monotonic_ns,
+            deadline_monotonic_ns=claimed.task.deadline_monotonic_ns,
+            input_sha256=claimed.task.payload.sha256,
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=outcome,
+            error_code=error_code,
+            cancellation_report=cancellation,
+        )
+        record = VLMExecutionRecord(
+            task_id=claimed.task.task_id,
+            worker_thread_id=threading.get_ident(),
+            started_monotonic_ns=claimed.started_monotonic_ns,
+            finished_monotonic_ns=finished,
+            execution_outcome=outcome.value,
+            error_code=error_code,
+            input_sha256=claimed.task.payload.sha256,
+            input_size_bytes=claimed.task.payload.size_bytes,
+            output_sha256=None,
+            output_length=None,
+            translation_route=None,
+            model_unload_requested=False,
+            model_unload_confirmed=None,
+            stage_durations_ns={},
+            stage_status={},
+            cancellation_requested=requested,
+            worker_observed_cancellation=requested,
+            backend_stop_confirmed=None,
+        )
+        return result, record
+
+    def __call__(self, claimed: ClaimedTask) -> ResultEnvelope:
+        if not isinstance(claimed, ClaimedTask):
+            raise TypeError("claimed must be a ClaimedTask")
+        if not self._invocation_lock.acquire(blocking=False):
+            raise VLMProcessProtocolError("vlm_process_adapter_busy")
+        self.inference_started_event.clear()
+        context = multiprocessing.get_context(self._start_method)
+        parent_connection, child_connection = context.Pipe(duplex=True)
+        cancellation_event = context.Event()
+        process = context.Process(
+            target=_process_worker_main,
+            args=(child_connection, cancellation_event),
+            name="phase1-vlm-process-worker",
+            daemon=False,
+        )
+        spawn_requested_ns = self._clock_ns()
+        child_started_ns: int | None = None
+        inference_started_ns: int | None = None
+        completion_received_ns: int | None = None
+        cancellation_forwarded_ns: int | None = None
+        terminate_requested = False
+        terminate_confirmed = False
+        protocol_complete = False
+        error_code: str | None = None
+        result: ResultEnvelope | None = None
+        record: VLMExecutionRecord | None = None
+        try:
+            try:
+                process.start()
+            except BaseException as exc:
+                error_code = _bounded_error_code("process_start", type(exc).__name__)
+            finally:
+                child_connection.close()
+
+            if error_code is None:
+                try:
+                    _send_message(
+                        parent_connection,
+                        {
+                            "type": "start",
+                            "protocol_version": PROCESS_PROTOCOL_VERSION,
+                            "factory_ref": self._factory_ref,
+                            "claimed": _serialize_claimed(claimed),
+                        },
+                    )
+                except (OSError, VLMProcessProtocolError):
+                    error_code = "process_start_message_failed"
+                    terminate_requested = True
+            if error_code is None:
+                deadline = time.monotonic() + self._execution_timeout_s
+                while result is None and error_code is None:
+                    if (
+                        claimed.cancellation_token.is_requested()
+                        and cancellation_forwarded_ns is None
+                    ):
+                        cancellation_event.set()
+                        cancellation_forwarded_ns = self._clock_ns()
+                    if parent_connection.poll(self._poll_interval_s):
+                        try:
+                            message = _receive_message(parent_connection)
+                        except _VLMProcessConnectionClosed:
+                            error_code = "process_worker_exit"
+                            continue
+                        except VLMProcessProtocolError:
+                            error_code = "process_message_invalid"
+                            continue
+                        try:
+                            message_type, payload = _decode_worker_message(message)
+                        except VLMProcessProtocolError as exc:
+                            error_code = str(exc)
+                            if not _ERROR_CODE_RE.fullmatch(error_code):
+                                error_code = "process_message_invalid"
+                            continue
+                        if message_type == "worker_started":
+                            assert isinstance(payload, int)
+                            child_started_ns = payload
+                        elif message_type == "inference_started":
+                            assert isinstance(payload, int)
+                            inference_started_ns = payload
+                            self.inference_started_event.set()
+                        elif message_type == "completed":
+                            assert isinstance(payload, tuple)
+                            result, record = payload
+                            completion_received_ns = self._clock_ns()
+                            protocol_complete = True
+                        elif message_type == "failed":
+                            assert isinstance(payload, str)
+                            error_code = payload
+                    elif not process.is_alive():
+                        error_code = "process_worker_exit"
+                    elif time.monotonic() >= deadline:
+                        error_code = "process_worker_timeout"
+                        terminate_requested = True
+
+            if process.pid is not None:
+                if terminate_requested and process.is_alive():
+                    process.terminate()
+                    process.join(self._terminate_join_timeout_s)
+                else:
+                    process.join(self._join_timeout_s)
+                    if process.is_alive():
+                        terminate_requested = True
+                        process.terminate()
+                        process.join(self._terminate_join_timeout_s)
+                terminate_confirmed = terminate_requested and not process.is_alive()
+
+            if result is None or record is None:
+                outcome = (
+                    ExecutionOutcome.TIMEOUT
+                    if error_code == "process_worker_timeout"
+                    else ExecutionOutcome.ERROR
+                )
+                result, record = self._failure_result(
+                    claimed,
+                    outcome=outcome,
+                    error_code=error_code or "process_worker_failed",
+                )
+            elif claimed.cancellation_token.is_requested() and (
+                result.execution_outcome is ExecutionOutcome.OK
+            ):
+                cancellation = CancellationReport(
+                    requested=True,
+                    client_wait_stopped=False,
+                    worker_observed=True,
+                    backend_stop_confirmed=None,
+                )
+                result = replace(
+                    result,
+                    execution_outcome=ExecutionOutcome.CANCEL_OBSERVED,
+                    cancellation_report=cancellation,
+                )
+                record = replace(
+                    record,
+                    execution_outcome=ExecutionOutcome.CANCEL_OBSERVED.value,
+                    cancellation_requested=True,
+                    worker_observed_cancellation=True,
+                    backend_stop_confirmed=None,
+                )
+
+            report = VLMProcessReport(
+                protocol_version=PROCESS_PROTOCOL_VERSION,
+                start_method=self._start_method,
+                process_name=process.name,
+                process_id=process.pid,
+                spawn_requested_monotonic_ns=spawn_requested_ns,
+                child_started_monotonic_ns=child_started_ns,
+                inference_started_monotonic_ns=inference_started_ns,
+                completion_received_monotonic_ns=completion_received_ns,
+                joined_monotonic_ns=self._clock_ns(),
+                exit_code=process.exitcode,
+                cancellation_forwarded=cancellation_forwarded_ns is not None,
+                cancellation_forwarded_monotonic_ns=cancellation_forwarded_ns,
+                terminate_requested=terminate_requested,
+                terminate_confirmed=terminate_confirmed,
+                protocol_complete=protocol_complete,
+                error_code=error_code,
+            )
+            self._publish(record, report)
+            return result
+        finally:
+            parent_connection.close()
+            if process.pid is not None and process.is_alive():
+                process.terminate()
+                process.join(self._terminate_join_timeout_s)
+            self._invocation_lock.release()

--- a/experiments/phase1/vlm_slice.py
+++ b/experiments/phase1/vlm_slice.py
@@ -7,11 +7,12 @@ import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable
+from typing import Callable, Protocol
 
 from jetson.phase1_runtime import (
     BoundedTaskBroker,
     BrokerSnapshot,
+    ClaimedTask,
     ExecutorShutdownReport,
     FinalDisposition,
     LaneConfig,
@@ -21,12 +22,24 @@ from jetson.phase1_runtime import (
     PeriodicProbe,
     ProbeStopReport,
     RuntimeEventSink,
+    ResultEnvelope,
     StateToken,
     TaskEnvelope,
     TaskKind,
 )
 
 from .vlm_adapter import FixedInputVLMAdapter, VLMExecutionRecord
+
+
+class VLMAdapter(Protocol):
+    """Minimum parent-side contract shared by thread and process adapters."""
+
+    inference_started_event: threading.Event
+
+    @property
+    def last_record(self) -> VLMExecutionRecord | None: ...
+
+    def __call__(self, claimed: ClaimedTask) -> ResultEnvelope: ...
 
 
 class VLMSliceCondition(str, Enum):
@@ -233,7 +246,7 @@ def run_vlm_slice(
     payload: PayloadRef,
     event_sink: RuntimeEventSink,
     *,
-    adapter: FixedInputVLMAdapter | None = None,
+    adapter: VLMAdapter | None = None,
     task_id: str = "vlm-001",
 ) -> VLMSliceReport:
     """Run one nominal or invalidated VLM request and close all threads."""

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -2,9 +2,9 @@
 
 The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel. The experiment layer now connects that kernel to the fixed Phase 0 VLM input without changing the robot application.
 
-The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. The experiment harness under `experiments/phase1/` has completed one motion-disabled simulation pilot and one fixed-input VLM correctness pilot on the Jetson. The real-model pilot validated nominal consumption and stale-result rejection, but also recorded skipped probe releases during lazy Python module import; formal comparison and application integration remain research work.
+The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. The experiment harness under `experiments/phase1/` has completed one motion-disabled simulation pilot and one fixed-input VLM correctness pilot on the Jetson. The real-model pilot validated nominal consumption and stale-result rejection, but also recorded skipped probe releases during lazy Python module import. A spawned-process VLM adapter is now host-tested to address that boundary; its Jetson pilot, formal comparison and application integration remain research work.
 
-> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 已完成固定输入 VLM 的 Jetson correctness pilot，但正式对比实验与运动控制接入尚未开始。
+> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 已完成固定输入 VLM 的 Jetson correctness pilot，进程隔离路径已通过 host-only 测试、尚待实机 pilot，正式对比实验与运动控制接入尚未开始。
 
 ## Modules
 
@@ -116,6 +116,7 @@ Audio, ASR text, captured images and communication logs are written beneath `ROB
 
 - The orchestration path is blocking and single-process; inference tasks do not have explicit deadlines or cancellation.
 - The Phase 1 VLM experiment uses one fixed file and is not connected to live acquisition, TTS or the synchronous application loop.
+- The spawned-process VLM path is an experiment runner boundary, not an application worker pool; no Jetson timing result has been collected from it yet.
 - llama.cpp and Ollama are managed outside the application.
 - The color tracker uses fixed HSV ranges and discrete motion commands tuned on the thesis robot.
 - The Jetson sends speed percentages, while the STM32 applies open-loop PWM rather than closed-loop wheel velocity.


### PR DESCRIPTION
## Summary

- add a spawned-process execution boundary for the fixed-input VLM adapter
- keep broker ownership, state generations, freshness checks and the periodic probe in the parent process
- add bounded IPC, cancellation forwarding and explicit child cleanup evidence
- extend the VLM runner and validator with an independently rebuilt process summary
- preserve compatibility with existing thread-mode VLM pilot artifacts

## Motivation

The first real-model VLM pilot passed its lifecycle-correctness Gates, but the 100 ms probe recorded 85 and 63 skipped releases during lazy Python module import.

This showed that moving the adapter into another Python thread did not isolate every GIL-holding workload. The new path evaluates a process-level mitigation without changing the broker, result-freshness policy or robot application.

## Process boundary

The implementation uses one child process per VLM request with the `spawn` start method.

The parent process remains responsible for:

- task admission and bounded ownership
- state generation changes
- result freshness and final dispositions
- lifecycle event recording
- the independent periodic probe
- child supervision and cleanup

The child process is responsible only for the fixed-input VLM adapter invocation.

Application messages use JSON with a maximum size of 65,536 bytes. Model text, prompts, exception tracebacks and private input paths are excluded from public artifacts.

## Cancellation and cleanup semantics

- stale-state cancellation is forwarded through a process-safe event
- the parent broker still owns the final `rejected_state` decision
- normal completion requires protocol closure, exit code zero and child reaping
- abrupt exit, malformed IPC and timeout become bounded adapter errors
- forced child termination is recorded explicitly
- child-process termination does not claim that Ollama or GPU inference stopped

## Evidence and validation

Process-isolated runs use `adapter_isolation=spawned_process`.

They receive distinct run IDs and add `process.json`, which is independently rebuilt from supervisor facts in `scenario.json`.

The process Gates require:

- one spawned child identity
- complete bounded IPC
- ordered spawn, inference, completion and join boundaries
- condition-correct cancellation forwarding
- normal exit and reaping without forced termination

The original thread mode remains the default. Existing VLM pilot artifacts produced with the earlier contract continue to validate.

## Test coverage

Host tests cover:

- nominal process completion
- stale-state cancellation forwarding
- integration with the existing broker, executor and periodic probe
- child-side execution errors
- abrupt child exit
- execution timeout and forced cleanup
- process-summary tampering
- import safety and child-process leak checks
- privacy boundaries for paths and model output

Validation results:

- Phase 0: 29 passed
- Phase 1: 117 passed
- total: 146 passed
- Black, Pyflakes and compileall passed
- both archived thread-mode VLM runs remain `VALID`

## Safety and claim boundary

- physical motion remains disabled
- UART and STM32 behavior are unchanged
- the synchronous application path is unchanged
- raw Jetson evidence remains outside version control
- no process-isolated Jetson result has been collected yet
- no timing-isolation, performance-superiority, hard-real-time or heterogeneous-inference claim is made