### PR TITLE
fix(phase1): preserve ASR stale telemetry coverage

### DIFF
--- a/docs/architecture/phase1-runtime-contract.md
+++ b/docs/architecture/phase1-runtime-contract.md
@@ -866,9 +866,20 @@ ASR uses its workload-specific FIFO lane with pending and result capacities of
 two. The first correctness slice admits one request so nominal completion and
 state invalidation remain isolated from later arrival-rate experiments. Its
 conditions are `asr_async` and `asr_stale`. The nominal condition consumes one
-matching transcript identity. The stale condition advances the state generation
-after Whisper starts, requests cancellation, stops and reaps the native
-`whisper-cli` process, and consumes no result.
+matching transcript identity. The stale condition observes active Whisper for
+0.5 s after its process starts, advances the state generation, requests
+cancellation, stops and reaps the native `whisper-cli` process, and consumes no
+result.
+
+The 0.5 s observation window is an experimental correctness control, not a
+formal performance threshold or a measurement of cancellation latency. It is
+greater than the default 200 ms resource-sampling period so the stale execution
+can contain at least one resource sample. The runner fails before creating a
+run directory if the stale window does not exceed the configured resource
+interval or if it reaches the adapter or slice completion timeout. This rule was
+added after an invalid Jetson attempt cancelled Whisper in about 6.5 ms and
+passed every lifecycle/process Gate while correctly failing resource coverage
+with zero in-interval samples. That failed attempt is diagnostic only.
 
 The cancellation claim differs from the VLM HTTP-service path. Whisper is the
 backend process for this invocation; successful termination and reaping can set
@@ -929,6 +940,8 @@ The fixed-input ASR slice additionally requires:
 - nominal Whisper exits with code zero and is reaped without termination;
 - stale cancellation is observed, stops the local wait, terminates and reaps
   Whisper, and records backend-stop confirmation only for that child;
+- the stale adapter remains active for the recorded observation window, which
+  must exceed the configured resource-sampling interval;
 - raw transcript text and private filesystem paths are absent from artifacts;
 - at least one valid resource sample falls inside the adapter interval.
 

--- a/experiments/phase1/README.md
+++ b/experiments/phase1/README.md
@@ -385,7 +385,16 @@ The two host-tested correctness conditions are:
 | Condition | State action | Required disposition and process fact |
 | --- | --- | --- |
 | `asr_async` | none | one transcript identity consumed; Whisper exits 0 and is reaped |
-| `asr_stale` | advance generation after Whisper starts | one `rejected_state`, zero consumed; Whisper is stopped and reaped |
+| `asr_stale` | observe active Whisper for 0.5 s, then advance generation | one `rejected_state`, zero consumed; Whisper is stopped and reaped |
+
+The stale observation window is a correctness-pilot control, not a cancellation
+latency or performance threshold. It is longer than the default 200 ms resource
+sampling interval so at least one sample can fall inside the active adapter
+interval. The runner rejects a stale window that does not exceed the configured
+resource interval or that reaches either the adapter or slice completion
+timeout. A first Jetson attempt without this control cancelled Whisper in about
+6.5 ms: every lifecycle and process Gate passed, but the resource-coverage Gate
+correctly failed because no 200 ms sample could fall inside that interval.
 
 Run them only from a clean, synchronized Jetson `main` branch after the fixed
 WAV has been restored beneath the ignored Phase 0 input root:
@@ -399,6 +408,7 @@ python3 -m experiments.phase1.run_asr_slice \
 
 python3 -m experiments.phase1.run_asr_slice \
   --condition asr_stale \
