### PR TITLE
feat(phase1): publish process-isolated VLM pilot analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,14 @@ shows that all skipped releases occurred during lazy module import in the
 independent Python probe, so thread-level timing isolation does not generalize
 from the simulated sleep workload. A spawned-process VLM adapter now keeps the
 broker, freshness checks and periodic probe in the parent process while moving
-the lazy adapter path behind bounded IPC. Its lifecycle, cancellation, crash,
-timeout and child-reaping paths are host-tested; it has not yet produced a
-Jetson result. Neither completed pilot authorizes a
-performance-superiority, hard-real-time or heterogeneous-inference claim. The
-broader research stage will investigate:
+the lazy adapter path behind bounded IPC. A subsequent
+[process-isolated correctness pilot](experiments/phase1/results/20260830T122541Z_phase1_vlm_process_reaping/)
+completed both real-model conditions with normally reaped children, zero stale
+consumption and no skipped 100 ms probe releases. The earlier thread reference
+recorded 148 skipped releases, but this cross-session single-run contrast is a
+descriptive mitigation signal rather than a causal comparison. No pilot
+authorizes a performance-superiority, hard-real-time or heterogeneous-inference
+claim. The broader research stage will investigate:
 
 - independent acquisition, inference, planning and control workers;
 - timestamped bounded queues, cancellation and stale-result rejection;

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -110,10 +110,14 @@ or formal performance result. The fixed-input VLM adapter has since completed
 one nominal/stale correctness pilot on the Jetson. Its independently derived
 [report](../../experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/)
 confirms stale-result rejection while also recording module-import-scale gaps
-in the threaded periodic probe. The next implementation moves the VLM adapter
-call into a spawned child process while the broker, freshness authority and
-periodic probe remain in the parent. This path is host-tested but has not yet
-been evaluated on the Jetson, so timing isolation is still not claimed.
+in the threaded periodic probe. The subsequent implementation moved the VLM
+adapter call into a spawned child process while the broker, freshness authority and
+periodic probe remain in the parent. Its independently derived
+[process-pilot report](../../experiments/phase1/results/20260830T122541Z_phase1_vlm_process_reaping/)
+records normally reaped children and no skipped probe releases in either
+condition. The earlier thread session recorded 148 skipped releases, but the
+cross-session single-run contrast remains descriptive, so timing isolation is
+still not claimed.
 
 ## Evaluation plan
 

--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -7,22 +7,24 @@ portable simulation protocol have been implemented. One motion-disabled Jetson
 simulation pilot has validated the protocol and runtime semantics. A
 fixed-input VLM correctness pilot has also completed nominal consumption and
 old-generation rejection on the Jetson. A spawned-process VLM adapter and its
-evidence Gates are host-tested, but no process-isolated Jetson result has been
-collected. Formal performance behavior remains unvalidated.
+evidence Gates have since completed one process-isolated Jetson correctness
+pilot. Formal performance behavior remains unvalidated.
 
 > 中文简介：本文冻结 Phase 1 异步运行时的任务模型、生命周期、队列、取消、结果新鲜度、
 > 快速周期代理和安全边界。host-only worker、周期探针、trace replay 和模拟实验运行器已实现；
 > Jetson simulation pilot 与固定输入 VLM correctness pilot 已完成并通过独立验证；
-> VLM 进程隔离路径已完成 host-only 测试，尚待 Jetson pilot；正式同步/异步对比实验仍需按 Gate 逐步完成。
+> VLM 进程隔离路径已完成 Jetson correctness pilot；正式同步/异步对比实验仍需按 Gate 逐步完成。
 
 ## Status
 
-- Phase: Phase 1C process-isolated VLM pilot preparation
-- Contract status: frozen through independently validated Jetson simulation
-  and fixed-input VLM correctness pilots
+- Phase: Phase 1C process-isolated VLM pilot analysis
+- Contract status: frozen through independently validated Jetson simulation,
+  thread-mode VLM and process-isolated VLM correctness pilots
 - VLM-pilot result: `main@aebd1a2`, session
   `20260830T073825Z_phase1_vlm_pilot`
 - VLM-pilot public analysis: `main@95a839d`
+- Process-isolated VLM result: `main@1818c83`, session
+  `20260830T122541Z_phase1_vlm_process_reaping`
 - Jetson-pilot result: `main@77138f2`, session `20260828T121142Z_phase1_jetson_pilot`
 - Jetson-pilot harness starting point: `main@844b633`
 - Simulation-runner starting point: `main@4514d97`
@@ -53,12 +55,15 @@ The current implementation includes:
 - deterministic VLM-pilot reconstruction and fail-closed recording of actual
   model-service listener bindings for subsequent runs;
 - a per-request spawned-process VLM supervisor, bounded IPC, explicit process
-  cleanup facts and independently rebuilt process Gates.
+  cleanup facts and independently rebuilt process Gates;
+- deterministic process-pilot reconstruction with a hash-fixed descriptive
+  thread reference.
 
-The VLM pilot includes no formal performance data. It validates the real-model
-integration and result-freshness path, while its skipped probe releases show
-that the simulated sleep result cannot be generalized to every Python worker
-thread workload. Neither completed pilot authorizes an
+The VLM pilots include no formal performance data. They validate the real-model
+integration, result-freshness and process-boundary paths. The thread pilot's
+skipped releases show that the simulated sleep result cannot be generalized to
+every Python worker workload; the later process pilot removes those observed
+gaps in two single-run conditions. No completed pilot authorizes an
 asynchronous-performance, hard-real-time, timing-isolation or
 heterogeneous-inference claim.
 
@@ -511,9 +516,10 @@ valid under its earlier artifact contract.
 
 Host fault-injection covers nominal completion, state invalidation, child-side
 execution errors, abrupt exit and timeout termination. These tests validate
-the boundary implementation, not Jetson scheduling behavior. A motion-disabled
-real-model pilot is required before deciding whether this mitigation removes
-the module-import-scale probe gaps.
+the boundary implementation, not Jetson scheduling behavior. The subsequent
+motion-disabled real-model pilot recorded no module-import-scale probe gaps in
+its two process-isolated runs. This single fixed-order session is descriptive
+evidence and does not establish a general timing-isolation claim.
 
 ## Event and replay requirements
 
@@ -816,6 +822,24 @@ llama.cpp to `127.0.0.1` and checked it before execution, but the archived
 preflight records only the configured loopback request URL. The derived report
 marks actual listener evidence incomplete. New runs use schema `0.2.0` and fail
 closed on the observed bindings.
+
+### Process-isolated VLM pilot outcome
+
+Session `20260830T122541Z_phase1_vlm_process_reaping` ran the same nominal and
+stale conditions on `main@1818c83`. Both source runs and their derived process
+summaries validate independently. Each child completed the bounded protocol,
+exited with code zero and was reaped without forced termination. Cancellation
+was forwarded only for `vlm_stale`; its result was still rejected by the
+parent's state-generation authority, with zero stale results consumed.
+
+The process-isolated 100 ms probes recorded 0 skipped releases, 0 deadline
+misses and maximum observed gaps of 100.647 ms and 100.272 ms. The published
+thread reference recorded 148 skipped releases across its two runs. This is a
+descriptive mitigation signal: the sessions each contain one fixed-order run
+per condition and come from different commits. It therefore does not authorize
+causal attribution, performance superiority or a general timing-isolation
+claim. Process exit also remains distinct from confirmed model-backend
+preemption.
 
 ## Gates
 

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -5,14 +5,15 @@ recorder, event schema, independent lifecycle replay, run validation, Jetson
 pilot orchestration, deterministic analysis, fixed-input VLM integration and
 descriptive summaries for the Phase 1 asynchronous runtime study. The first
 Jetson simulation pilot and fixed-input VLM correctness pilot are complete.
-A spawned-process VLM adapter and evidence path are host-tested; their Jetson
-pilot and all formal synchronous/asynchronous data remain uncollected.
+A spawned-process VLM adapter has also completed one independently validated
+Jetson correctness pilot. Formal synchronous/asynchronous data remain
+uncollected.
 
 > 中文简介：本目录用于 Phase 1 异步运行时研究。当前已实现 host-only 有界 broker、
 > 单 worker 执行层、100 ms 周期探针、独立 trace replay、模拟条件运行器和 Jetson
 > pilot 证据链，并完成 Jetson simulation pilot 与固定输入 VLM correctness pilot；
-> 当前已验证真实模型接入和陈旧结果拒绝，VLM 进程隔离路径已完成 host-only 测试、尚待
-> Jetson pilot，正式对比数据尚未采集。
+> 当前已验证真实模型接入、陈旧结果拒绝与子进程正常回收，VLM 进程隔离路径已完成
+> Jetson correctness pilot；正式对比数据尚未采集。
 
 ## Current status
 
@@ -30,8 +31,10 @@ pilot and all formal synchronous/asynchronous data remain uncollected.
 - Fixed-input VLM adapter, single-request runner and validator: completed one
   independently validated Jetson correctness pilot
 - Deterministic VLM pilot analysis and listener-binding preflight: implemented
-- Spawned-process VLM adapter, cleanup evidence and runner mode: host-tested;
-  Jetson process pilot not yet run
+- Spawned-process VLM adapter, cleanup evidence and runner mode: completed one
+  independently validated Jetson correctness pilot
+- Deterministic process-pilot reconstruction and descriptive thread reference:
+  implemented
 - Real ASR/LLM slices: not started
 - Formal Phase 1 data: not collected
 - Physical motion and UART: excluded
@@ -213,6 +216,16 @@ were scheduled during lazy module import. The result therefore validates
 nominal consumption and stale-result rejection while explicitly withholding a
 thread-level timing-isolation claim.
 
+The third public derived result is the
+[`20260830T122541Z` process-isolated VLM pilot](results/20260830T122541Z_phase1_vlm_process_reaping/).
+Both spawned children completed the bounded protocol, exited with code zero
+and were reaped without forced termination. The 100 ms probe recorded zero
+skipped releases and zero deadline misses in both conditions. The previously
+published thread pilot recorded 148 skipped releases, but the two sessions are
+single, fixed-order observations from different commits. The public report
+therefore labels the contrast as a descriptive mitigation signal and continues
+to prohibit causal performance and timing-isolation claims.
+
 ## Fixed-input VLM slice
 
 The first real-workload integration reuses the exact Phase 0 C100 JPEG, the
