### PR TITLE
fix(phase1): make VLM process reaping deterministic

### DIFF
--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -483,6 +483,13 @@ with code zero and be reaped without `terminate`. An EOF, malformed message,
 unexpected child exit or execution timeout becomes a bounded adapter error;
 the parent still reaps or terminates the child within finite budgets.
 
+After the final protocol message is sent, the child stops its signal monitor,
+closes the private pipe and exits from inside the process with the appropriate
+status code. This explicit process boundary prevents imported inference
+runtimes from holding the interpreter open after their bounded result has been
+delivered. It does not bypass adapter cleanup: model unload and output
+normalization finish before the completion message is constructed.
+
 Cancellation is forwarded through a process-safe event. For `vlm_stale`, the
 parent advances the generation only after receiving the child inference-start
 signal. The child may later report that it observed cancellation, but the
@@ -495,6 +502,10 @@ The process runner adds `adapter_isolation=spawned_process`, a distinct run ID
 and `process.json`. The latter is rebuilt from the supervisor facts in
 `scenario.json` and fails closed unless spawn ownership, protocol completion,
 boundary order, cancellation forwarding and normal child reaping all pass.
+The runner writes the scenario, process summary and any available slice summary
+before applying those final Gates. A failed manifest remains ineligible but
+hashes each completed diagnostic artifact, so a cleanup failure does not erase
+the evidence needed to identify it.
 The original thread mode remains the default and the first VLM pilot remains
 valid under its earlier artifact contract.
 

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -299,6 +299,12 @@ cancellation forwarding, exit code zero and a normally reaped child. A forced
 child termination is recorded separately and never becomes a claim that the
 Ollama backend stopped inference.
 
+The child closes its bounded protocol and exits from inside the process after
+adapter cleanup, preventing imported inference runtimes from delaying process
+reaping during interpreter shutdown. If a final Gate still fails, the run is
+marked failed after its completed scenario, process and slice diagnostics are
+written and hashed.
+
 After this implementation is merged and the Jetson is synchronized to that
 `main` commit, the two motion-disabled pilot conditions can be run with:
 

--- a/experiments/phase1/run_vlm_slice.py
+++ b/experiments/phase1/run_vlm_slice.py
@@ -129,6 +129,25 @@ def _artifact_identity(path: Path) -> dict[str, object]:
     }
 
 