+  --stale-observation-s 0.5 \
   --session-id 20260831T000000Z_phase1_asr_pilot \
   --repetition 1
 ```

--- a/experiments/phase1/asr_slice.py
+++ b/experiments/phase1/asr_slice.py
@@ -73,6 +73,7 @@ class ASRSliceSpec:
     probe_join_timeout_s: float = 5.0
     prelude_s: float = 1.0
     postlude_s: float = 1.0
+    stale_observation_s: float = 0.5
     probe_period_ns: int = 100_000_000
     probe_deadline_ns: int = 100_000_000
 
@@ -88,6 +89,11 @@ class ASRSliceSpec:
             _finite_seconds(getattr(self, field_name), field_name, positive=True)
         for field_name in ("prelude_s", "postlude_s"):
             _finite_seconds(getattr(self, field_name), field_name)
+        _finite_seconds(
+            self.stale_observation_s,
+            "stale_observation_s",
+            positive=True,
+        )
         for field_name in ("probe_period_ns", "probe_deadline_ns"):
             value = getattr(self, field_name)
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
@@ -110,6 +116,7 @@ class ASRSliceSpec:
             "probe_join_timeout_s": self.probe_join_timeout_s,
             "prelude_s": self.prelude_s,
             "postlude_s": self.postlude_s,
+            "stale_observation_s": self.stale_observation_s,
             "probe_period_ns": self.probe_period_ns,
             "probe_deadline_ns": self.probe_deadline_ns,
             "state_advance_after_inference_start": (
@@ -306,6 +313,7 @@ def run_asr_slice(
                 spec.completion_timeout_s
             ):
                 raise TimeoutError("ASR inference did not reach its start boundary")
+            _sleep(spec.stale_observation_s)
             executor.advance_state(
                 "asr-slice",
                 reason="fixed_input_state_change",

--- a/experiments/phase1/run_asr_slice.py
+++ b/experiments/phase1/run_asr_slice.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 import re
 import sys
 from datetime import datetime, timezone
@@ -194,6 +195,22 @@ def run_once(
         raise ASRRunError(
             "adapter execution timeout must be below the slice completion timeout"
         )
+    if not math.isfinite(args.stale_observation_s) or args.stale_observation_s <= 0:
+        raise ASRRunError("stale observation window must be positive and finite")
+    if condition is ASRSliceCondition.STALE:
+        resource_interval_s = args.resource_interval_ms / 1000.0
+        if args.stale_observation_s <= resource_interval_s:
+            raise ASRRunError(
+                "stale observation window must exceed the resource interval"
+            )
+        if args.stale_observation_s >= args.adapter_execution_timeout_s:
+            raise ASRRunError(
+                "stale observation window must be below the adapter timeout"
+            )
+        if args.stale_observation_s >= args.completion_timeout_s:
+            raise ASRRunError(
+                "stale observation window must be below the completion timeout"
+            )
     session_id = _validate_session_id(args.session_id or make_asr_session_id())
     injected_components = [
         name
@@ -236,6 +253,7 @@ def run_once(
         probe_join_timeout_s=args.probe_join_timeout_s,
         prelude_s=args.prelude_s,
         postlude_s=args.postlude_s,
+        stale_observation_s=args.stale_observation_s,
         probe_period_ns=int(args.probe_period_ms * 1_000_000),
         probe_deadline_ns=int(args.probe_deadline_ms * 1_000_000),
     )
@@ -404,6 +422,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--probe-join-timeout-s", type=float, default=5.0)
     parser.add_argument("--prelude-s", type=float, default=1.0)
     parser.add_argument("--postlude-s", type=float, default=1.0)
+    parser.add_argument("--stale-observation-s", type=float, default=0.5)
     parser.add_argument("--probe-period-ms", type=float, default=100.0)
     parser.add_argument("--probe-deadline-ms", type=float, default=100.0)
     parser.add_argument("--resource-interval-ms", type=int, default=200)

--- a/experiments/phase1/summarize_asr_slice.py
+++ b/experiments/phase1/summarize_asr_slice.py
@@ -17,7 +17,7 @@ from experiments.phase1.jetson_telemetry import summarize_resource_samples
 from experiments.phase1.replay_lifecycle import TraceProfile, replay_file
 
 
-ASR_SUMMARY_SCHEMA_VERSION = "0.1.0"
+ASR_SUMMARY_SCHEMA_VERSION = "0.2.0"
 
 
 def _gate(
@@ -121,6 +121,20 @@ def build_asr_summary(
         and started_ns <= value <= finished_ns
         for value in resource_times
     )
+    stale_observation_s = spec.get("stale_observation_s")
+    stale_observation_ns = (
+        int(stale_observation_s * 1_000_000_000)
+        if isinstance(stale_observation_s, (int, float))
+        and not isinstance(stale_observation_s, bool)
+        else None
+    )
+    adapter_duration_ns = adapter.get("duration_ns")
+    stale_observation_holds = condition is ASRSliceCondition.ASYNC or (
+        isinstance(stale_observation_ns, int)
+        and stale_observation_ns > 0
+        and isinstance(adapter_duration_ns, int)
+        and adapter_duration_ns >= stale_observation_ns
+    )
 
     gates = [
         _gate(
@@ -215,6 +229,20 @@ def build_asr_summary(
                 "nominal execution has no cancellation request"
                 if condition is ASRSliceCondition.ASYNC
                 else "state invalidation is confirmed at the Whisper process boundary"
+            ),
+        ),
+        _gate(
+            "stale_observation_window",
+            stale_observation_holds,
+            observed={
+                "condition": condition.value,
+                "required_observation_ns": stale_observation_ns,
+                "adapter_duration_ns": adapter_duration_ns,
+            },
+            requirement=(
+                "the stale condition observes active Whisper long enough for telemetry"
+                if condition is ASRSliceCondition.STALE
+                else "the stale-only observation control is not applied"
             ),
         ),
         _gate(

--- a/experiments/phase1/tests/test_asr_runner.py
+++ b/experiments/phase1/tests/test_asr_runner.py
@@ -121,6 +121,8 @@ class ASRRunnerTests(unittest.TestCase):
                 "0.02",
                 "--postlude-s",
                 "0.02",
+                "--stale-observation-s",
+                "0.06",
                 "--probe-period-ms",
                 "5",
                 "--probe-deadline-ms",
@@ -180,7 +182,7 @@ class ASRRunnerTests(unittest.TestCase):
         output_base = Path(command[command.index("-of") + 1])
         output_txt = output_base.with_suffix(".txt")
         script = (
-            "import time; from pathlib import Path; time.sleep(0.04); "
+            "import time; from pathlib import Path; time.sleep(0.12); "
             f"Path({str(output_txt)!r}).write_text({self.transcript!r}, "
             "encoding='utf-8')"
         )
@@ -260,6 +262,18 @@ class ASRRunnerTests(unittest.TestCase):
         )
         self.assertTrue(stale["adapter"]["process"]["reaped"])
         self.assertTrue(stale["adapter"]["cancellation"]["backend_stop_confirmed"])
+        self.assertEqual(stale["spec"]["stale_observation_s"], 0.06)
+        self.assertGreater(
+            stale["resources"]["inference_interval_sample_count"],
+            0,
+        )
+        self.assertTrue(
+            next(
+                gate
+                for gate in stale["gates"]
+                if gate["name"] == "stale_observation_window"
+            )["passed"]
+        )
         self.assertEqual(
             {thread.name for thread in threading.enumerate()}, baseline_threads
         )
@@ -291,6 +305,20 @@ class ASRRunnerTests(unittest.TestCase):
         args.adapter_execution_timeout_s = args.completion_timeout_s
         with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
             with self.assertRaisesRegex(RuntimeError, "execution timeout"):
+                run_once(
+                    args,
+                    repo_root=REPO_ROOT,
+                    preflight_builder=self.preflight_builder,
+                    sampler_factory=self.sampler_factory,
+                    adapter_factory=self.adapter_factory,
+                )
+        self.assertFalse((self.root / "runs" / SESSION_ID).exists())
+
+    def test_stale_observation_budget_is_rejected_before_output_creation(self) -> None:
+        args = self.args(ASRSliceCondition.STALE)
+        args.stale_observation_s = args.resource_interval_ms / 1000.0
+        with patch.dict(os.environ, {"ROBOT_ENABLE_MOTION": "0"}):
+            with self.assertRaisesRegex(RuntimeError, "resource interval"):
                 run_once(
                     args,
                     repo_root=REPO_ROOT,

--- a/experiments/phase1/tests/test_asr_slice.py
+++ b/experiments/phase1/tests/test_asr_slice.py
@@ -87,6 +87,7 @@ class ASRSliceTests(unittest.TestCase):
             probe_join_timeout_s=1.0,
             prelude_s=0.005,
             postlude_s=0.005,
+            stale_observation_s=0.01,
             probe_period_ns=1_000_000,
             probe_deadline_ns=2_000_000,
         )
@@ -125,6 +126,10 @@ class ASRSliceTests(unittest.TestCase):
         self.assertTrue(report.adapter.terminate_requested)
         self.assertTrue(report.adapter.process_reaped)
         self.assertTrue(report.adapter.backend_stop_confirmed)
+        self.assertGreaterEqual(
+            report.adapter.finished_monotonic_ns - report.adapter.started_monotonic_ns,
+            10_000_000,
+        )
         self.assertTrue(all(process.poll() is not None for process in self.processes))
 
     def test_artifacts_do_not_contain_transcript_or_input_path(self) -> None:
@@ -139,6 +144,13 @@ class ASRSliceTests(unittest.TestCase):
                 condition=ASRSliceCondition.ASYNC,
                 result_validity_s=1.0,
                 completion_timeout_s=1.0,
+            )
+
+    def test_spec_requires_positive_stale_observation_window(self) -> None:
+        with self.assertRaisesRegex(ValueError, "stale_observation_s"):
+            ASRSliceSpec(
+                condition=ASRSliceCondition.STALE,
+                stale_observation_s=0.0,
             )
 
 

--- a/experiments/phase1/validate_asr_slice.py
+++ b/experiments/phase1/validate_asr_slice.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -263,6 +264,30 @@ def validate_asr_slice_dir(run_dir: Path | str) -> list[str]:
         or spec.get("queue_semantics") != "utterance_fifo"
     ):
         errors.append("manifest ASR specification is inconsistent")
+    else:
+        stale_observation_s = spec.get("stale_observation_s")
+        if (
+            isinstance(stale_observation_s, bool)
+            or not isinstance(stale_observation_s, (int, float))
+            or not math.isfinite(stale_observation_s)
+            or stale_observation_s <= 0
+        ):
+            errors.append("manifest stale observation window is invalid")
+        resource_interval_ms = manifest.get("resource_interval_ms")
+        if (
+            isinstance(resource_interval_ms, bool)
+            or not isinstance(resource_interval_ms, int)
+            or resource_interval_ms < 50
+            or resource_interval_ms > 10_000
+        ):
+            errors.append("manifest resource interval is invalid")
+        elif (
+            condition is ASRSliceCondition.STALE
+            and isinstance(stale_observation_s, (int, float))
+            and not isinstance(stale_observation_s, bool)
+            and stale_observation_s <= resource_interval_ms / 1000.0
+        ):
+            errors.append("stale observation window does not exceed resource interval")
 
     if not isinstance(report, Mapping):
         errors.append("scenario ASR report is missing")


### PR DESCRIPTION
## Summary

- add a recorded 0.5-second observation window after Whisper starts in `asr_stale`
- ensure the observation window exceeds the configured resource sampling interval
- reject invalid observation, adapter-timeout and completion-timeout budgets before creating a run directory
- add an independently reconstructed `stale_observation_window` Gate
- update the ASR summary schema from `0.1.0` to `0.2.0`
- document the failed Jetson diagnostic attempt and the corrected pilot protocol

## Root cause

The first Jetson `asr_stale` attempt successfully exercised the intended lifecycle:

- final disposition was `rejected_state`
- accepted result count was zero
- stale consumption count was zero
- cancellation was observed
- Whisper was terminated and reaped
- backend stop was confirmed
- every lifecycle and process Gate passed

However, the adapter interval lasted only about 6.54 ms while resource sampling ran every 200 ms. No resource sample could reliably fall inside that interval, so `resource_trace_valid` correctly failed.

Repeated execution would only make success timing-dependent.

## Changes

- observe active Whisper for 0.5 seconds before advancing the state generation
- require the stale observation window to exceed the resource interval
- require the window to remain below adapter and completion timeout budgets
- serialize the observation control in the run specification
- verify the observation window in deterministic summary reconstruction
- independently validate the new specification and sampling relationship
- add regression coverage for valid and invalid observation budgets
- preserve the failed run as diagnostic evidence only

The observation window is a correctness-pilot control. It is not a cancellation-latency measurement or a formal performance threshold.

## Validation

- ASR-specific tests: 22 passed
- Phase 0 tests: 29 passed
- Phase 1 tests: 146 passed
- Black: passed
- Pyflakes: passed
- compileall: passed
- `git diff --check`: passed

## Evidence and claim boundaries

This PR does not claim a completed ASR Jetson pilot.

Because the ASR summary schema changed to `0.2.0`, the previous nominal `0.1.0` run must not be combined with a corrected stale run. After merge, both `asr_async` and `asr_stale` will be rerun under one new session on synchronized Jetson `main`.

This PR does not permit formal performance, hard-real-time, cancellation-latency or heterogeneous-inference claims.