@@ -271,6 +284,19 @@ python3 -m experiments.phase1.analyze_vlm_pilot \
   --markdown-output /path/to/README.md
 ```
 
+For a process-isolated session, add the published thread analysis as a frozen
+workload-identity reference:
+
+```bash
+python3 -m experiments.phase1.analyze_vlm_pilot \
+  /path/to/process_session_dir \
+  --source-archive-sha256 <process_archive_sha256> \
+  --thread-reference-analysis \
+    experiments/phase1/results/20260830T073825Z_phase1_vlm_pilot/analysis.json \
+  --json-output /path/to/analysis.json \
+  --markdown-output /path/to/README.md
+```
+
 The first VLM pilot was collected under preflight schema `0.1.0`. Its request
 URLs were loopback addresses, and the operator checked the llama.cpp listener
 before execution, but actual listener bindings were not stored in the archive.
@@ -305,8 +331,7 @@ reaping during interpreter shutdown. If a final Gate still fails, the run is
 marked failed after its completed scenario, process and slice diagnostics are
 written and hashed.
 
-After this implementation is merged and the Jetson is synchronized to that
-`main` commit, the two motion-disabled pilot conditions can be run with:
+The two motion-disabled pilot conditions can be reproduced with:
 
 ```bash
 export ROBOT_ENABLE_MOTION=0