+def _completed_artifact_identities(
+    run_dir: Path,
+    completed_names: set[str],
+) -> dict[str, object]:
+    names = (
+        "preflight.json",
+        "events.jsonl",
+        "resources.jsonl",
+        "scenario.json",
+        "summary.json",
+        "process.json",
+    )
+    return {
+        name: _artifact_identity(run_dir / name)
+        for name in names
+        if name in completed_names
+    }
+
+
 def _reproducibility(
     environment: dict[str, object],
     *,
@@ -226,6 +245,7 @@ def run_once(
     preflight_path = run_dir / "preflight.json"
     manifest_path = run_dir / "manifest.json"
     write_json_atomic(preflight_path, preflight)
+    completed_artifact_names = {"preflight.json"}
 
     spec = VLMSliceSpec(
         condition=condition,
@@ -323,7 +343,9 @@ def run_once(
         )
         recorder.close()
         recorder = None
+        completed_artifact_names.add("events.jsonl")
         sampler_report = sampler.stop()
+        completed_artifact_names.add("resources.jsonl")
         manifest["resource_sampler_report"] = sampler_report.to_dict()
         if not sampler_report.successful:
             raise VLMRunError("tegrastats did not produce a valid closed trace")
@@ -345,10 +367,12 @@ def run_once(
                 process_record,
                 condition=condition,
             )
-            if process_summary.get("valid") is not True:
-                raise VLMRunError("one or more VLM process Gates failed")
         scenario_path = run_dir / "scenario.json"
         write_json_atomic(scenario_path, scenario)
+        completed_artifact_names.add("scenario.json")
+        if process_summary is not None:
+            write_json_atomic(run_dir / "process.json", process_summary)
+            completed_artifact_names.add("process.json")
         samples = load_resource_samples(run_dir / "resources.jsonl")
         summary = build_vlm_summary(
             run_dir / "events.jsonl",
@@ -361,11 +385,11 @@ def run_once(
         )
         summary_path = run_dir / "summary.json"
         write_json_atomic(summary_path, summary)
+        completed_artifact_names.add("summary.json")
+        if process_summary is not None and process_summary.get("valid") is not True:
+            raise VLMRunError("one or more VLM process Gates failed")
         if summary.get("valid") is not True:
             raise VLMRunError("one or more VLM slice Gates failed")
-
-        if process_summary is not None:
-            write_json_atomic(run_dir / "process.json", process_summary)
 
         artifact_names = [
             "preflight.json",
@@ -393,6 +417,7 @@ def run_once(
     except Exception as exc:
         if recorder is not None:
             recorder.close()
+            completed_artifact_names.add("events.jsonl")
         if sampler is not None and sampler.is_running:
             try:
                 sampler.stop()
@@ -400,6 +425,11 @@ def run_once(
                 manifest["cleanup_error_code"] = type(cleanup_exc).__name__.lower()
         if sampler is not None and sampler.stop_report is not None:
             manifest["resource_sampler_report"] = sampler.stop_report.to_dict()
+            completed_artifact_names.add("resources.jsonl")
+        manifest["artifacts"] = _completed_artifact_identities(
+            run_dir,
+            completed_artifact_names,
+        )
         manifest["status"] = "failed"
         manifest["completed_at"] = utc_now_iso()
         manifest["failure_code"] = type(exc).__name__.lower()

--- a/experiments/phase1/tests/test_vlm_process_adapter.py
+++ b/experiments/phase1/tests/test_vlm_process_adapter.py
@@ -35,6 +35,9 @@ UNRESPONSIVE_FACTORY = (
     "experiments.phase1.tests.vlm_process_fixture:UnresponsiveVLMAdapter"
 )
 ERROR_FACTORY = "experiments.phase1.tests.vlm_process_fixture:ErrorVLMAdapter"
+LINGERING_THREAD_FACTORY = (
+    "experiments.phase1.tests.vlm_process_fixture:LingeringThreadVLMAdapter"
+)
 
 
 class ProcessIsolatedVLMAdapterTests(unittest.TestCase):
@@ -179,6 +182,23 @@ class ProcessIsolatedVLMAdapterTests(unittest.TestCase):
         self.assertIsNone(record.output_sha256)
         self.assertTrue(report.protocol_complete)
         self.assertEqual(report.exit_code, 0)
+
+    def test_completed_child_exit_is_not_blocked_by_runtime_threads(self) -> None:
+        adapter = ProcessIsolatedVLMAdapter(
+            factory_ref=LINGERING_THREAD_FACTORY,
+            execution_timeout_s=5.0,
+            join_timeout_s=1.0,
+        )
+        result = adapter(self.claimed())
+        report = adapter.last_process_report
+
+        self.assertEqual(result.execution_outcome, ExecutionOutcome.OK)
+        self.assertIsNotNone(report)
+        assert report is not None
+        self.assertTrue(report.protocol_complete)
+        self.assertEqual(report.exit_code, 0)
+        self.assertFalse(report.terminate_requested)
+        self.assertFalse(report.terminate_confirmed)
 
     def test_unresponsive_child_is_terminated_and_reaped(self) -> None:
         adapter = ProcessIsolatedVLMAdapter(

--- a/experiments/phase1/tests/test_vlm_runner.py
+++ b/experiments/phase1/tests/test_vlm_runner.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import threading
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -478,6 +479,82 @@ class VLMRunnerTests(unittest.TestCase):
 
         remaining_children = {child.pid for child in multiprocessing.active_children()}
         self.assertEqual(remaining_children, baseline_children)
+
+    def test_failed_process_gate_persists_hashed_diagnostics(self) -> None:
+        class ReapingFailureAdapter:
+            def __init__(self) -> None:
+                self.delegate = ProcessIsolatedVLMAdapter(
+                    factory_ref=PROCESS_FIXTURE_FACTORY,
+                    execution_timeout_s=2.0,
+                )
+                self.inference_started_event = self.delegate.inference_started_event
+                self.last_record = None
+                self.last_process_report = None
+
+            def __call__(self, claimed):
+                result = self.delegate(claimed)
+                self.last_record = self.delegate.last_record
+                report = self.delegate.last_process_report
+                assert report is not None
+                self.last_process_report = replace(
+                    report,
+                    exit_code=-15,
+                    terminate_requested=True,
+                    terminate_confirmed=True,
+                )
+                return result
+
+        with (
+            patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}),
+            patch(
+                "experiments.phase1.run_vlm_slice.collect_environment",
+                return_value=clean_environment(),
+            ),
+            self.assertRaisesRegex(RuntimeError, "process Gates failed"),
+        ):
+            run_once(
+                self.process_args(VLMSliceCondition.ASYNC),
+                repo_root=REPO_ROOT,
+                preflight_builder=self.preflight_builder,
+                sampler_factory=self.sampler_factory,
+                adapter_factory=ReapingFailureAdapter,
+            )
+
+        session_dir = self.root / "runs" / SESSION_ID
+        manifest_path = next(session_dir.rglob("manifest.json"))
+        run_dir = manifest_path.parent
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        process = json.loads((run_dir / "process.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(manifest["status"], "failed")
+        self.assertEqual(manifest["failure_code"], "vlmrunerror")
+        self.assertEqual(
+            set(manifest["artifacts"]),
+            {
+                "preflight.json",
+                "events.jsonl",
+                "resources.jsonl",
+                "scenario.json",
+                "summary.json",
+                "process.json",
+            },
+        )
+        self.assertFalse(process["valid"])
+        reaping_gate = next(
+            gate for gate in process["gates"] if gate["name"] == "process_reaped"
+        )
+        self.assertFalse(reaping_gate["passed"])
+        for name, identity in manifest["artifacts"].items():
+            path = run_dir / name
+            self.assertEqual(identity["size_bytes"], path.stat().st_size)
+            self.assertEqual(identity["sha256"], sha256_file(path))
+        combined = "\n".join(
+            (run_dir / name).read_text(encoding="utf-8")
+            for name in manifest["artifacts"]
+        )
+        self.assertNotIn(str(self.input_path), combined)
+        self.assertNotIn("bounded fixture output", combined)
+        self.assertEqual(list(run_dir.glob("*.tmp")), [])
 
     def test_process_timeout_budget_is_rejected_before_output_creation(self) -> None:
         args = self.process_args(VLMSliceCondition.ASYNC)

--- a/experiments/phase1/tests/vlm_process_fixture.py
+++ b/experiments/phase1/tests/vlm_process_fixture.py
@@ -100,6 +100,17 @@ class AbruptExitVLMAdapter:
         os._exit(17)
 
 
+class LingeringThreadVLMAdapter(FixtureVLMAdapter):
+    def __call__(self, claimed: ClaimedTask) -> ResultEnvelope:
+        blocker = threading.Event()
+        threading.Thread(
+            target=blocker.wait,
+            args=(60.0,),
+            name="phase1-vlm-lingering-runtime",
+        ).start()
+        return super().__call__(claimed)
+
+
 class ErrorVLMAdapter(FixtureVLMAdapter):
     def __call__(self, claimed: ClaimedTask) -> ResultEnvelope:
         self.inference_started_event.set()

--- a/experiments/phase1/vlm_process_adapter.py
+++ b/experiments/phase1/vlm_process_adapter.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import math
 import multiprocessing
+import os
 import re
 import threading
 import time
@@ -467,6 +468,7 @@ def _process_worker_main(
     send_lock = threading.Lock()
     monitor_stop = threading.Event()
     monitor: threading.Thread | None = None
+    exit_code = 1
     try:
         _send_message(
             connection,
@@ -530,6 +532,7 @@ def _process_worker_main(
             },
             lock=send_lock,
         )
+        exit_code = 0
     except BaseException as exc:
         try:
             _send_message(
@@ -550,6 +553,7 @@ def _process_worker_main(
         if monitor is not None:
             monitor.join(0.2)
         connection.close()
+        os._exit(exit_code)
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary

This change fixes a process-reaping failure observed during the motion-disabled Jetson VLM pilot.

The VLM request and bounded IPC protocol completed successfully, but imported inference runtimes prevented the spawned child from finishing interpreter shutdown within the join budget. The parent consequently terminated the child, producing `exit_code=-15` and failing the `process_reaped` Gate.

## Changes

- exit the child process explicitly after adapter cleanup, final protocol delivery, signal-monitor shutdown and pipe closure
- preserve non-zero exit status when the child reports an internal worker failure
- write `scenario.json`, `process.json` and the available slice summary before applying final process Gates
- record SHA-256 identities only for artifacts that were fully written or closed
- retain failed runs as ineligible diagnostic evidence instead of losing the failing process facts
- add a regression fixture that reproduces interpreter shutdown blocking through a lingering non-daemon runtime thread
- add regression coverage for failed-Gate artifact persistence, hashing and private-output exclusion
- document the deterministic child-exit and failed-evidence contracts

## Validation

- Phase 0 tests: 29 passed
- Phase 1 tests: 119 passed
- Black: passed
- Pyflakes: passed
- compileall: passed
- `git diff --check`: passed

## Safety and scope

- motion remains disabled
- no UART, STM32 or physical-control paths were changed
- no Phase 0 source or formal evidence artifacts were modified
- the change does not claim backend preemption, timing isolation, performance superiority or heterogeneous-inference performance