@@ -327,10 +352,11 @@ python3 -m experiments.phase1.run_vlm_slice \
   --repetition 1
 ```
 
-These commands are a correctness and timing-isolation pilot, not a formal
-thread/process comparison. The two earlier thread runs remain unchanged and
-valid. Process-level timing behavior is not claimed until the new Jetson
-artifacts are collected and independently analyzed.
+These commands define a correctness pilot, not a formal thread/process
+comparison. Session `20260830T122541Z_phase1_vlm_process_reaping` completed
+both conditions on `main@1818c83`; the Jetson and Windows independent validators
+and every slice and process Gate passed. The result is published as descriptive
+evidence and does not freeze a formal timing threshold.
 
 ## Planned implementation order
 
@@ -349,11 +375,11 @@ artifacts are collected and independently analyzed.
    slice — complete;
 8. record actual model-service listener bindings and qualify the simulated
    thread-isolation result with real-workload evidence — complete;
-9. implement and host-test process-level VLM isolation — complete; run and
-   independently analyze its Jetson pilot, then extend the adapter/runtime
-   boundary to ASR and LLM;
-10. freeze formal thresholds and collect balanced synchronous/asynchronous data;
-11. add an opt-in motion-disabled application slice after the research Gates
+9. implement process-level VLM isolation and independently analyze its Jetson
+   correctness pilot — complete;
+10. extend the adapter/runtime boundary to ASR and LLM;
+11. freeze formal thresholds and collect balanced synchronous/asynchronous data;
+12. add an opt-in motion-disabled application slice after the research Gates
    pass.
 
 Contract changes are reviewed before implementation, and the formal protocol

--- a/experiments/phase1/analyze_vlm_pilot.py
+++ b/experiments/phase1/analyze_vlm_pilot.py
@@ -13,11 +13,25 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from experiments.phase1.jetson_telemetry import load_resource_samples
+from experiments.phase1.manifest import sha256_file
+from experiments.phase1.summarize_vlm_process_slice import VLM_PROCESS_ISOLATION
 from experiments.phase1.validate_vlm_slice import validate_vlm_slice_dir
 
 
 ANALYSIS_SCHEMA_VERSION = "0.1.0"
 EXPECTED_CONDITIONS = ("vlm_async", "vlm_stale")
+THREAD_ANALYSIS_KIND = "phase1_fixed_input_vlm_pilot"
+PROCESS_ANALYSIS_KIND = "phase1_fixed_input_vlm_process_pilot"
+_CONDITION_LAYOUTS = {
+    "thread": {
+        "vlm_async": "vlm_async",
+        "vlm_stale": "vlm_stale",
+    },
+    VLM_PROCESS_ISOLATION: {
+        "vlm_async": "vlm_process_async",
+        "vlm_stale": "vlm_process_stale",
+    },
+}
 _EXPECTED_RUN_FILES = {
     "events.jsonl",
     "manifest.json",
@@ -25,6 +39,13 @@ _EXPECTED_RUN_FILES = {
     "resources.jsonl",
     "scenario.json",
     "summary.json",
+}
+_EXPECTED_PROCESS_GATES = {
+    "spawned_process",
+    "bounded_protocol",
+    "process_reaped",
+    "boundary_order",
+    "cancellation_forwarding",
 }
 _STAGE_ORDER = (
     "input_verify_before",
@@ -101,21 +122,29 @@ def _metric_value(
     return round(_number(observed, f"resource metric {metric}.{field}"), 6)
 
 
-def _find_run_directories(session_dir: Path) -> dict[str, Path]:
+def _find_run_directories(session_dir: Path) -> tuple[str, dict[str, Path]]:
     observed = sorted(path.name for path in session_dir.iterdir())
-    if observed != sorted(EXPECTED_CONDITIONS) or not all(
-        (session_dir / condition).is_dir() for condition in EXPECTED_CONDITIONS
-    ):
+    matches = [
+        (adapter_isolation, layout)
+        for adapter_isolation, layout in _CONDITION_LAYOUTS.items()
+        if observed == sorted(layout.values())
+        and all((session_dir / name).is_dir() for name in layout.values())
+    ]
+    if len(matches) != 1:
         raise ValueError(
-            "VLM pilot must contain exactly vlm_async and vlm_stale directories"
+            "VLM pilot must contain exactly one supported two-condition layout"
         )
+    adapter_isolation, layout = matches[0]
     runs: dict[str, Path] = {}
     for condition in EXPECTED_CONDITIONS:
-        candidates = sorted((session_dir / condition).iterdir())
+        condition_directory = layout[condition]
+        candidates = sorted((session_dir / condition_directory).iterdir())
         if len(candidates) != 1 or not candidates[0].is_dir():
-            raise ValueError(f"{condition} must contain exactly one run directory")
+            raise ValueError(
+                f"{condition_directory} must contain exactly one run directory"
+            )
         runs[condition] = candidates[0]
-    return runs
+    return adapter_isolation, runs
 
 
 def _disposition_counts(lifecycle: Mapping[str, object]) -> dict[str, int]:
@@ -326,9 +355,108 @@ def _listener_evidence(preflight: Mapping[str, object]) -> dict[str, object]:
     }
 
 
-def _run_record(condition: str, run_dir: Path) -> dict[str, object]:
+def _process_interval_ms(
+    earlier: object,
+    later: object,
+    name: str,
+) -> float:
+    earlier_ns = _integer(earlier, f"{name} start")
+    later_ns = _integer(later, f"{name} finish")
+    if later_ns < earlier_ns:
+        raise ValueError(f"{name} boundaries are reversed")
+    return _milliseconds(later_ns - earlier_ns, name)
+
+
+def _process_record(
+    condition: str,
+    scenario: Mapping[str, object],
+    process_summary: Mapping[str, object],
+) -> dict[str, object]:
+    scenario_facts = _mapping(scenario.get("process"), "scenario process facts")
+    summary_facts = _mapping(process_summary.get("process"), "process summary facts")
+    if dict(scenario_facts) != dict(summary_facts):
+        raise ValueError("scenario and process summary facts differ")
+    if process_summary.get("condition") != condition:
+        raise ValueError("process summary condition is inconsistent")
+    if process_summary.get("adapter_isolation") != VLM_PROCESS_ISOLATION:
+        raise ValueError("process summary isolation is inconsistent")
+    gates = process_summary.get("gates")
+    if not isinstance(gates, list) or not all(
+        isinstance(gate, Mapping) for gate in gates
+    ):
+        raise ValueError("process gates must be a list of objects")
+    gate_names = [gate.get("name") for gate in gates]
+    if (
+        len(gate_names) != len(_EXPECTED_PROCESS_GATES)
+        or set(gate_names) != _EXPECTED_PROCESS_GATES
+        or any(not isinstance(name, str) for name in gate_names)
+    ):
+        raise ValueError("process gate set is incomplete or unsupported")
+    process_id = _integer(summary_facts.get("process_id"), "process identifier")
+    if process_id <= 0:
+        raise ValueError("process identifier must be positive")
+
+    spawn_ns = summary_facts.get("spawn_requested_monotonic_ns")
+    child_ns = summary_facts.get("child_started_monotonic_ns")
+    inference_ns = summary_facts.get("inference_started_monotonic_ns")
+    completion_ns = summary_facts.get("completion_received_monotonic_ns")
+    joined_ns = summary_facts.get("joined_monotonic_ns")
+    return {
+        "protocol_version": summary_facts.get("protocol_version"),
+        "start_method": summary_facts.get("start_method"),
+        "process_id_recorded": True,
+        "protocol_complete": summary_facts.get("protocol_complete"),
+        "exit_code": summary_facts.get("exit_code"),
+        "cancellation_forwarded": summary_facts.get("cancellation_forwarded"),
+        "terminate_requested": summary_facts.get("terminate_requested"),
+        "terminate_confirmed": summary_facts.get("terminate_confirmed"),
+        "error_code": summary_facts.get("error_code"),
+        "valid": process_summary.get("valid") is True,
+        "gate_results": {
+            str(gate["name"]): gate.get("passed") is True for gate in gates
+        },
+        "timing_ms": {
+            "spawn_to_child_start": _process_interval_ms(
+                spawn_ns,
+                child_ns,
+                "spawn to child start",
+            ),
+            "child_start_to_inference": _process_interval_ms(
+                child_ns,
+                inference_ns,
+                "child start to inference",
+            ),
+            "inference_to_completion_receipt": _process_interval_ms(
+                inference_ns,
+                completion_ns,
+                "inference to completion receipt",
+            ),
+            "completion_receipt_to_join": _process_interval_ms(
+                completion_ns,
+                joined_ns,
+                "completion receipt to join",
+            ),
+            "total_supervision": _process_interval_ms(
+                spawn_ns,
+                joined_ns,
+                "total process supervision",
+            ),
+        },
+    }
+
+
+def _run_record(
+    condition: str,
+    run_dir: Path,
+    *,
+    adapter_isolation: str,
+) -> dict[str, object]:
+    expected_files = set(_EXPECTED_RUN_FILES)
+    process_isolated = adapter_isolation == VLM_PROCESS_ISOLATION
+    if process_isolated:
+        expected_files.add("process.json")
     observed_files = {path.name for path in run_dir.iterdir() if path.is_file()}
-    if observed_files != _EXPECTED_RUN_FILES or any(
+    if observed_files != expected_files or any(
         not path.is_file() for path in run_dir.iterdir()
     ):
         raise ValueError(f"{condition} run files do not match the evidence contract")
@@ -358,7 +486,7 @@ def _run_record(condition: str, run_dir: Path) -> dict[str, object]:
         isinstance(gate, Mapping) for gate in gates
     ):
         raise ValueError("summary gates must be a list of objects")
-    return {
+    record: dict[str, object] = {
         "condition": condition,
         "run_id": manifest.get("run_id"),
         "session_id": manifest.get("session_id"),
@@ -412,6 +540,18 @@ def _run_record(condition: str, run_dir: Path) -> dict[str, object]:
         },
         "resources": _resource_record(summary, samples),
     }
+    if process_isolated:
+        record["adapter_isolation"] = VLM_PROCESS_ISOLATION
+        if manifest.get("adapter_isolation") != VLM_PROCESS_ISOLATION:
+            raise ValueError("manifest process isolation is inconsistent")
+        process_summary = _read_object(run_dir / "process.json")
+        process = _process_record(condition, scenario, process_summary)
+        record["process"] = process
+        validation = record["validation"]
+        assert isinstance(validation, dict)
+        validation["process_summary_valid"] = process["valid"] is True
+        validation["all_process_gates_passed"] = all(process["gate_results"].values())
+    return record
 
 
 def _same_value(runs: Sequence[Mapping[str, object]], path: Sequence[str]) -> object:
@@ -426,10 +566,153 @@ def _same_value(runs: Sequence[Mapping[str, object]], path: Sequence[str]) -> ob
     return values[0]
 
 
+def _thread_reference_record(
+    path: Path,
+    *,
+    input_identity: object,
+    moondream_digest: object,
+    qwen_model_ids: object,
+) -> dict[str, object]:
+    reference = _read_object(path)
+    if reference.get("analysis_kind") != THREAD_ANALYSIS_KIND:
+        raise ValueError("thread reference analysis kind is unsupported")
+    validation = _mapping(reference.get("validation"), "thread reference validation")
+    if validation.get("all_runs_valid") is not True:
+        raise ValueError("thread reference does not contain valid source runs")
+    identity = _mapping(reference.get("identity"), "thread reference identity")
+    expected_identity = {
+        "input": input_identity,
+        "moondream_digest": moondream_digest,
+        "qwen_model_ids": qwen_model_ids,
+    }
+    if any(identity.get(name) != value for name, value in expected_identity.items()):
+        raise ValueError("thread reference workload identity does not match")
+    claims = _mapping(
+        reference.get("claim_boundary"), "thread reference claim boundary"
+    )
+    for name in (
+        "timing_domain_isolation_claim_permitted",
+        "asynchronous_performance_superiority_claim_permitted",
+        "hard_real_time_claim_permitted",
+        "heterogeneous_inference_claim_permitted",
+    ):
+        if claims.get(name) is not False:
+            raise ValueError("thread reference claim boundary is not conservative")
+    runs_value = reference.get("runs")
+    if (
+        not isinstance(runs_value, list)
+        or len(runs_value) != 2
+        or not all(isinstance(run, Mapping) for run in runs_value)
+    ):
+        raise ValueError("thread reference runs must be a list of objects")
+    runs_by_condition = {str(run.get("condition")): run for run in runs_value}
+    if set(runs_by_condition) != set(EXPECTED_CONDITIONS):
+        raise ValueError("thread reference condition set is incomplete")
+
+    conditions: dict[str, object] = {}
+    for condition in EXPECTED_CONDITIONS:
+        run = runs_by_condition[condition]
+        timing = _mapping(run.get("timing"), "thread reference timing")
+        probe = _mapping(timing.get("probe"), "thread reference probe")
+        conditions[condition] = {
+            "adapter_total_ms": round(
+                _number(timing.get("adapter_total_ms"), "thread adapter duration"),
+                6,
+            ),
+            "probe_skipped_releases": _integer(
+                probe.get("skipped_releases"), "thread skipped releases"
+            ),
+            "probe_deadline_miss_count": _integer(
+                probe.get("deadline_miss_count"), "thread deadline misses"
+            ),
+            "probe_max_lateness_ms": round(
+                _number(
+                    probe.get("max_lateness_ms"),
+                    "thread probe maximum lateness",
+                ),
+                6,
+            ),
+            "probe_maximum_observed_gap_ms": round(
+                _number(
+                    probe.get("maximum_observed_gap_ms"),
+                    "thread probe maximum gap",
+                ),
+                6,
+            ),
+        }
+    source = _mapping(reference.get("source"), "thread reference source")
+    return {
+        "analysis_sha256": sha256_file(path),
+        "analysis_kind": reference.get("analysis_kind"),
+        "analysis_schema_version": reference.get("analysis_schema_version"),
+        "session_id": reference.get("session_id"),
+        "git_commit": source.get("git_commit"),
+        "source_archive_sha256": source.get("source_archive_sha256"),
+        "workload_identity_matched": True,
+        "conditions": conditions,
+    }
+
+
+def _thread_process_comparison(
+    runs: Sequence[Mapping[str, object]],
+    reference: Mapping[str, object],
+) -> dict[str, object]:
+    process_runs = {str(run.get("condition")): run for run in runs}
+    reference_conditions = _mapping(
+        reference.get("conditions"), "thread reference conditions"
+    )
+    conditions: dict[str, object] = {}
+    thread_skipped_total = 0
+    process_skipped_total = 0
+    for condition in EXPECTED_CONDITIONS:
+        process_timing = _mapping(
+            process_runs[condition].get("timing"), "process run timing"
+        )
+        process_probe = _mapping(process_timing.get("probe"), "process run probe")
+        thread = _mapping(
+            reference_conditions.get(condition), "thread reference condition"
+        )
+        thread_skipped = _integer(
+            thread.get("probe_skipped_releases"), "thread skipped releases"
+        )
+        process_skipped = _integer(
+            process_probe.get("skipped_releases"), "process skipped releases"
+        )
+        thread_skipped_total += thread_skipped
+        process_skipped_total += process_skipped
+        conditions[condition] = {
+            "thread": dict(thread),
+            "spawned_process": {
+                "adapter_total_ms": process_timing.get("adapter_total_ms"),
+                "probe_skipped_releases": process_skipped,
+                "probe_deadline_miss_count": process_probe.get("deadline_miss_count"),
+                "probe_max_lateness_ms": process_probe.get("max_lateness_ms"),
+                "probe_maximum_observed_gap_ms": process_probe.get(
+                    "maximum_observed_gap_ms"
+                ),
+            },
+            "observed_skipped_release_difference": (process_skipped - thread_skipped),
+        }
+    return {
+        "comparison_role": "cross_session_descriptive_reference",
+        "conditions": conditions,
+        "total_probe_skipped_releases": {
+            "thread": thread_skipped_total,
+            "spawned_process": process_skipped_total,
+        },
+        "descriptive_mitigation_signal_observed": (
+            thread_skipped_total > 0 and process_skipped_total == 0
+        ),
+        "causal_attribution_permitted": False,
+        "performance_superiority_claim_permitted": False,
+    }
+
+
 def analyze_vlm_pilot_dir(
     session_dir: Path | str,
     *,
     source_archive_sha256: str | None = None,
+    thread_reference_analysis: Path | str | None = None,
 ) -> dict[str, object]:
     """Validate and reconstruct one two-condition real-model VLM pilot."""
 
@@ -441,9 +724,17 @@ def analyze_vlm_pilot_dir(
         normalized_hash = source_archive_sha256.lower()
         if _SHA256_RE.fullmatch(normalized_hash) is None:
             raise ValueError("source_archive_sha256 must contain 64 hexadecimal digits")
-    run_dirs = _find_run_directories(directory)
+    adapter_isolation, run_dirs = _find_run_directories(directory)
+    process_isolated = adapter_isolation == VLM_PROCESS_ISOLATION
+    if thread_reference_analysis is not None and not process_isolated:
+        raise ValueError("thread reference is only supported for a process pilot")
     runs = [
-        _run_record(condition, run_dirs[condition]) for condition in EXPECTED_CONDITIONS
+        _run_record(
+            condition,
+            run_dirs[condition],
+            adapter_isolation=adapter_isolation,
+        )
+        for condition in EXPECTED_CONDITIONS
     ]
     session_id = _same_value(runs, ("session_id",))
     if session_id != directory.name:
@@ -466,6 +757,23 @@ def analyze_vlm_pilot_dir(
         run["services"]["listener_evidence"]["complete"] is True for run in runs
     )
     skipped_total = sum(run["timing"]["probe"]["skipped_releases"] for run in runs)
+    deadline_miss_total = sum(
+        run["timing"]["probe"]["deadline_miss_count"] for run in runs
+    )
+    process_boundary_correctness = process_isolated and all(
+        run["process"]["valid"] is True
+        and all(run["process"]["gate_results"].values())
+        and run["process"]["protocol_complete"] is True
+        and run["process"]["exit_code"] == 0
+        and run["process"]["terminate_requested"] is False
+        and run["process"]["error_code"] is None
+        for run in runs
+    )
+    periodic_probe_continuity = (
+        skipped_total == 0
+        and deadline_miss_total == 0
+        and all(run["timing"]["probe"]["joined"] is True for run in runs)
+    )
     limitations = [
         "single_run_per_condition",
         "fixed_condition_order",
@@ -485,9 +793,31 @@ def analyze_vlm_pilot_dir(
     ):
         limitations.append("emc_unavailable")
 
-    return {
+    thread_reference: dict[str, object] | None = None
+    comparison: dict[str, object] | None = None
+    if thread_reference_analysis is not None:
+        reference_path = Path(thread_reference_analysis).resolve()
+        if not reference_path.is_file():
+            raise ValueError("thread reference analysis does not exist")
+        thread_reference = _thread_reference_record(
+            reference_path,
+            input_identity=input_identity,
+            moondream_digest=moondream_digest,
+            qwen_model_ids=qwen_models,
+        )
+        comparison = _thread_process_comparison(runs, thread_reference)
+        limitations.append("thread_process_comparison_crosses_sessions")
+        limitations.append("thread_process_order_not_randomized_or_balanced")
+        if thread_reference.get("git_commit") != git_commit:
+            limitations.append("thread_process_source_commits_differ")
+    if process_isolated:
+        limitations.append("backend_stop_not_confirmed_by_process_exit")
+
+    analysis: dict[str, object] = {
         "analysis_schema_version": ANALYSIS_SCHEMA_VERSION,
-        "analysis_kind": "phase1_fixed_input_vlm_pilot",
+        "analysis_kind": (
+            PROCESS_ANALYSIS_KIND if process_isolated else THREAD_ANALYSIS_KIND
+        ),
         "session_id": session_id,
         "source": {
             "git_commit": git_commit,
@@ -531,6 +861,33 @@ def analyze_vlm_pilot_dir(
             "limitations": limitations,
         },
     }
+    if process_isolated:
+        analysis["adapter_isolation"] = VLM_PROCESS_ISOLATION
+        source = analysis["source"]
+        assert isinstance(source, dict)
+        source["thread_reference"] = thread_reference
+        claim_boundary = analysis["claim_boundary"]
+        assert isinstance(claim_boundary, dict)
+        claim_boundary["process_boundary_correctness_observed"] = (
+            process_boundary_correctness
+        )
+        claim_boundary["periodic_probe_continuity_observed"] = periodic_probe_continuity
+        validation = analysis["validation"]
+        assert isinstance(validation, dict)
+        validation["all_process_gates_passed"] = all(
+            run["validation"]["process_summary_valid"] is True
+            and run["validation"]["all_process_gates_passed"] is True
+            for run in runs
+        )
+        validation["process_boundary_correctness_observed"] = (
+            process_boundary_correctness
+        )
+        validation["periodic_probe_continuity_observed"] = periodic_probe_continuity
+        data_quality = analysis["data_quality"]
+        assert isinstance(data_quality, dict)
+        data_quality["total_probe_deadline_misses"] = deadline_miss_total
+        analysis["thread_process_comparison"] = comparison
+    return analysis
 
 
 def _format_number(value: object, digits: int = 3) -> str:
@@ -559,8 +916,290 @@ def _render_dispositions(value: object) -> str:
     return ", ".join(f"{name}={record[name]}" for name in sorted(record))
 
 
+def _render_process_markdown(analysis: Mapping[str, object]) -> str:
+    source = _mapping(analysis.get("source"), "analysis source")
+    identity = _mapping(analysis.get("identity"), "analysis identity")
+    validation = _mapping(analysis.get("validation"), "analysis validation")
+    quality = _mapping(analysis.get("data_quality"), "analysis data quality")
+    claims = _mapping(analysis.get("claim_boundary"), "analysis claim boundary")
+    runs_value = analysis.get("runs")
+    if not isinstance(runs_value, list) or not all(
+        isinstance(run, Mapping) for run in runs_value
+    ):
+        raise ValueError("analysis runs must be a list of objects")
+    runs: list[Mapping[str, object]] = list(runs_value)
+    input_identity = _mapping(identity.get("input"), "analysis input identity")
+    qwen_ids = identity.get("qwen_model_ids")
+    lines = [
+        "# Phase 1 Process-isolated Fixed-input VLM Pilot",
+        "",
+        (
+            "This report records one motion-disabled spawned-process correctness "
+            "pilot on the Jetson Orin Nano. It validates process ownership, bounded "
+            "IPC, stale-result rejection and deterministic child reaping."
+        ),
+        "",
+        "## Evidence boundary",
+        "",
+        "- Workload: one fixed Phase 0 C100 image per condition.",
+        "- Conditions: one `vlm_async` run followed by one `vlm_stale` run.",
+        "- Isolation: one spawned child per VLM request; broker and probe remain in the parent.",
+        "- Physical motion and UART access: disabled.",
+        "- Permitted interpretation: integration, lifecycle and process-boundary correctness.",
+        (
+            "- Not permitted: causal performance claims, timing-domain isolation, "
+            "hard-real-time or heterogeneous-inference claims."
+        ),
+        "",
+        "## Provenance",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Session | `{analysis.get('session_id')}` |",
+        f"| Source commit | `{source.get('git_commit')}` |",
+        f"| Source branch | `{source.get('git_branch')}` |",
+        f"| Transfer archive SHA-256 | `{source.get('source_archive_sha256')}` |",
+        f"| Independently valid runs | {_format_number(validation.get('all_runs_valid'))} |",
+        f"| Process Gates passed | {_format_number(validation.get('all_process_gates_passed'))} |",
+        "",
+        "Machine-readable derived data: [`analysis.json`](analysis.json).",
+        "",
+        "## Frozen identities",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Input SHA-256 | `{input_identity.get('sha256')}` |",
+        f"| Input size | {_format_number(input_identity.get('size_bytes'))} bytes |",
+        f"| Moondream digest | `{identity.get('moondream_digest')}` |",
+        f"| Qwen model | `{', '.join(qwen_ids) if isinstance(qwen_ids, list) else qwen_ids}` |",
+        "",
+        "## Correctness and process results",
+        "",
+        "| Condition | Execution | Disposition | Accepted | Cancel forwarded | Exit | Terminate | Slice/Process Gates |",
+        "| --- | --- | --- | ---: | --- | ---: | --- | --- |",
+    ]
+    for run in runs:
+        result = _mapping(run.get("result"), "run result")
+        process = _mapping(run.get("process"), "run process")
+        run_validation = _mapping(run.get("validation"), "run validation")
+        gates_passed = (
+            run_validation.get("all_gates_passed") is True
+            and run_validation.get("all_process_gates_passed") is True
+        )
+        lines.append(
+            "| `{condition}` | `{outcome}` | {dispositions} | {accepted} | "
+            "{cancel} | {exit_code} | {terminate} | {gates} |".format(
+                condition=run.get("condition"),
+                outcome=result.get("execution_outcome"),
+                dispositions=_render_dispositions(result.get("disposition_counts")),
+                accepted=_format_number(result.get("accepted_result_count")),
+                cancel=_format_number(process.get("cancellation_forwarded")),
+                exit_code=_format_number(process.get("exit_code")),
+                terminate=_format_number(process.get("terminate_requested")),
+                gates="pass" if gates_passed else "fail",
+            )
+        )
+    lines.extend(
+        [
+            "",
+            (
+                "The nominal result was consumed once. The stale result was rejected "
+                "before consumption after cancellation was forwarded. Child exit does "
+                "not confirm that the external model backend stopped inference."
+            ),
+            "",
+            "## Process supervision timing",
+            "",
+            "| Condition | Spawn -> start (ms) | Start -> inference (ms) | Inference -> completion receipt (ms) | Completion -> join (ms) | Total supervision (ms) |",
+            "| --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        process = _mapping(run.get("process"), "run process")
+        timing = _mapping(process.get("timing_ms"), "process timing")
+        lines.append(
+            "| `{condition}` | {spawn} | {start} | {inference} | {join} | {total} |".format(
+                condition=run.get("condition"),
+                spawn=_format_number(timing.get("spawn_to_child_start")),
+                start=_format_number(timing.get("child_start_to_inference")),
+                inference=_format_number(timing.get("inference_to_completion_receipt")),
+                join=_format_number(timing.get("completion_receipt_to_join")),
+                total=_format_number(timing.get("total_supervision")),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Pipeline timing",
+            "",
+            "| Condition | Adapter total (ms) | Module import | Moondream | Qwen | Unload |",
+            "| --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        timing = _mapping(run.get("timing"), "run timing")
+        lines.append(
+            "| `{condition}` | {total} | {module} | {moondream} | {qwen} | {unload} |".format(
+                condition=run.get("condition"),
+                total=_format_number(timing.get("adapter_total_ms")),
+                module=_format_number(_stage_duration(run, "module_import")),
+                moondream=_format_number(_stage_duration(run, "moondream_inference")),
+                qwen=_format_number(_stage_duration(run, "qwen_rewrite")),
+                unload=_format_number(_stage_duration(run, "model_unload")),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "These single, fixed-order timings are descriptive and are not compared inferentially.",
+            "",
+            "## Periodic-probe observations",
+            "",
+            "| Condition | Ticks | Skipped | Deadline misses | Max lateness (ms) | Max gap (ms) |",
+            "| --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        probe = _mapping(
+            _mapping(run.get("timing"), "run timing").get("probe"), "run probe"
+        )
+        lines.append(
+            "| `{condition}` | {ticks} | {skipped} | {misses} | {lateness} | {gap} |".format(
+                condition=run.get("condition"),
+                ticks=_format_number(probe.get("tick_count")),
+                skipped=_format_number(probe.get("skipped_releases")),
+                misses=_format_number(probe.get("deadline_miss_count")),
+                lateness=_format_number(probe.get("max_lateness_ms")),
+                gap=_format_number(probe.get("maximum_observed_gap_ms")),
+            )
+        )
+
+    comparison_value = analysis.get("thread_process_comparison")
+    if isinstance(comparison_value, Mapping):
+        reference = _mapping(source.get("thread_reference"), "thread reference")
+        comparison = comparison_value
+        conditions = _mapping(comparison.get("conditions"), "comparison conditions")
+        lines.extend(
+            [
+                "",
+                "## Descriptive thread reference",
+                "",
+                f"- Reference session: `{reference.get('session_id')}`",
+                f"- Reference commit: `{reference.get('git_commit')}`",
+                f"- Reference analysis SHA-256: `{reference.get('analysis_sha256')}`",
+                "",
+                "| Condition | Thread skipped | Process skipped | Thread max gap (ms) | Process max gap (ms) |",
+                "| --- | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for condition in EXPECTED_CONDITIONS:
+            item = _mapping(conditions.get(condition), "comparison condition")
+            thread = _mapping(item.get("thread"), "thread comparison record")
+            process = _mapping(item.get("spawned_process"), "process comparison record")
+            lines.append(
+                "| `{condition}` | {thread_skipped} | {process_skipped} | {thread_gap} | {process_gap} |".format(
+                    condition=condition,
+                    thread_skipped=_format_number(thread.get("probe_skipped_releases")),
+                    process_skipped=_format_number(
+                        process.get("probe_skipped_releases")
+                    ),
+                    thread_gap=_format_number(
+                        thread.get("probe_maximum_observed_gap_ms")
+                    ),
+                    process_gap=_format_number(
+                        process.get("probe_maximum_observed_gap_ms")
+                    ),
+                )
+            )
+        totals = _mapping(
+            comparison.get("total_probe_skipped_releases"), "comparison totals"
+        )
+        lines.extend(
+            [
+                "",
+                (
+                    "The thread reference recorded {thread} skipped releases and the "
+                    "spawned-process pilot recorded {process}. This is a descriptive "
+                    "mitigation signal, not a causal or performance-superiority claim; "
+                    "the sessions used single fixed-order runs from different commits."
+                ).format(
+                    thread=totals.get("thread"),
+                    process=totals.get("spawned_process"),
+                ),
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Resource observations",
+            "",
+            "| Condition | Samples | Covered | RAM mean/max (MB) | GR3D mean/max (%) | Tj max (C) | VDD_IN mean/max (mW) |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        resources = _mapping(run.get("resources"), "run resources")
+        ram = _mapping(resources.get("ram_used_mb"), "RAM summary")
+        gr3d = _mapping(resources.get("gr3d_usage_pct"), "GR3D summary")
+        temperature = _mapping(
+            resources.get("junction_temperature_c"), "temperature summary"
+        )
+        power = _mapping(resources.get("vdd_in_instant_mw"), "power summary")
+        lines.append(
+            "| `{condition}` | {samples} | {covered} | {ram_mean}/{ram_max} | "
+            "{gpu_mean}/{gpu_max} | {temperature} | {power_mean}/{power_max} |".format(
+                condition=run.get("condition"),
+                samples=_format_number(resources.get("sample_count")),
+                covered=_format_number(
+                    resources.get("inference_interval_sample_count")
+                ),
+                ram_mean=_format_number(ram.get("mean")),
+                ram_max=_format_number(ram.get("max")),
+                gpu_mean=_format_number(gr3d.get("mean")),
+                gpu_max=_format_number(gr3d.get("max")),
+                temperature=_format_number(temperature.get("max")),
+                power_mean=_format_number(power.get("mean")),
+                power_max=_format_number(power.get("max")),
+            )
+        )
+    limitations = quality.get("limitations")
+    if not isinstance(limitations, list):
+        raise ValueError("analysis limitations must be a list")
+    lines.extend(["", "## Evidence gaps", ""])
+    lines.extend(f"- `{item}`" for item in limitations)
+    lines.extend(
+        [
+            "",
+            (
+                "Both process runs recorded loopback-only listener bindings. Process "
+                "exit and cancellation forwarding are bounded local facts. This evidence "
+                "does not prove backend preemption."
+            ),
+            "",
+            (
+                "GR3D activity is device-level evidence and is not attributed to a "
+                "particular model or processor. The result does not authorize a "
+                "heterogeneous-inference claim."
+            ),
+            "",
+            (
+                "A timing-domain or performance claim remains prohibited: "
+                f"`timing_domain_isolation_claim_permitted={claims.get('timing_domain_isolation_claim_permitted')}`."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def render_markdown(analysis: Mapping[str, object]) -> str:
     """Render the machine-readable analysis without adding new claims."""
+
+    if analysis.get("analysis_kind") == PROCESS_ANALYSIS_KIND:
+        return _render_process_markdown(analysis)
+    if analysis.get("analysis_kind") != THREAD_ANALYSIS_KIND:
+        raise ValueError("analysis kind is unsupported")
 
     source = _mapping(analysis.get("source"), "analysis source")
     identity = _mapping(analysis.get("identity"), "analysis identity")
@@ -822,6 +1461,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("session_dir", type=Path)
     parser.add_argument("--source-archive-sha256")
+    parser.add_argument("--thread-reference-analysis", type=Path)
     parser.add_argument("--json-output", type=Path)
     parser.add_argument("--markdown-output", type=Path)
     return parser
@@ -837,6 +1477,7 @@ def main(argv: list[str] | None = None) -> int:
         analysis = analyze_vlm_pilot_dir(
             session_dir,
             source_archive_sha256=args.source_archive_sha256,
+            thread_reference_analysis=args.thread_reference_analysis,
         )
         json_text = json.dumps(
             analysis,
@@ -849,7 +1490,8 @@ def main(argv: list[str] | None = None) -> int:
         else:
             print(json_text)
         if args.markdown_output is not None:
-            _write_text_atomic(args.markdown_output, render_markdown(analysis) + "\n")
+            markdown_text = render_markdown(analysis).rstrip("\n") + "\n"
+            _write_text_atomic(args.markdown_output, markdown_text)
     except (OSError, TypeError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/experiments/phase1/results/20260830T122541Z_phase1_vlm_process_reaping/README.md
+++ b/experiments/phase1/results/20260830T122541Z_phase1_vlm_process_reaping/README.md
@@ -1,0 +1,106 @@
+# Phase 1 Process-isolated Fixed-input VLM Pilot
+
+This report records one motion-disabled spawned-process correctness pilot on the Jetson Orin Nano. It validates process ownership, bounded IPC, stale-result rejection and deterministic child reaping.
+
+## Evidence boundary
+
+- Workload: one fixed Phase 0 C100 image per condition.
+- Conditions: one `vlm_async` run followed by one `vlm_stale` run.
+- Isolation: one spawned child per VLM request; broker and probe remain in the parent.
+- Physical motion and UART access: disabled.
+- Permitted interpretation: integration, lifecycle and process-boundary correctness.
+- Not permitted: causal performance claims, timing-domain isolation, hard-real-time or heterogeneous-inference claims.
+
+## Provenance
+
+| Field | Value |
+| --- | --- |
+| Session | `20260830T122541Z_phase1_vlm_process_reaping` |
+| Source commit | `1818c83de574f44e0253216ab591d3be8c57d2f3` |
+| Source branch | `main` |
+| Transfer archive SHA-256 | `7074838c73ce23720b47decd9165f96fb6033e734fc010574969482d0d088dc2` |
+| Independently valid runs | yes |
+| Process Gates passed | yes |
+
+Machine-readable derived data: [`analysis.json`](analysis.json).
+
+## Frozen identities
+
+| Field | Value |
+| --- | --- |
+| Input SHA-256 | `607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7` |
+| Input size | 9009 bytes |
+| Moondream digest | `55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b` |
+| Qwen model | `qwen2.5-1.5b-instruct-q4_k_m.gguf` |
+
+## Correctness and process results
+
+| Condition | Execution | Disposition | Accepted | Cancel forwarded | Exit | Terminate | Slice/Process Gates |
+| --- | --- | --- | ---: | --- | ---: | --- | --- |
+| `vlm_async` | `ok` | consumed=1 | 1 | no | 0 | no | pass |
+| `vlm_stale` | `cancel_observed` | rejected_state=1 | 0 | yes | 0 | no | pass |
+
+The nominal result was consumed once. The stale result was rejected before consumption after cancellation was forwarded. Child exit does not confirm that the external model backend stopped inference.
+
+## Process supervision timing
+
+| Condition | Spawn -> start (ms) | Start -> inference (ms) | Inference -> completion receipt (ms) | Completion -> join (ms) | Total supervision (ms) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `vlm_async` | 180.500 | 14382.295 | 53111.196 | 61.044 | 67735.035 |
+| `vlm_stale` | 181.305 | 15282.647 | 44743.007 | 104.367 | 60311.326 |
+
+## Pipeline timing
+
+| Condition | Adapter total (ms) | Module import | Moondream | Qwen | Unload |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `vlm_async` | 67677.763 | 14380.694 | 30949.417 | 21756.256 | 400.828 |
+| `vlm_stale` | 60210.021 | 15281.019 | 27780.618 | 16547.201 | 402.481 |
+
+These single, fixed-order timings are descriptive and are not compared inferentially.
+
+## Periodic-probe observations
+
+| Condition | Ticks | Skipped | Deadline misses | Max lateness (ms) | Max gap (ms) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `vlm_async` | 698 | 0 | 0 | 0.780 | 100.647 |
+| `vlm_stale` | 624 | 0 | 0 | 0.419 | 100.272 |
+
+## Descriptive thread reference
+
+- Reference session: `20260830T073825Z_phase1_vlm_pilot`
+- Reference commit: `aebd1a22f8d9a9bfce1cd8dfd2f089e1cc48a204`
+- Reference analysis SHA-256: `9d5835453ffe857c33e180f9c75840396d199f8c6cb10a1facb63d1b6e15f04d`
+
+| Condition | Thread skipped | Process skipped | Thread max gap (ms) | Process max gap (ms) |
+| --- | ---: | ---: | ---: | ---: |
+| `vlm_async` | 85 | 0 | 4262.876 | 100.647 |
+| `vlm_stale` | 63 | 0 | 2700.375 | 100.272 |
+
+The thread reference recorded 148 skipped releases and the spawned-process pilot recorded 0. This is a descriptive mitigation signal, not a causal or performance-superiority claim; the sessions used single fixed-order runs from different commits.
+
+## Resource observations
+
+| Condition | Samples | Covered | RAM mean/max (MB) | GR3D mean/max (%) | Tj max (C) | VDD_IN mean/max (mW) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `vlm_async` | 339 | 329 | 4682.702/5714.000 | 5.782/99.000 | 53.906 | 5926.339/16646.000 |
+| `vlm_stale` | 303 | 293 | 4517.340/5662.000 | 6.347/99.000 | 53.375 | 5881.010/16215.000 |
+
+## Evidence gaps
+
+- `single_run_per_condition`
+- `fixed_condition_order`
+- `no_real_workload_synchronous_condition`
+- `formal_thresholds_not_frozen`
+- `model_unload_not_independently_confirmed`
+- `resource_activity_not_attributed_to_a_model_or_processor`
+- `emc_unavailable`
+- `thread_process_comparison_crosses_sessions`
+- `thread_process_order_not_randomized_or_balanced`
+- `thread_process_source_commits_differ`
+- `backend_stop_not_confirmed_by_process_exit`
+
+Both process runs recorded loopback-only listener bindings. Process exit and cancellation forwarding are bounded local facts. This evidence does not prove backend preemption.
+
+GR3D activity is device-level evidence and is not attributed to a particular model or processor. The result does not authorize a heterogeneous-inference claim.
+
+A timing-domain or performance claim remains prohibited: `timing_domain_isolation_claim_permitted=False`.

--- a/experiments/phase1/results/20260830T122541Z_phase1_vlm_process_reaping/analysis.json
+++ b/experiments/phase1/results/20260830T122541Z_phase1_vlm_process_reaping/analysis.json
@@ -1,0 +1,611 @@
+{
+  "analysis_schema_version": "0.1.0",
+  "analysis_kind": "phase1_fixed_input_vlm_process_pilot",
+  "session_id": "20260830T122541Z_phase1_vlm_process_reaping",
+  "source": {
+    "git_commit": "1818c83de574f44e0253216ab591d3be8c57d2f3",
+    "git_branch": "main",
+    "source_archive_sha256": "7074838c73ce23720b47decd9165f96fb6033e734fc010574969482d0d088dc2",
+    "run_artifacts": {
+      "vlm_async": {
+        "preflight.json": {
+          "size_bytes": 8141,
+          "sha256": "5042c58ef4c1da3c3b716fe4dab150787e937c6b0dffc7d42983ad77a84127ed"
+        },
+        "events.jsonl": {
+          "size_bytes": 415290,
+          "sha256": "9487e5ebcbee9f765714bae50dc4f753dd82b6910c5f9b08bc7c1800fe2f05cb"
+        },
+        "resources.jsonl": {
+          "size_bytes": 448239,
+          "sha256": "3989230b2dc566ecd8e30da6f1b0615aef6ce4d2fedb59e3d6ecbc80d2d81722"
+        },
+        "scenario.json": {
+          "size_bytes": 3674,
+          "sha256": "e66393d8a05fd6c4f8ee242a021883d5279596d0c562ab6dd80d926a45663416"
+        },
+        "summary.json": {
+          "size_bytes": 13929,
+          "sha256": "5394eb7ceaf7aaf6beca6240e6f5d3b9b2821bf1d359bacc48517852f6b62f3e"
+        },
+        "process.json": {
+          "size_bytes": 2306,
+          "sha256": "dac930c81c5b82a3854bce32c2b7f9c810f1095f4fe6361cb9bc7dc15ad434d5"
+        }
+      },
+      "vlm_stale": {
+        "preflight.json": {
+          "size_bytes": 8141,
+          "sha256": "332a2b16ee713228a40eb09559fa2df34c895236f900c6bd796f8ae515345315"
+        },
+        "events.jsonl": {
+          "size_bytes": 371615,
+          "sha256": "b9d272fbd71ce40202a134b508a601f17dba7acd474ef13bd3463d93c1587dd4"
+        },
+        "resources.jsonl": {
+          "size_bytes": 400439,
+          "sha256": "b4ab36389b5a664c0dc224f4600e41b4f95bf99edefca4c7e795c0bddc27307f"
+        },
+        "scenario.json": {
+          "size_bytes": 3706,
+          "sha256": "424d5b460a5de6bdcb19d1e8943cadcdd56e91224dd29bf0825d63ed3a36829c"
+        },
+        "summary.json": {
+          "size_bytes": 13983,
+          "sha256": "4e2fd78552fab89c5df2ff8e217ebfc4a2e23d6e97d1b9f54179d1f00bcd5d07"
+        },
+        "process.json": {
+          "size_bytes": 2323,
+          "sha256": "ac0261d2844796f48342a0bb7189593cbb679d63b8135c8fa32a6bf321299cc4"
+        }
+      }
+    },
+    "thread_reference": {
+      "analysis_sha256": "9d5835453ffe857c33e180f9c75840396d199f8c6cb10a1facb63d1b6e15f04d",
+      "analysis_kind": "phase1_fixed_input_vlm_pilot",
+      "analysis_schema_version": "0.1.0",
+      "session_id": "20260830T073825Z_phase1_vlm_pilot",
+      "git_commit": "aebd1a22f8d9a9bfce1cd8dfd2f089e1cc48a204",
+      "source_archive_sha256": "01869a420203929bc895c589082ec1d60244b2ba2ec8865fc6249bfaf07cae23",
+      "workload_identity_matched": true,
+      "conditions": {
+        "vlm_async": {
+          "adapter_total_ms": 79757.102262,
+          "probe_skipped_releases": 85,
+          "probe_deadline_miss_count": 0,
+          "probe_max_lateness_ms": 88.396307,
+          "probe_maximum_observed_gap_ms": 4262.87556
+        },
+        "vlm_stale": {
+          "adapter_total_ms": 61776.669919,
+          "probe_skipped_releases": 63,
+          "probe_deadline_miss_count": 0,
+          "probe_max_lateness_ms": 93.880989,
+          "probe_maximum_observed_gap_ms": 2700.37549
+        }
+      }
+    }
+  },
+  "identity": {
+    "input": {
+      "sha256": "607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7",
+      "size_bytes": 9009,
+      "media_type": "image/jpeg",
+      "path_recorded": false
+    },
+    "moondream_digest": "55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b",
+    "qwen_model_ids": [
+      "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+    ]
+  },
+  "claim_boundary": {
+    "design_role": "correctness_pilot",
+    "descriptive_only": true,
+    "real_workload_integration_observed": true,
+    "stale_result_rejection_observed": true,
+    "timing_domain_isolation_claim_permitted": false,
+    "asynchronous_performance_superiority_claim_permitted": false,
+    "hard_real_time_claim_permitted": false,
+    "heterogeneous_inference_claim_permitted": false,
+    "condition_resource_attribution_permitted": false,
+    "process_boundary_correctness_observed": true,
+    "periodic_probe_continuity_observed": true
+  },
+  "validation": {
+    "run_count": 2,
+    "all_runs_valid": true,
+    "correctness_observed": true,
+    "listener_binding_evidence_complete": true,
+    "all_process_gates_passed": true,
+    "process_boundary_correctness_observed": true,
+    "periodic_probe_continuity_observed": true
+  },
+  "runs": [
+    {
+      "condition": "vlm_async",
+      "run_id": "20260830T122546Z_phase1_vlm_process_async_vlm_001",
+      "session_id": "20260830T122541Z_phase1_vlm_process_reaping",
+      "source": {
+        "git_commit": "1818c83de574f44e0253216ab591d3be8c57d2f3",
+        "git_branch": "main",
+        "artifacts": {
+          "preflight.json": {
+            "size_bytes": 8141,
+            "sha256": "5042c58ef4c1da3c3b716fe4dab150787e937c6b0dffc7d42983ad77a84127ed"
+          },
+          "events.jsonl": {
+            "size_bytes": 415290,
+            "sha256": "9487e5ebcbee9f765714bae50dc4f753dd82b6910c5f9b08bc7c1800fe2f05cb"
+          },
+          "resources.jsonl": {
+            "size_bytes": 448239,
+            "sha256": "3989230b2dc566ecd8e30da6f1b0615aef6ce4d2fedb59e3d6ecbc80d2d81722"
+          },
+          "scenario.json": {
+            "size_bytes": 3674,
+            "sha256": "e66393d8a05fd6c4f8ee242a021883d5279596d0c562ab6dd80d926a45663416"
+          },
+          "summary.json": {
+            "size_bytes": 13929,
+            "sha256": "5394eb7ceaf7aaf6beca6240e6f5d3b9b2821bf1d359bacc48517852f6b62f3e"
+          },
+          "process.json": {
+            "size_bytes": 2306,
+            "sha256": "dac930c81c5b82a3854bce32c2b7f9c810f1095f4fe6361cb9bc7dc15ad434d5"
+          }
+        }
+      },
+      "input": {
+        "sha256": "607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7",
+        "size_bytes": 9009,
+        "media_type": "image/jpeg",
+        "path_recorded": false
+      },
+      "services": {
+        "moondream_model": "moondream",
+        "moondream_digest": "55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b",
+        "qwen_model_ids": [
+          "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+        ],
+        "listener_evidence": {
+          "preflight_schema_version": "0.2.0",
+          "complete": true,
+          "services": {
+            "ollama": {
+              "recorded": true,
+              "addresses": [
+                "127.0.0.1"
+              ],
+              "loopback_only": true
+            },
+            "qwen": {
+              "recorded": true,
+              "addresses": [
+                "127.0.0.1"
+              ],
+              "loopback_only": true
+            }
+          }
+        }
+      },
+      "validation": {
+        "manifest_status": "completed",
+        "summary_valid": true,
+        "all_gates_passed": true,
+        "real_vlm_path_executed": true,
+        "process_summary_valid": true,
+        "all_process_gates_passed": true
+      },
+      "result": {
+        "execution_outcome": "ok",
+        "translation_route": "qwen",
+        "disposition_counts": {
+          "consumed": 1
+        },
+        "accepted_result_count": 1,
+        "stale_consumed_count": 0,
+        "raw_text_recorded": false,
+        "model_unload": {
+          "unload_requested": true,
+          "unload_confirmed": null
+        },
+        "cancellation": {
+          "requested": false,
+          "worker_observed": false,
+          "client_wait_stopped": false,
+          "backend_stop_confirmed": null
+        }
+      },
+      "timing": {
+        "adapter_total_ms": 67677.763076,
+        "stages": [
+          {
+            "stage": "input_verify_before",
+            "status": "ok",
+            "duration_ms": 0.414259
+          },
+          {
+            "stage": "module_import",
+            "status": "ok",
+            "duration_ms": 14380.694291
+          },
+          {
+            "stage": "moondream_inference",
+            "status": "ok",
+            "duration_ms": 30949.416803
+          },
+          {
+            "stage": "qwen_rewrite",
+            "status": "ok",
+            "duration_ms": 21756.256282
+          },
+          {
+            "stage": "output_normalization",
+            "status": "ok",
+            "duration_ms": 0.042786
+          },
+          {
+            "stage": "model_unload",
+            "status": "ok",
+            "duration_ms": 400.827722
+          },
+          {
+            "stage": "input_verify_after",
+            "status": "ok",
+            "duration_ms": 3.052746
+          }
+        ],
+        "probe": {
+          "period_ms": 100.0,
+          "deadline_ms": 100.0,
+          "tick_count": 698,
+          "skipped_releases": 0,
+          "scheduled_release_count": 698,
+          "skipped_release_rate": 0.0,
+          "deadline_miss_count": 0,
+          "max_lateness_ms": 0.780063,
+          "maximum_observed_gap_ms": 100.647451,
+          "joined": true,
+          "error_code": null,
+          "skipped_releases_by_adapter_stage": {}
+        }
+      },
+      "resources": {
+        "sample_count": 339,
+        "inference_interval_sample_count": 329,
+        "parse_error_count": 0,
+        "parse_warning_counts": {
+          "emc_missing": 339
+        },
+        "sample_interval_ms": {
+          "mean": 205.967483,
+          "p95": 206.512601,
+          "p99": 206.964335,
+          "max": 217.594618
+        },
+        "ram_used_mb": {
+          "mean": 4682.702065,
+          "p95": 5712.0,
+          "max": 5714.0
+        },
+        "gr3d_usage_pct": {
+          "mean": 5.781711,
+          "p95": 32.0,
+          "max": 99.0
+        },
+        "junction_temperature_c": {
+          "mean": 51.773699,
+          "p95": 52.125,
+          "max": 53.906
+        },
+        "vdd_in_instant_mw": {
+          "mean": 5926.339233,
+          "p95": 8412.0,
+          "max": 16646.0
+        }
+      },
+      "adapter_isolation": "spawned_process",
+      "process": {
+        "protocol_version": "0.1.0",
+        "start_method": "spawn",
+        "process_id_recorded": true,
+        "protocol_complete": true,
+        "exit_code": 0,
+        "cancellation_forwarded": false,
+        "terminate_requested": false,
+        "terminate_confirmed": false,
+        "error_code": null,
+        "valid": true,
+        "gate_results": {
+          "spawned_process": true,
+          "bounded_protocol": true,
+          "process_reaped": true,
+          "boundary_order": true,
+          "cancellation_forwarding": true
+        },
+        "timing_ms": {
+          "spawn_to_child_start": 180.499904,
+          "child_start_to_inference": 14382.295292,
+          "inference_to_completion_receipt": 53111.195803,
+          "completion_receipt_to_join": 61.043623,
+          "total_supervision": 67735.034622
+        }
+      }
+    },
+    {
+      "condition": "vlm_stale",
+      "run_id": "20260830T123150Z_phase1_vlm_process_stale_vlm_001",
+      "session_id": "20260830T122541Z_phase1_vlm_process_reaping",
+      "source": {
+        "git_commit": "1818c83de574f44e0253216ab591d3be8c57d2f3",
+        "git_branch": "main",
+        "artifacts": {
+          "preflight.json": {
+            "size_bytes": 8141,
+            "sha256": "332a2b16ee713228a40eb09559fa2df34c895236f900c6bd796f8ae515345315"
+          },
+          "events.jsonl": {
+            "size_bytes": 371615,
+            "sha256": "b9d272fbd71ce40202a134b508a601f17dba7acd474ef13bd3463d93c1587dd4"
+          },
+          "resources.jsonl": {
+            "size_bytes": 400439,
+            "sha256": "b4ab36389b5a664c0dc224f4600e41b4f95bf99edefca4c7e795c0bddc27307f"
+          },
+          "scenario.json": {
+            "size_bytes": 3706,
+            "sha256": "424d5b460a5de6bdcb19d1e8943cadcdd56e91224dd29bf0825d63ed3a36829c"
+          },
+          "summary.json": {
+            "size_bytes": 13983,
+            "sha256": "4e2fd78552fab89c5df2ff8e217ebfc4a2e23d6e97d1b9f54179d1f00bcd5d07"
+          },
+          "process.json": {
+            "size_bytes": 2323,
+            "sha256": "ac0261d2844796f48342a0bb7189593cbb679d63b8135c8fa32a6bf321299cc4"
+          }
+        }
+      },
+      "input": {
+        "sha256": "607c9faf3ea03b8b032d8c1d9e86c697d9fb48ca3c2f278e453941da6b871be7",
+        "size_bytes": 9009,
+        "media_type": "image/jpeg",
+        "path_recorded": false
+      },
+      "services": {
+        "moondream_model": "moondream",
+        "moondream_digest": "55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b",
+        "qwen_model_ids": [
+          "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+        ],
+        "listener_evidence": {
+          "preflight_schema_version": "0.2.0",
+          "complete": true,
+          "services": {
+            "ollama": {
+              "recorded": true,
+              "addresses": [
+                "127.0.0.1"
+              ],
+              "loopback_only": true
+            },
+            "qwen": {
+              "recorded": true,
+              "addresses": [
+                "127.0.0.1"
+              ],
+              "loopback_only": true
+            }
+          }
+        }
+      },
+      "validation": {
+        "manifest_status": "completed",
+        "summary_valid": true,
+        "all_gates_passed": true,
+        "real_vlm_path_executed": true,
+        "process_summary_valid": true,
+        "all_process_gates_passed": true
+      },
+      "result": {
+        "execution_outcome": "cancel_observed",
+        "translation_route": "qwen",
+        "disposition_counts": {
+          "rejected_state": 1
+        },
+        "accepted_result_count": 0,
+        "stale_consumed_count": 0,
+        "raw_text_recorded": false,
+        "model_unload": {
+          "unload_requested": true,
+          "unload_confirmed": null
+        },
+        "cancellation": {
+          "requested": true,
+          "worker_observed": true,
+          "client_wait_stopped": false,
+          "backend_stop_confirmed": null
+        }
+      },
+      "timing": {
+        "adapter_total_ms": 60210.021036,
+        "stages": [
+          {
+            "stage": "input_verify_before",
+            "status": "ok",
+            "duration_ms": 0.416307
+          },
+          {
+            "stage": "module_import",
+            "status": "ok",
+            "duration_ms": 15281.018932
+          },
+          {
+            "stage": "moondream_inference",
+            "status": "ok",
+            "duration_ms": 27780.61775
+          },
+          {
+            "stage": "qwen_rewrite",
+            "status": "ok",
+            "duration_ms": 16547.200885
+          },
+          {
+            "stage": "output_normalization",
+            "status": "ok",
+            "duration_ms": 0.139782
+          },
+          {
+            "stage": "model_unload",
+            "status": "ok",
+            "duration_ms": 402.480788
+          },
+          {
+            "stage": "input_verify_after",
+            "status": "ok",
+            "duration_ms": 5.877826
+          }
+        ],
+        "probe": {
+          "period_ms": 100.0,
+          "deadline_ms": 100.0,
+          "tick_count": 624,
+          "skipped_releases": 0,
+          "scheduled_release_count": 624,
+          "skipped_release_rate": 0.0,
+          "deadline_miss_count": 0,
+          "max_lateness_ms": 0.418757,
+          "maximum_observed_gap_ms": 100.2719,
+          "joined": true,
+          "error_code": null,
+          "skipped_releases_by_adapter_stage": {}
+        }
+      },
+      "resources": {
+        "sample_count": 303,
+        "inference_interval_sample_count": 293,
+        "parse_error_count": 0,
+        "parse_warning_counts": {
+          "emc_missing": 303
+        },
+        "sample_interval_ms": {
+          "mean": 205.902815,
+          "p95": 206.523216,
+          "p99": 206.745794,
+          "max": 206.86821
+        },
+        "ram_used_mb": {
+          "mean": 4517.339934,
+          "p95": 5647.0,
+          "max": 5662.0
+        },
+        "gr3d_usage_pct": {
+          "mean": 6.346535,
+          "p95": 55.0,
+          "max": 99.0
+        },
+        "junction_temperature_c": {
+          "mean": 51.414944,
+          "p95": 51.781,
+          "max": 53.375
+        },
+        "vdd_in_instant_mw": {
+          "mean": 5881.009901,
+          "p95": 8491.0,
+          "max": 16215.0
+        }
+      },
+      "adapter_isolation": "spawned_process",
+      "process": {
+        "protocol_version": "0.1.0",
+        "start_method": "spawn",
+        "process_id_recorded": true,
+        "protocol_complete": true,
+        "exit_code": 0,
+        "cancellation_forwarded": true,
+        "terminate_requested": false,
+        "terminate_confirmed": false,
+        "error_code": null,
+        "valid": true,
+        "gate_results": {
+          "spawned_process": true,
+          "bounded_protocol": true,
+          "process_reaped": true,
+          "boundary_order": true,
+          "cancellation_forwarding": true
+        },
+        "timing_ms": {
+          "spawn_to_child_start": 181.304827,
+          "child_start_to_inference": 15282.647228,
+          "inference_to_completion_receipt": 44743.006797,
+          "completion_receipt_to_join": 104.366986,
+          "total_supervision": 60311.325838
+        }
+      }
+    }
+  ],
+  "data_quality": {
+    "total_probe_skipped_releases": 0,
+    "limitations": [
+      "single_run_per_condition",
+      "fixed_condition_order",
+      "no_real_workload_synchronous_condition",
+      "formal_thresholds_not_frozen",
+      "model_unload_not_independently_confirmed",
+      "resource_activity_not_attributed_to_a_model_or_processor",
+      "emc_unavailable",
+      "thread_process_comparison_crosses_sessions",
+      "thread_process_order_not_randomized_or_balanced",
+      "thread_process_source_commits_differ",
+      "backend_stop_not_confirmed_by_process_exit"
+    ],
+    "total_probe_deadline_misses": 0
+  },
+  "adapter_isolation": "spawned_process",
+  "thread_process_comparison": {
+    "comparison_role": "cross_session_descriptive_reference",
+    "conditions": {
+      "vlm_async": {
+        "thread": {
+          "adapter_total_ms": 79757.102262,
+          "probe_skipped_releases": 85,
+          "probe_deadline_miss_count": 0,
+          "probe_max_lateness_ms": 88.396307,
+          "probe_maximum_observed_gap_ms": 4262.87556
+        },
+        "spawned_process": {
+          "adapter_total_ms": 67677.763076,
+          "probe_skipped_releases": 0,
+          "probe_deadline_miss_count": 0,
+          "probe_max_lateness_ms": 0.780063,
+          "probe_maximum_observed_gap_ms": 100.647451
+        },
+        "observed_skipped_release_difference": -85
+      },
+      "vlm_stale": {
+        "thread": {
+          "adapter_total_ms": 61776.669919,
+          "probe_skipped_releases": 63,
+          "probe_deadline_miss_count": 0,
+          "probe_max_lateness_ms": 93.880989,
+          "probe_maximum_observed_gap_ms": 2700.37549
+        },
+        "spawned_process": {
+          "adapter_total_ms": 60210.021036,
+          "probe_skipped_releases": 0,
+          "probe_deadline_miss_count": 0,
+          "probe_max_lateness_ms": 0.418757,
+          "probe_maximum_observed_gap_ms": 100.2719
+        },
+        "observed_skipped_release_difference": -63
+      }
+    },
+    "total_probe_skipped_releases": {
+      "thread": 148,
+      "spawned_process": 0
+    },
+    "descriptive_mitigation_signal_observed": true,
+    "causal_attribution_permitted": false,
+    "performance_superiority_claim_permitted": false
+  }
+}

--- a/experiments/phase1/tests/test_vlm_process_pilot_analysis.py
+++ b/experiments/phase1/tests/test_vlm_process_pilot_analysis.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from experiments.phase1.analyze_vlm_pilot import (
+    PROCESS_ANALYSIS_KIND,
+    analyze_vlm_pilot_dir,
+    main,
+    render_markdown,
+)
+from experiments.phase1.tests.test_vlm_pilot_analysis import (
+    ARCHIVE_SHA256,
+    _write_run,
+    make_session,
+)
+
+
+PROCESS_SESSION_ID = "20260830T122541Z_phase1_vlm_process_reaping"
+PROCESS_ARCHIVE_SHA256 = "2" * 64
+
+
+def _process_facts(condition: str) -> dict[str, object]:
+    cancellation_forwarded = condition == "vlm_stale"
+    return {
+        "protocol_version": "0.1.0",
+        "start_method": "spawn",
+        "process_name": "phase1-vlm-process-worker",
+        "process_id": 1234,
+        "spawn_requested_monotonic_ns": 800_000_000,
+        "child_started_monotonic_ns": 900_000_000,
+        "inference_started_monotonic_ns": 1_300_000_000,
+        "completion_received_monotonic_ns": 1_640_000_000,
+        "joined_monotonic_ns": 1_650_000_000,
+        "exit_code": 0,
+        "cancellation_forwarded": cancellation_forwarded,
+        "cancellation_forwarded_monotonic_ns": (
+            1_400_000_000 if cancellation_forwarded else None
+        ),
+        "terminate_requested": False,
+        "terminate_confirmed": False,
+        "protocol_complete": True,
+        "error_code": None,
+    }
+
+
+def _convert_run(run_dir: Path, condition: str) -> None:
+    manifest_path = run_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["session_id"] = PROCESS_SESSION_ID
+    manifest["adapter_isolation"] = "spawned_process"
+    manifest["artifact_kind"] = "phase1_fixed_input_vlm_process_run"
+    manifest["artifacts"]["process.json"] = {
+        "sha256": "8" * 64,
+        "size_bytes": 1,
+    }
+    manifest_path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+    preflight_path = run_dir / "preflight.json"
+    preflight = json.loads(preflight_path.read_text(encoding="utf-8"))
+    preflight["vlm_preflight_schema_version"] = "0.2.0"
+    for name in ("ollama", "qwen"):
+        service = preflight["services"][name]
+        service["listener_addresses"] = ["127.0.0.1"]
+        service["listener_loopback_only"] = True
+    preflight_path.write_text(json.dumps(preflight) + "\n", encoding="utf-8")
+
+    facts = _process_facts(condition)
+    scenario_path = run_dir / "scenario.json"
+    scenario = json.loads(scenario_path.read_text(encoding="utf-8"))
+    scenario["process"] = facts
+    scenario["report"]["probe"].update(
+        {
+            "tick_count": 12,
+            "skipped_releases": 0,
+            "deadline_miss_count": 0,
+            "max_lateness_ns": 500_000,
+            "max_gap_ns": 100_500_000,
+        }
+    )
+    scenario_path.write_text(json.dumps(scenario) + "\n", encoding="utf-8")
+
+    events_path = run_dir / "events.jsonl"
+    events = [
+        json.loads(line)
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    events = [event for event in events if event["event"] != "probe.skipped"]
+    events_path.write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+
+    process = {
+        "vlm_process_summary_schema_version": "0.1.0",
+        "adapter_isolation": "spawned_process",
+        "condition": condition,
+        "valid": True,
+        "process": facts,
+        "gates": [
+            {"name": name, "passed": True}
+            for name in (
+                "spawned_process",
+                "bounded_protocol",
+                "process_reaped",
+                "boundary_order",
+                "cancellation_forwarding",
+            )
+        ],
+    }
+    (run_dir / "process.json").write_text(
+        json.dumps(process) + "\n",
+        encoding="utf-8",
+    )
+
+
+def make_process_session(root: Path) -> Path:
+    session = root / PROCESS_SESSION_ID
+    for condition in ("vlm_async", "vlm_stale"):
+        run_dir = _write_run(session, condition)
+        _convert_run(run_dir, condition)
+        source = session / condition
+        target = session / condition.replace("vlm_", "vlm_process_", 1)
+        source.rename(target)
+    return session
+
+
+def write_thread_reference(root: Path) -> Path:
+    thread_session = make_session(root / "thread")
+    analysis = analyze_vlm_pilot_dir(
+        thread_session,
+        source_archive_sha256=ARCHIVE_SHA256,
+    )
+    path = root / "thread-analysis.json"
+    path.write_text(json.dumps(analysis) + "\n", encoding="utf-8")
+    return path
+
+
+class VLMProcessPilotAnalysisTests(unittest.TestCase):
+    def test_process_analysis_reconstructs_boundary_and_comparison(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                reference = write_thread_reference(root)
+                session = make_process_session(root)
+                analysis = analyze_vlm_pilot_dir(
+                    session,
+                    source_archive_sha256=PROCESS_ARCHIVE_SHA256,
+                    thread_reference_analysis=reference,
+                )
+
+        self.assertEqual(analysis["analysis_kind"], PROCESS_ANALYSIS_KIND)
+        self.assertTrue(analysis["validation"]["all_process_gates_passed"])
+        self.assertTrue(analysis["validation"]["process_boundary_correctness_observed"])
+        self.assertTrue(analysis["validation"]["periodic_probe_continuity_observed"])
+        self.assertTrue(
+            analysis["thread_process_comparison"][
+                "descriptive_mitigation_signal_observed"
+            ]
+        )
+        self.assertEqual(
+            analysis["thread_process_comparison"]["total_probe_skipped_releases"],
+            {"thread": 4, "spawned_process": 0},
+        )
+        self.assertFalse(
+            analysis["claim_boundary"]["timing_domain_isolation_claim_permitted"]
+        )
+        for run in analysis["runs"]:
+            self.assertEqual(run["process"]["exit_code"], 0)
+            self.assertFalse(run["process"]["terminate_requested"])
+            self.assertTrue(all(run["process"]["gate_results"].values()))
+            self.assertEqual(run["timing"]["probe"]["skipped_releases"], 0)
+
+    def test_process_cli_is_deterministic_and_private(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                reference = write_thread_reference(root)
+                session = make_process_session(root / "private-source")
+                json_path = root / "published" / "analysis.json"
+                markdown_path = root / "published" / "README.md"
+                arguments = [
+                    str(session),
+                    "--source-archive-sha256",
+                    PROCESS_ARCHIVE_SHA256,
+                    "--thread-reference-analysis",
+                    str(reference),
+                    "--json-output",
+                    str(json_path),
+                    "--markdown-output",
+                    str(markdown_path),
+                ]
+                first_result = main(arguments)
+                first_json = json_path.read_text(encoding="utf-8")
+                first_markdown = markdown_path.read_text(encoding="utf-8")
+                second_result = main(arguments)
+                second_json = json_path.read_text(encoding="utf-8")
+                second_markdown = markdown_path.read_text(encoding="utf-8")
+                temporary_files = list(root.rglob("*.tmp"))
+
+        self.assertEqual(first_result, 0)
+        self.assertEqual(second_result, 0)
+        self.assertEqual(first_json, second_json)
+        self.assertEqual(first_markdown, second_markdown)
+        self.assertNotIn(str(session), first_json)
+        self.assertNotIn(str(reference), first_json)
+        self.assertNotIn("private-source", first_json)
+        self.assertIn("descriptive mitigation signal", first_markdown)
+        self.assertIn("recorded 4 skipped releases", first_markdown)
+        self.assertNotIn("performance improvement", first_markdown)
+        self.assertFalse(temporary_files)
+
+    def test_process_analysis_rejects_divergent_supervisor_facts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = make_process_session(Path(temp_dir))
+            run_dir = next((session / "vlm_process_async").iterdir())
+            process_path = run_dir / "process.json"
+            process = json.loads(process_path.read_text(encoding="utf-8"))
+            process["process"]["exit_code"] = -15
+            process_path.write_text(json.dumps(process) + "\n", encoding="utf-8")
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                with self.assertRaisesRegex(ValueError, "facts differ"):
+                    analyze_vlm_pilot_dir(session)
+
+    def test_process_analysis_rejects_reference_identity_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                reference = write_thread_reference(root)
+                value = json.loads(reference.read_text(encoding="utf-8"))
+                value["identity"]["input"]["sha256"] = "9" * 64
+                reference.write_text(json.dumps(value) + "\n", encoding="utf-8")
+                session = make_process_session(root)
+                with self.assertRaisesRegex(ValueError, "identity does not match"):
+                    analyze_vlm_pilot_dir(
+                        session,
+                        thread_reference_analysis=reference,
+                    )
+
+    def test_process_markdown_preserves_claim_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = make_process_session(Path(temp_dir))
+            with patch(
+                "experiments.phase1.analyze_vlm_pilot.validate_vlm_slice_dir",
+                return_value=[],
+            ):
+                analysis = analyze_vlm_pilot_dir(session)
+
+        report = render_markdown(analysis)
+        self.assertIn("Process-isolated Fixed-input VLM Pilot", report)
+        self.assertIn("does not prove backend preemption", report)
+        self.assertIn("timing_domain_isolation_claim_permitted=False", report)
+        self.assertNotIn("hard real-time guarantee", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -2,9 +2,9 @@
 
 The Jetson package contains the high-level runtime from the bachelor's thesis: offline speech interaction, local language and vision inference, color-target motion planning, and UART communication with the STM32. It also contains the host-testable Phase 1 task-runtime kernel. The experiment layer now connects that kernel to the fixed Phase 0 VLM input without changing the robot application.
 
-The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. The experiment harness under `experiments/phase1/` has completed one motion-disabled simulation pilot and one fixed-input VLM correctness pilot on the Jetson. The real-model pilot validated nominal consumption and stale-result rejection, but also recorded skipped probe releases during lazy Python module import. A spawned-process VLM adapter is now host-tested to address that boundary; its Jetson pilot, formal comparison and application integration remain research work.
+The thesis application was validated on a Jetson Orin Nano Super 8GB running Ubuntu 22.04 and Python 3.10.12. It remains the synchronous reference implementation. The Phase 1 package currently covers host-safe task identity, bounded ownership, a single-worker observable executor and a software periodic probe. The experiment harness under `experiments/phase1/` has completed one motion-disabled simulation pilot, one threaded fixed-input VLM correctness pilot and one spawned-process VLM correctness pilot on the Jetson. The threaded real-model pilot recorded skipped probe releases during lazy Python module import. The process pilot completed both lifecycle conditions with normally reaped children and no skipped probe releases, but formal comparison and application integration remain research work.
 
-> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 已完成固定输入 VLM 的 Jetson correctness pilot，进程隔离路径已通过 host-only 测试、尚待实机 pilot，正式对比实验与运动控制接入尚未开始。
+> 中文简介：本目录包含“章鱼号”的 Jetson 端运行程序，负责离线语音交互、本地大模型与视觉模型调用、颜色目标接近和 STM32 串口通信。当前整机应用仍使用已验证的同步路径；Phase 1 已完成线程版与进程隔离版固定输入 VLM 的 Jetson correctness pilot，正式对比实验与运动控制接入尚未开始。
 
 ## Modules
 
@@ -116,7 +116,7 @@ Audio, ASR text, captured images and communication logs are written beneath `ROB
 
 - The orchestration path is blocking and single-process; inference tasks do not have explicit deadlines or cancellation.
 - The Phase 1 VLM experiment uses one fixed file and is not connected to live acquisition, TTS or the synchronous application loop.
-- The spawned-process VLM path is an experiment runner boundary, not an application worker pool; no Jetson timing result has been collected from it yet.
+- The spawned-process VLM path is an experiment runner boundary, not an application worker pool; its two Jetson observations are descriptive correctness evidence rather than a formal timing result.
 - llama.cpp and Ollama are managed outside the application.
 - The color tracker uses fixed HSV ranges and discrete motion commands tuned on the thesis robot.
 - The Jetson sends speed percentages, while the STM32 applies open-loop PWM rather than closed-loop wheel velocity.


### PR DESCRIPTION
## Summary

- Extend the Phase 1 VLM pilot analyzer to support both thread-isolated and spawned-process two-condition sessions.
- Reconstruct and validate the spawned-process protocol facts and all five process Gates.
- Add bounded process-supervision timing summaries and deterministic report generation.
- Support an optional hash-recorded thread-pilot reference with strict workload-identity matching.
- Publish privacy-bounded derived artifacts for the completed process-isolated Jetson pilot.
- Update the Phase 1 runtime contract and operator documentation to reflect the completed pilot.

## Pilot evidence

Session: `20260830T122541Z_phase1_vlm_process_reaping`

Source archive SHA-256:

`7074838c73ce23720b47decd9165f96fb6033e734fc010574969482d0d088dc2`

Both process-isolated runs validated successfully:

- `vlm_async`: one result consumed, child process exited with code 0, and no forced termination was required.
- `vlm_stale`: one result rejected by state, zero stale results consumed, cancellation forwarded to the child process, and the child exited with code 0.
- All process and slice Gates passed for both conditions.
- No residual worker process or loaded Ollama model remained after either run.

The descriptive probe trace recorded zero skipped samples and zero deadline misses in both spawned-process runs. The thread-reference comparison is included only as a bounded mitigation signal.

## Claim boundaries

This change does not make causal performance, performance-superiority, timing-isolation, hard-real-time, backend-preemption, or heterogeneous-inference claims.

Raw prompts, model output text, local filesystem paths, process IDs, and raw Jetson evidence are excluded from the published derivatives.

## Validation

- Phase 0 unit tests: 29 passed
- Phase 1 unit tests: 124 passed
- Process and slice validation: both real Jetson runs `VALID`
- Black: passed
- Pyflakes: passed
- Python compilation: passed
- `git diff --check`: passed